### PR TITLE
fix typecheck and lint issues

### DIFF
--- a/apps/cli/__tests__/clear.spec.ts
+++ b/apps/cli/__tests__/clear.spec.ts
@@ -1,5 +1,4 @@
-import { access } from 'node:fs/promises'
-import fs from 'node:fs/promises'
+import fs, { access } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 

--- a/apps/server/__tests__/channels/middleware/access-control.spec.ts
+++ b/apps/server/__tests__/channels/middleware/access-control.spec.ts
@@ -96,6 +96,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -111,6 +112,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/ack.spec.ts
+++ b/apps/server/__tests__/channels/middleware/ack.spec.ts
@@ -12,6 +12,7 @@ const makeCtx = (ack?: () => Promise<void>): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -26,7 +27,9 @@ const makeCtx = (ack?: () => Promise<void>): ChannelContext => ({
   getChannelAdapterPreference: vi.fn(),
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
-  setChannelPermissionModePreference: vi.fn()
+  setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn()
 })
 
 beforeEach(() => vi.clearAllMocks())

--- a/apps/server/__tests__/channels/middleware/admin-gate.spec.ts
+++ b/apps/server/__tests__/channels/middleware/admin-gate.spec.ts
@@ -12,6 +12,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -27,6 +28,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/bind-session.spec.ts
+++ b/apps/server/__tests__/channels/middleware/bind-session.spec.ts
@@ -32,6 +32,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: 'sess-abc',
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -47,6 +48,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/commands.spec.ts
+++ b/apps/server/__tests__/channels/middleware/commands.spec.ts
@@ -52,6 +52,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => {
     sessionId: 'sess-abc',
     channelAdapter: undefined,
     channelPermissionMode: undefined,
+    channelEffort: undefined,
     contentItems: undefined,
     commandText: '',
     defineMessages,
@@ -86,6 +87,10 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => {
         adapter: ctx.channelAdapter,
         permissionMode
       })
+    }),
+    getChannelEffortPreference: vi.fn(() => ctx.channelEffort),
+    setChannelEffortPreference: vi.fn((effort) => {
+      ctx.channelEffort = effort
     }),
     ...overrides
   }
@@ -445,7 +450,7 @@ describe('session setting commands', () => {
     const ctx = makeCtx({ commandText: '/get', config: { type: 'lark' } as any })
     await channelCommandMiddleware(ctx, vi.fn())
     expect(ctx.reply).toHaveBeenCalledWith(
-      '缺少参数：<field>\n可选值：\n- model：模型，读取当前会话使用的模型名称。\n- adapter：适配器，读取当前会话绑定的适配器。\n- permissionMode：权限模式，读取当前会话的权限策略。\n用法：/get <field:model|adapter|permissionMode>'
+      '缺少参数：<field>\n可选值：\n- model：模型，读取当前会话使用的模型名称。\n- adapter：适配器，读取当前会话绑定的适配器。\n- permissionMode：权限模式，读取当前会话的权限策略。\n- effort：Effort，读取当前会话的显式 effort 设置。\n用法：/get <field:model|adapter|permissionMode|effort>'
     )
   })
 

--- a/apps/server/__tests__/channels/middleware/deduplicate.spec.ts
+++ b/apps/server/__tests__/channels/middleware/deduplicate.spec.ts
@@ -17,6 +17,7 @@ const makeCtx = (messageId = 'msg1'): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -31,7 +32,9 @@ const makeCtx = (messageId = 'msg1'): ChannelContext => ({
   getChannelAdapterPreference: vi.fn(),
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
-  setChannelPermissionModePreference: vi.fn()
+  setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn()
 })
 
 beforeEach(() => vi.clearAllMocks())

--- a/apps/server/__tests__/channels/middleware/dispatch.spec.ts
+++ b/apps/server/__tests__/channels/middleware/dispatch.spec.ts
@@ -33,6 +33,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: 'hello world',
   defineMessages,
@@ -48,6 +49,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/i18n.spec.ts
+++ b/apps/server/__tests__/channels/middleware/i18n.spec.ts
@@ -17,6 +17,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -32,6 +33,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/parse-content.spec.ts
+++ b/apps/server/__tests__/channels/middleware/parse-content.spec.ts
@@ -95,6 +95,7 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -110,6 +111,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
   setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn(),
   ...overrides
 })
 

