### PR TITLE
fix(client): align effort select styles

### DIFF
--- a/apps/client/src/components/chat/sender/Sender.scss
+++ b/apps/client/src/components/chat/sender/Sender.scss
@@ -451,6 +451,7 @@
 
 .adapter-select,
 .model-select,
+.effort-select,
 .permission-mode-select {
   .ant-select-selector {
     height: 28px !important;
@@ -499,10 +500,15 @@
   min-width: 160px;
 }
 
+.effort-select {
+  min-width: 72px;
+}
+
 .permission-mode-select {
   min-width: 120px;
 }
 
+.effort-select-popup,
 .permission-mode-select-popup {
   .ant-select-item-option-content {
     font-size: 12px;


### PR DESCRIPTION
## Summary
- align the effort select trigger with the other sender selects
- reuse the same popup option text styling for the effort select dropdown
- add a smaller minimum width so the control matches its content