### PR TITLE
docs: capture claude adapter release lessons

### DIFF
--- a/.ai/rules/RELEASE.md
+++ b/.ai/rules/RELEASE.md
@@ -64,14 +64,17 @@
 ### 单包发布
 
 1. 确认该包自上次发布以来存在应计入发版范围的变更。
-2. 更新目标包 `package.json` 版本号。
-3. 补对应的 `changelog/<version>/<package>.md`。
-4. 如果需要，更新锁文件或其它发布元数据。
-5. 执行发布前最小检查清单。
-6. 提交 release commit。
-7. 执行 `pnpm tools publish-plan -- --package <pkg> --publish`。
-8. 发布成功后补 tag。
-9. 如果形成了新的稳定经验，回写文档。
+2. 区分 alpha / 正式版：
+   - alpha / 预发布可以基于功能分支直接发布，用于下游联调验证。
+   - 正式版应先把发布内容合入默认分支，再从默认分支对应提交发布，避免出现“npm 正式版已发布，但 GitHub 默认分支还没有这次变更”。
+3. 更新目标包 `package.json` 版本号。
+4. 补对应的 `changelog/<version>/<package>.md`。
+5. 如果需要，更新锁文件或其它发布元数据。
+6. 执行发布前最小检查清单。
+7. 提交 release commit。
+8. 若是正式版，先完成默认分支合入，再执行 `pnpm tools publish-plan -- --package <pkg> --publish`。
+9. 发布成功后补 tag。
+10. 如果形成了新的稳定经验，回写文档。
 
 ### 整体发布
 

--- a/packages/adapters/claude-code/AGENTS.md
+++ b/packages/adapters/claude-code/AGENTS.md
@@ -82,6 +82,16 @@
   - `@anthropic-ai/claude-code` 默认跟进最新稳定版。
   - `@musistudio/claude-code-router` 默认保持在最新 `1.x`，除非已经确认 `2.x` 有明确维护信号且当前需求必须依赖其新能力。
 
+### 4. 主会话 binary 不能依赖系统 PATH
+
+- 原则：Claude 主会话和 CCR 都应该从 adapter 自己的依赖树解析可执行文件，不要把主会话写成裸 `claude` 然后依赖系统 `PATH`。
+- 这样做的好处：
+  - 避免命中全局安装、其他工作区或旧版本包里的 Claude binary。
+  - 排查 `Invalid API key`、`Please run /login` 这类看起来像鉴权问题、实则是“跑错 binary”的场景时，定位更直接。
+- 本包里的例子：
+  - `src/ccr/paths.ts` 统一负责从依赖包 `package.json/bin` 解析 `claude` 和 `ccr`。
+  - `src/claude/prepare.ts` 返回给 session 的 `cliPath` 应始终来自 `resolveClaudeCliPath()`，不要回退成系统 `PATH` 上的裸命令。
+
 ## 真实 CLI 验证
 
 不要只看 unit test。至少跑一轮真实 Claude Code：


### PR DESCRIPTION
## Summary\n- document the claude adapter binary-path pitfall\n- clarify alpha vs stable single-package release flow\n