--- a/apps/server/__tests__/channels/middleware/resolve-session.spec.ts
+++ b/apps/server/__tests__/channels/middleware/resolve-session.spec.ts
@@ -17,6 +17,7 @@ const makeCtx = (): ChannelContext => ({
   sessionId: undefined,
   channelAdapter: undefined,
   channelPermissionMode: undefined,
+  channelEffort: undefined,
   contentItems: undefined,
   commandText: '',
   defineMessages,
@@ -31,7 +32,9 @@ const makeCtx = (): ChannelContext => ({
   getChannelAdapterPreference: vi.fn(),
   setChannelAdapterPreference: vi.fn(),
   getChannelPermissionModePreference: vi.fn(),
-  setChannelPermissionModePreference: vi.fn()
+  setChannelPermissionModePreference: vi.fn(),
+  getChannelEffortPreference: vi.fn(),
+  setChannelEffortPreference: vi.fn()
 })
 
 beforeEach(() => vi.clearAllMocks())

--- a/apps/server/__tests__/db/schema.spec.ts
+++ b/apps/server/__tests__/db/schema.spec.ts
@@ -76,14 +76,12 @@ describe('db schema modules', () => {
 
     initSchema(sqlite, [sessionsSchemaModule, channelSessionsSchemaModule, automationSchemaModule])
 
-    const sessionColumns = sqlite.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
-    const channelColumns = sqlite.prepare('PRAGMA table_info(channel_sessions)').all() as Array<{ name: string }>
-    const channelPreferenceColumns = sqlite.prepare('PRAGMA table_info(channel_preferences)').all() as Array<
-      { name: string }
-    >
-    const automationRuleColumns = sqlite.prepare('PRAGMA table_info(automation_rules)').all() as Array<{ name: string }>
-    const automationTaskColumns = sqlite.prepare('PRAGMA table_info(automation_tasks)').all() as Array<{ name: string }>
-    const automationRunColumns = sqlite.prepare('PRAGMA table_info(automation_runs)').all() as Array<{ name: string }>
+    const sessionColumns = sqlite.prepare('PRAGMA table_info(sessions)').all<{ name: string }>()
+    const channelColumns = sqlite.prepare('PRAGMA table_info(channel_sessions)').all<{ name: string }>()
+    const channelPreferenceColumns = sqlite.prepare('PRAGMA table_info(channel_preferences)').all<{ name: string }>()
+    const automationRuleColumns = sqlite.prepare('PRAGMA table_info(automation_rules)').all<{ name: string }>()
+    const automationTaskColumns = sqlite.prepare('PRAGMA table_info(automation_tasks)').all<{ name: string }>()
+    const automationRunColumns = sqlite.prepare('PRAGMA table_info(automation_runs)').all<{ name: string }>()
 
     expect(sessionColumns.map(column => column.name)).toEqual(expect.arrayContaining([
       'parentSessionId',

--- a/apps/server/src/db/automation/repo.ts
+++ b/apps/server/src/db/automation/repo.ts
@@ -151,14 +151,14 @@ function mapAutomationTaskRow(row: AutomationTaskRow): AutomationTask {
 export function createAutomationRepo(db: SqliteDatabase) {
   const listRules = (): AutomationRule[] => {
     const stmt = db.prepare('SELECT * FROM automation_rules ORDER BY createdAt DESC')
-    const rows = stmt.all() as AutomationRuleRow[]
+    const rows = stmt.all<AutomationRuleRow>()
     return rows.map(mapAutomationRuleRow)
   }
 
   const listRuleDetails = (): AutomationRuleDetail[] => {
     const rules = listRules()
-    const triggerRows = db.prepare('SELECT * FROM automation_triggers').all() as AutomationTriggerRow[]
-    const taskRows = db.prepare('SELECT * FROM automation_tasks').all() as AutomationTaskRow[]
+    const triggerRows = db.prepare('SELECT * FROM automation_triggers').all<AutomationTriggerRow>()
+    const taskRows = db.prepare('SELECT * FROM automation_tasks').all<AutomationTaskRow>()
     const triggerMap = new Map<string, AutomationTrigger[]>()
     const taskMap = new Map<string, AutomationTask[]>()
     for (const row of triggerRows) {
@@ -180,20 +180,20 @@ export function createAutomationRepo(db: SqliteDatabase) {
 
   const getRule = (id: string): AutomationRule | undefined => {
     const stmt = db.prepare('SELECT * FROM automation_rules WHERE id = ?')
-    const row = stmt.get(id) as AutomationRuleRow | undefined
+    const row = stmt.get<AutomationRuleRow>(id)
     if (row == null) return undefined
     return mapAutomationRuleRow(row)
   }
 
   const listTriggers = (ruleId: string): AutomationTrigger[] => {
     const stmt = db.prepare('SELECT * FROM automation_triggers WHERE ruleId = ? ORDER BY createdAt ASC')
-    const rows = stmt.all(ruleId) as AutomationTriggerRow[]
+    const rows = stmt.all<AutomationTriggerRow>(ruleId)
     return rows.map(mapAutomationTriggerRow)
   }
 
   const listTasks = (ruleId: string): AutomationTask[] => {
     const stmt = db.prepare('SELECT * FROM automation_tasks WHERE ruleId = ? ORDER BY createdAt ASC')
-    const rows = stmt.all(ruleId) as AutomationTaskRow[]
+    const rows = stmt.all<AutomationTaskRow>(ruleId)
     return rows.map(mapAutomationTaskRow)
   }
 
@@ -244,7 +244,7 @@ export function createAutomationRepo(db: SqliteDatabase) {
 
   const getTrigger = (id: string): AutomationTrigger | undefined => {
     const stmt = db.prepare('SELECT * FROM automation_triggers WHERE id = ?')
-    const row = stmt.get(id) as AutomationTriggerRow | undefined
+    const row = stmt.get<AutomationTriggerRow>(id)
     if (!row) return undefined
     return mapAutomationTriggerRow(row)
   }
@@ -328,7 +328,7 @@ export function createAutomationRepo(db: SqliteDatabase) {
       ORDER BY r.createdAt DESC
       LIMIT ?
     `)
-    const rows = stmt.all(ruleId, limit) as Array<{
+    const rows = stmt.all<{
       id: string
       ruleId: string
       sessionId: string
@@ -339,7 +339,7 @@ export function createAutomationRepo(db: SqliteDatabase) {
       title?: string | null
       lastMessage?: string | null
       lastUserMessage?: string | null
-    }>
+    }>(ruleId, limit)
     return rows.map(row => ({
       id: row.id,
       ruleId: row.ruleId,

--- a/apps/server/src/db/channelSessions/repo.ts
+++ b/apps/server/src/db/channelSessions/repo.ts
@@ -37,7 +37,7 @@ export function createChannelSessionsRepo(db: SqliteDatabase) {
       FROM channel_sessions
       WHERE channelType = ? AND sessionType = ? AND channelId = ?
     `)
-    return stmt.get(channelType, sessionType, channelId) as ChannelSessionRow | undefined
+    return stmt.get<ChannelSessionRow>(channelType, sessionType, channelId)
   }
 
   const getBySessionId = (sessionId: string): ChannelSessionRow | undefined => {
@@ -48,7 +48,7 @@ export function createChannelSessionsRepo(db: SqliteDatabase) {
       ORDER BY updatedAt DESC
       LIMIT 1
     `)
-    return stmt.get(sessionId) as ChannelSessionRow | undefined
+    return stmt.get<ChannelSessionRow>(sessionId)
   }
 
   const upsert = (row: Omit<ChannelSessionRow, 'createdAt' | 'updatedAt'>) => {
@@ -94,7 +94,7 @@ export function createChannelSessionsRepo(db: SqliteDatabase) {
       FROM channel_preferences
       WHERE channelType = ? AND sessionType = ? AND channelId = ?
     `)
-    return stmt.get(channelType, sessionType, channelId) as ChannelPreferenceRow | undefined
+    return stmt.get<ChannelPreferenceRow>(channelType, sessionType, channelId)
   }
 
   const upsertPreference = (row: Omit<ChannelPreferenceRow, 'createdAt' | 'updatedAt'>) => {

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -14,7 +14,7 @@ export interface SchemaModule {
 
 function createSchemaContext(db: SqliteDatabase): SchemaContext {
   const getColumns = (tableName: string) => {
-    const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>
+    const rows = db.prepare(`PRAGMA table_info(${tableName})`).all<{ name: string }>()
     return rows.map(row => row.name)
   }
 

--- a/apps/server/src/db/sessions/messages.repo.ts
+++ b/apps/server/src/db/sessions/messages.repo.ts
@@ -10,7 +10,7 @@ export function createMessagesRepo(db: SqliteDatabase) {
 
   const list = (sessionId: string): unknown[] => {
     const stmt = db.prepare('SELECT data FROM messages WHERE sessionId = ? ORDER BY id ASC')
-    const rows = stmt.all(sessionId) as { data: string }[]
+    const rows = stmt.all<{ data: string }>(sessionId)
     return rows.map(r => JSON.parse(r.data) as unknown)
   }
 

--- a/apps/server/src/db/sessions/repo.ts
+++ b/apps/server/src/db/sessions/repo.ts
@@ -82,7 +82,7 @@ export function createSessionsRepo(db: SqliteDatabase) {
       ${whereClause}
       ORDER BY isStarred DESC, createdAt DESC
     `)
-    const rows = stmt.all() as SessionRow[]
+    const rows = stmt.all<SessionRow>()
     return rows.map(mapSessionRow)
   }
 
@@ -91,7 +91,7 @@ export function createSessionsRepo(db: SqliteDatabase) {
       ${SESSION_SELECT}
       WHERE s.id = ?
     `)
-    const row = stmt.get(id) as (SessionRow | undefined)
+    const row = stmt.get<SessionRow>(id)
     if (row == null) return undefined
     return mapSessionRow(row)
   }
@@ -123,7 +123,7 @@ export function createSessionsRepo(db: SqliteDatabase) {
       if (!currentId) continue
       updateStmt.run(isArchived ? 1 : 0, currentId)
       updatedIds.push(currentId)
-      const rows = stmt.all(currentId) as { id: string }[]
+      const rows = stmt.all<{ id: string }>(currentId)
       for (const row of rows) {
         stack.push(row.id)
       }

--- a/apps/server/src/db/sessions/tags.repo.ts
+++ b/apps/server/src/db/sessions/tags.repo.ts
@@ -7,7 +7,10 @@ export function createTagsRepo(db: SqliteDatabase) {
 
       for (const tagName of tags) {
         db.prepare('INSERT OR IGNORE INTO tags (name) VALUES (?)').run(tagName)
-        const tag = db.prepare('SELECT id FROM tags WHERE name = ?').get(tagName) as { id: number }
+        const tag = db.prepare('SELECT id FROM tags WHERE name = ?').get<{ id: number }>(tagName)
+        if (tag == null) {
+          throw new Error(`Failed to resolve tag id for ${tagName}.`)
+        }
         db.prepare('INSERT OR IGNORE INTO session_tags (sessionId, tagId) VALUES (?, ?)').run(sessionId, tag.id)
       }
     })

--- a/apps/server/src/db/sqlite.ts
+++ b/apps/server/src/db/sqlite.ts
@@ -1,12 +1,15 @@
 import { createRequire } from 'node:module'
+import type {
+  DatabaseSync as NodeDatabaseSync,
+  DatabaseSyncOptions,
+  StatementSync
+} from 'node:sqlite'
 
-const require = createRequire(import.meta.url)
+const require = createRequire(__filename)
 const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
 
-type DatabaseSyncOptions = import('node:sqlite').DatabaseSyncOptions
-type StatementSync = import('node:sqlite').StatementSync
-
 export type SqliteBindValue = null | number | bigint | string | NodeJS.ArrayBufferView
+type SqliteRow = object
 
 export interface SqliteRunResult {
   changes: number
@@ -14,12 +17,12 @@ export interface SqliteRunResult {
 }
 
 export interface SqliteStatement {
-  all: (...params: SqliteBindValue[]) => Record<string, unknown>[]
-  get: (...params: SqliteBindValue[]) => Record<string, unknown> | undefined
+  all: <TRow extends SqliteRow = SqliteRow>(...params: SqliteBindValue[]) => TRow[]
+  get: <TRow extends SqliteRow = SqliteRow>(...params: SqliteBindValue[]) => TRow | undefined
   run: (...params: SqliteBindValue[]) => SqliteRunResult
 }
 
-type SqliteTransactionFn = (...args: unknown[]) => unknown
+type SqliteTransactionFn = (...args: any[]) => unknown
 
 export interface SqliteDatabase {
   close: () => void
@@ -28,21 +31,21 @@ export interface SqliteDatabase {
   transaction: <T extends SqliteTransactionFn>(fn: T) => T
 }
 
-function cloneRow(row: Record<string, unknown>) {
+function cloneRow<TRow extends SqliteRow>(row: TRow): TRow {
   return { ...row }
 }
 
 class NodeSqliteStatement implements SqliteStatement {
   constructor(private readonly statement: StatementSync) {}
 
-  all(...params: SqliteBindValue[]) {
+  all<TRow extends SqliteRow = SqliteRow>(...params: SqliteBindValue[]) {
     return this.statement
       .all(...params)
-      .map(row => cloneRow(row as Record<string, unknown>))
+      .map(row => cloneRow(row as TRow))
   }
 
-  get(...params: SqliteBindValue[]) {
-    const row = this.statement.get(...params) as Record<string, unknown> | undefined
+  get<TRow extends SqliteRow = SqliteRow>(...params: SqliteBindValue[]) {
+    const row = this.statement.get(...params) as TRow | undefined
     return row == null ? undefined : cloneRow(row)
   }
 
@@ -58,7 +61,7 @@ class NodeSqliteStatement implements SqliteStatement {
 class NodeSqliteDatabase implements SqliteDatabase {
   private savepointId = 0
 
-  constructor(private readonly database: DatabaseSync) {}
+  constructor(private readonly database: NodeDatabaseSync) {}
 
   close() {
     if (this.database.isOpen) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vibe-forge/plugin-standard-dev": "workspace:*",
     "@vibe-forge/server": "workspace:*",
     "@vibe-forge/task": "workspace:*",
+    "baseline-browser-mapping": "2.10.13",
     "commander": "^12.1.0",
     "dprint": "^0.50.2",
     "esbuild-register": "^3.6.0",

--- a/packages/adapters/codex/src/runtime/session-common.ts
+++ b/packages/adapters/codex/src/runtime/session-common.ts
@@ -300,7 +300,7 @@ function buildCodexConfigOverrides(params: {
  * Build `-c mcp_servers.<name>.*` overrides for each filtered MCP server.
  */
 function buildMcpConfigArgs(servers: Record<string, unknown>): string[] {
-  const toTomlKey = (name: string) => /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name)
+  const toTomlKey = (name: string) => /^[\w-]+$/.test(name) ? name : JSON.stringify(name)
   const args: string[] = []
   for (const [name, server] of Object.entries(servers)) {
     const {

--- a/packages/adapters/opencode/src/runtime/common.ts
+++ b/packages/adapters/opencode/src/runtime/common.ts
@@ -5,13 +5,13 @@ export { resolveOpenCodeModel } from './common/model'
 export { buildToolPermissionConfig, mapPermissionModeToOpenCode } from './common/permissions'
 export { buildOpenCodeSessionTitle, normalizeOpenCodePrompt, resolveLocalAttachmentPath } from './common/prompt'
 export {
-  type OpenCodeSessionRecord,
   extractOpenCodeSessionRecords,
+  type OpenCodeSessionRecord,
   selectOpenCodeSessionByTitle
 } from './common/session-records'
 export {
-  DEFAULT_OPENCODE_TOOLS,
   buildOpenCodeRunArgs,
   buildToolConfig,
+  DEFAULT_OPENCODE_TOOLS,
   sanitizeOpenCodeExtraOptions
 } from './common/tools'

--- a/packages/config/__tests__/load.spec.ts
+++ b/packages/config/__tests__/load.spec.ts
@@ -88,7 +88,7 @@ adapters:
             extend: './base.yaml',
             defaultModel: 'project-model',
             env: {
-              API_KEY: '${TEST_API_KEY}'
+              API_KEY: `\${TEST_API_KEY}`
             },
             permissions: {
               allow: ['Edit']

--- a/packages/utils/src/plugin-resolver.ts
+++ b/packages/utils/src/plugin-resolver.ts
@@ -167,7 +167,7 @@ export const normalizePluginConfig = (
 ): PluginConfig | undefined => {
   if (plugins == null) return undefined
   if (!Array.isArray(plugins)) {
-    throw new Error(`Invalid ${path} config. "plugins" must be an array of plugin instances; the legacy object map format is no longer supported.`)
+    throw new TypeError(`Invalid ${path} config. "plugins" must be an array of plugin instances; the legacy object map format is no longer supported.`)
   }
 
   return plugins.map((plugin, index) => normalizePluginInstanceConfig(plugin, `${path}[${index}]`))
@@ -231,7 +231,6 @@ const loadManifest = (
 
   const workspaceRequire = createWorkspaceRequire(cwd)
   try {
-    // eslint-disable-next-line ts/no-require-imports
     const mod = workspaceRequire(rootEntryPath)
     return toPluginManifest(mod?.default ?? mod)
   } catch (error) {

--- a/packages/workspace-assets/__tests__/bundle.spec.ts
+++ b/packages/workspace-assets/__tests__/bundle.spec.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path'
 import process from 'node:process'
 
 import { describe, expect, it } from 'vitest'

--- a/packages/workspace-assets/src/index.ts
+++ b/packages/workspace-assets/src/index.ts
@@ -824,16 +824,14 @@ const generateSpecRoutePrompt = (specs: Definition<Spec>[], options?: { active?:
       )
     : ''
 
-  return (
-    '<system-prompt>\n' +
-    activeIdentityPrompt +
-    '根据用户需要以及实际的开发目标来决定使用不同的工作流程，调用 `load-spec` mcp tool 完成工作流程的加载。\n' +
-    '- 根据实际需求传入标识，这不是路径，只能使用工具进行加载\n' +
-    '- 通过参数的描述以及实际应用场景决定怎么传入参数\n' +
-    '项目存在如下工作流程：\n' +
-    `${specsRouteStr}\n` +
-    '</system-prompt>\n'
-  )
+  return `<system-prompt>
+${activeIdentityPrompt}根据用户需要以及实际的开发目标来决定使用不同的工作流程，调用 \`load-spec\` mcp tool 完成工作流程的加载。
+- 根据实际需求传入标识，这不是路径，只能使用工具进行加载
+- 通过参数的描述以及实际应用场景决定怎么传入参数
+项目存在如下工作流程：
+${specsRouteStr}
+</system-prompt>
+`
 }
 
 const generateEntitiesRoutePrompt = (entities: Definition<Entity>[]) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@vibe-forge/task':
         specifier: workspace:*
         version: link:packages/task
+      baseline-browser-mapping:
+        specifier: 2.10.13
+        version: 2.10.13
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -2363,8 +2366,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==, tarball: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz}
 
-  baseline-browser-mapping@2.8.18:
-    resolution: {integrity: sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==, tarball: https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz}
+  baseline-browser-mapping@2.10.13:
+    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==, tarball: https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bignumber.js@9.3.1:
@@ -7301,7 +7305,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.18: {}
+  baseline-browser-mapping@2.10.13: {}
 
   bignumber.js@9.3.1: {}
 
@@ -7340,7 +7344,7 @@ snapshots:
 
   browserslist@4.26.3:
     dependencies:
-      baseline-browser-mapping: 2.8.18
+      baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001751
       electron-to-chromium: 1.5.237
       node-releases: 2.0.25

--- a/scripts/publish-plan-core.mjs
+++ b/scripts/publish-plan-core.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { createInterface } from 'node:readline/promises'


### PR DESCRIPTION
## Summary
- fix sqlite repo/query typing issues and align related tests
- clean up lint violations across adapters, config, utils, workspace assets, and scripts
- update baseline-browser-mapping to suppress the stale browser baseline warning

## Verification
- pnpm typecheck
- pnpm exec eslint .
- npx vitest run apps/cli/__tests__/clear.spec.ts apps/server/__tests__/db/sqlite.spec.ts apps/server/__tests__/db/schema.spec.ts apps/server/__tests__/channels/middleware/*.spec.ts packages/config/__tests__/load.spec.ts packages/workspace-assets/__tests__/bundle.spec.ts