### PR TITLE
Improve CLI session resume and list UX

### DIFF
--- a/.ai/rules/usage/cli.md
+++ b/.ai/rules/usage/cli.md
@@ -7,10 +7,12 @@
 - `npx vf run --help`
 - `npx vf-mcp --help`
 - `vf run`：执行一次任务
-- `vf --resume <sessionId>`：恢复已有 CLI 会话，固定参数从 `.ai/caches/` 对应会话读取
+- `vf --resume <sessionId>`：恢复已有 CLI 会话，固定参数和已解析 adapter 都从 `.ai/caches/` 对应会话读取
 - `vf-mcp`：启动独立 MCP stdio server
 - `vf-call-hook`：从标准输入读取 hook payload 并执行 hooks runtime
-- `vf list` / `vf ls`：列出历史任务缓存
+- `vf list` / `vf ls`：以 compact 视图列出历史任务缓存
+- `vf list --view default`：展示 adapter / model 等常用列
+- `vf list --view full`：展示上下文、PID 与辅助命令列
 - `vf list --running`：只看当前仍在运行的 CLI 会话
 - `vf clear`：清理本地日志与缓存
 - `vf stop <sessionId>`：优雅停止正在运行的 CLI 会话
@@ -47,5 +49,7 @@ npx vf run --adapter codex --print "读取 README 并给出一个三步改进建
 
 ```bash
 npx vf list
+npx vf list --view default
+npx vf list --view full
 npx vf --resume <sessionId>
 ```

--- a/apps/cli/__tests__/session-cache.spec.ts
+++ b/apps/cli/__tests__/session-cache.spec.ts
@@ -7,7 +7,13 @@ import { Command } from 'commander'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registerListCommand } from '#~/commands/list.js'
-import { formatResumeCommand, listCliSessions, resolveCliSession, writeCliSessionRecord } from '#~/session-cache.js'
+import {
+  formatResumeCommand,
+  listCliSessions,
+  resolveCliSession,
+  resolveCliSessionAdapter,
+  writeCliSessionRecord
+} from '#~/session-cache.js'
 
 const tempDirs: string[] = []
 const originalCwd = process.cwd()
@@ -37,8 +43,9 @@ describe('session cache utilities', () => {
         description: 'Inspect README',
         createdAt: 1,
         updatedAt: 2,
+        resolvedAdapter: 'codex',
         taskOptions: {
-          adapter: 'codex',
+          adapter: 'claude-code',
           cwd,
           ctxId: 'ctx-alpha'
         },
@@ -68,6 +75,7 @@ describe('session cache utilities', () => {
 
     const resolved = await resolveCliSession(cwd, 'session-a')
     expect(resolved.resume?.ctxId).toBe('ctx-alpha')
+    expect(resolveCliSessionAdapter(resolved)).toBe('codex')
     expect(formatResumeCommand('session-alpha')).toBe('vf --resume session-alpha')
   })
 
@@ -102,9 +110,10 @@ describe('session cache utilities', () => {
 })
 
 describe('list command', () => {
-  it('prints a useful table with resume commands', async () => {
+  it('prints a compact table by default and shows next-step hints', async () => {
     const cwd = await createTempDir()
     const tableSpy = vi.spyOn(console, 'table').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     await writeCliSessionRecord(cwd, 'ctx-demo', 'session-demo', {
       resume: {
@@ -115,6 +124,7 @@ describe('list command', () => {
         description: 'Review CLI resume flow',
         createdAt: 10,
         updatedAt: 20,
+        resolvedAdapter: 'codex',
         taskOptions: {
           adapter: 'codex',
           cwd,
@@ -150,7 +160,79 @@ describe('list command', () => {
       expect.objectContaining({
         Session: 'session-demo',
         Status: 'running',
-        Resume: 'vf --resume session-demo'
+        Description: 'Review CLI resume flow'
+      })
+    ])
+    expect(Object.keys(tableSpy.mock.calls[0]?.[0]?.[0] ?? {})).toEqual([
+      'Session',
+      'Status',
+      'Updated',
+      'Description'
+    ])
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Resume latest: vf --resume session-demo')
+    )
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Stop a running session: vf stop session-demo')
+    )
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('More columns: vf list --view default')
+    )
+  })
+
+  it('prints full view rows with helper commands', async () => {
+    const cwd = await createTempDir()
+    const tableSpy = vi.spyOn(console, 'table').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await writeCliSessionRecord(cwd, 'ctx-demo', 'session-demo', {
+      resume: {
+        version: 1,
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        cwd,
+        description: 'Review CLI resume flow',
+        createdAt: 10,
+        updatedAt: 20,
+        resolvedAdapter: 'codex',
+        taskOptions: {
+          adapter: 'codex',
+          cwd,
+          ctxId: 'ctx-demo'
+        },
+        adapterOptions: {
+          runtime: 'cli',
+          sessionId: 'session-demo',
+          mode: 'direct',
+          model: 'gpt-5.4'
+        },
+        outputFormat: 'text'
+      },
+      detail: {
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        status: 'running',
+        pid: 123,
+        startTime: 10,
+        description: 'Review CLI resume flow',
+        adapter: 'codex',
+        model: 'gpt-5.4'
+      }
+    })
+
+    process.chdir(cwd)
+    const program = new Command()
+    registerListCommand(program)
+    await program.parseAsync(['list', '--view', 'full'], { from: 'user' })
+
+    expect(tableSpy).toHaveBeenCalledTimes(1)
+    expect(tableSpy.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({
+        Session: 'session-demo',
+        Context: 'ctx-demo',
+        Resume: 'vf --resume session-demo',
+        Stop: 'vf stop session-demo',
+        Kill: 'vf kill session-demo'
       })
     ])
   })
@@ -158,6 +240,7 @@ describe('list command', () => {
   it('supports filtering to running sessions only', async () => {
     const cwd = await createTempDir()
     const tableSpy = vi.spyOn(console, 'table').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
 
     await writeCliSessionRecord(cwd, 'ctx-running', 'session-running', {
       resume: {
@@ -167,6 +250,7 @@ describe('list command', () => {
         cwd,
         createdAt: 10,
         updatedAt: 20,
+        resolvedAdapter: 'codex',
         taskOptions: { cwd, ctxId: 'ctx-running' },
         adapterOptions: { runtime: 'cli', sessionId: 'session-running', mode: 'direct' },
         outputFormat: 'text'
@@ -187,6 +271,7 @@ describe('list command', () => {
         cwd,
         createdAt: 11,
         updatedAt: 21,
+        resolvedAdapter: 'claude-code',
         taskOptions: { cwd, ctxId: 'ctx-done' },
         adapterOptions: { runtime: 'cli', sessionId: 'session-done', mode: 'direct' },
         outputFormat: 'text'

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -25,6 +25,8 @@ program
     `
 Examples:
   vf "读取 README 并给出改进建议"
+  vf list
+  vf list --view full
   vf --resume <sessionId>
   vf list --running
 `

--- a/apps/cli/src/commands/kill.ts
+++ b/apps/cli/src/commands/kill.ts
@@ -2,12 +2,22 @@ import process from 'node:process'
 
 import type { Command } from 'commander'
 
+import { formatListCommand, formatResumeCommand } from '#~/session-cache.js'
+
 import { signalCliSession } from './session-control'
 
 export function registerKillCommand(program: Command) {
   program
     .command('kill <sessionId>')
     .description('Force kill a running CLI session')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  vf list --running
+  vf kill <sessionId>
+`
+    )
     .action(async (sessionId: string) => {
       try {
         const result = await signalCliSession({
@@ -16,6 +26,9 @@ export function registerKillCommand(program: Command) {
           signal: 'SIGKILL'
         })
         console.log(result.message)
+        console.log(
+          `Tips:\n  Check running sessions: ${formatListCommand({ running: true })}\n  Resume later: ${formatResumeCommand(sessionId)}`
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,9 +1,22 @@
 import process from 'node:process'
 
 import type { TaskDetail } from '@vibe-forge/types'
+import { Option } from 'commander'
 import type { Command } from 'commander'
 
-import { formatResumeCommand, listCliSessions } from '#~/session-cache.js'
+import {
+  formatKillCommand,
+  formatListCommand,
+  formatResumeCommand,
+  formatStopCommand,
+  listCliSessions,
+  resolveCliSessionAdapter,
+  resolveCliSessionCtxId,
+  resolveCliSessionDescription,
+  resolveCliSessionId,
+  resolveCliSessionModel,
+  resolveCliSessionUpdatedAt
+} from '#~/session-cache.js'
 
 interface ListOptions {
   all?: boolean
@@ -11,10 +24,29 @@ interface ListOptions {
   limit?: string
   running?: boolean
   status?: string[]
+  verbose?: boolean
+  view?: ListView
+}
+
+interface ListRow {
+  sessionId: string
+  ctxId: string
+  status: TaskDetail['status'] | 'unknown'
+  adapter: string
+  model: string
+  updatedAt: number
+  pid?: number
+  description: string
+  resumeCommand: string
+  stopCommand: string
+  killCommand: string
 }
 
 const TASK_STATUSES = ['pending', 'running', 'completed', 'failed', 'stopped'] as const
+const LIST_VIEWS = ['compact', 'default', 'full'] as const
+
 type TaskStatus = (typeof TASK_STATUSES)[number]
+type ListView = (typeof LIST_VIEWS)[number]
 
 const isTaskStatus = (value: string): value is TaskStatus => (TASK_STATUSES as readonly string[]).includes(value)
 
@@ -23,16 +55,98 @@ const truncate = (value: string | undefined, maxLength: number) => {
   return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value
 }
 
-const getUpdatedAt = (params: {
-  detailStartTime?: number
-  detailEndTime?: number
-  resumeUpdatedAt?: number
-}) => (
-  params.resumeUpdatedAt ??
-    params.detailEndTime ??
-    params.detailStartTime ??
-    0
+const formatUpdatedAt = (updatedAt: number) => updatedAt === 0 ? '' : new Date(updatedAt).toLocaleString()
+
+const resolveListView = (view: ListView | undefined, verbose: boolean | undefined): ListView =>
+  verbose ? 'full' : (view ?? 'compact')
+
+const buildListRows = (records: Awaited<ReturnType<typeof listCliSessions>>) => (
+  records.map((record) => {
+    const sessionId = resolveCliSessionId(record)
+    const status = record.detail?.status ?? 'unknown'
+
+    return {
+      sessionId,
+      ctxId: resolveCliSessionCtxId(record),
+      status,
+      adapter: resolveCliSessionAdapter(record),
+      model: resolveCliSessionModel(record),
+      updatedAt: resolveCliSessionUpdatedAt(record),
+      pid: record.detail?.pid,
+      description: resolveCliSessionDescription(record),
+      resumeCommand: sessionId === '' ? '' : formatResumeCommand(sessionId),
+      stopCommand: status === 'running' && sessionId !== '' ? formatStopCommand(sessionId) : '',
+      killCommand: status === 'running' && sessionId !== '' ? formatKillCommand(sessionId) : ''
+    } satisfies ListRow
+  })
 )
+
+const renderListRows = (rows: ListRow[], view: ListView) => {
+  switch (view) {
+    case 'compact':
+      return rows.map((row) => ({
+        Session: row.sessionId,
+        Status: row.status,
+        Updated: formatUpdatedAt(row.updatedAt),
+        Description: truncate(row.description, 72)
+      }))
+    case 'default':
+      return rows.map((row) => ({
+        Session: row.sessionId,
+        Status: row.status,
+        Adapter: row.adapter,
+        Model: row.model,
+        Updated: formatUpdatedAt(row.updatedAt),
+        Description: truncate(row.description, 72)
+      }))
+    case 'full':
+      return rows.map((row) => ({
+        Session: row.sessionId,
+        Context: row.ctxId,
+        Status: row.status,
+        Adapter: row.adapter,
+        Model: row.model,
+        Updated: formatUpdatedAt(row.updatedAt),
+        PID: row.pid ?? '',
+        Description: truncate(row.description, 72),
+        Resume: row.resumeCommand,
+        Stop: row.stopCommand,
+        Kill: row.killCommand
+      }))
+  }
+}
+
+const buildListHints = (rows: ListRow[], view: ListView) => {
+  const hints: string[] = []
+  const latest = rows[0]
+  const running = rows.find(row => row.stopCommand !== '')
+
+  if (latest?.resumeCommand) {
+    hints.push(`Resume latest: ${latest.resumeCommand}`)
+  }
+  if (running?.stopCommand) {
+    hints.push(`Stop a running session: ${running.stopCommand}`)
+  }
+
+  switch (view) {
+    case 'compact':
+      hints.push(`More columns: ${formatListCommand({ view: 'default' })}`)
+      break
+    case 'default':
+      hints.push(`All columns: ${formatListCommand({ view: 'full' })}`)
+      break
+    case 'full':
+      break
+  }
+
+  return hints
+}
+
+const printListHints = (rows: ListRow[], view: ListView) => {
+  const hints = buildListHints(rows, view)
+  if (hints.length === 0) return
+  console.log(`Tips:\n  ${hints.join('\n  ')}`)
+}
 
 export function registerListCommand(program: Command) {
   program
@@ -44,6 +158,22 @@ export function registerListCommand(program: Command) {
     .option('--limit <count>', 'Limit displayed sessions')
     .option('--running', 'Show only running sessions', false)
     .option('--status <status...>', `Filter by status (${TASK_STATUSES.join(', ')})`)
+    .addOption(
+      new Option('--view <view>', 'Display view')
+        .choices([...LIST_VIEWS])
+        .default('compact')
+    )
+    .option('--verbose', 'Alias for --view full', false)
+    .addHelpText(
+      'after',
+      `
+Examples:
+  vf list
+  vf list --view default
+  vf list --view full
+  vf list --running
+`
+    )
     .action(async (opts: ListOptions) => {
       try {
         const records = await listCliSessions(process.cwd())
@@ -64,32 +194,13 @@ export function registerListCommand(program: Command) {
         const limit = opts.all
           ? records.length
           : Math.max(1, Number.parseInt(opts.limit ?? '20', 10) || 20)
-        const rows = records
+        const view = resolveListView(opts.view, opts.verbose)
+        const rows = buildListRows(records)
           .filter((record) => (
             requestedStatuses.size === 0 ||
-            (record.detail?.status != null && requestedStatuses.has(record.detail.status))
+            (record.status !== 'unknown' && requestedStatuses.has(record.status))
           ))
           .slice(0, limit)
-          .map((record) => {
-            const sessionId = record.resume?.sessionId ?? record.detail?.sessionId ?? ''
-            const ctxId = record.resume?.ctxId ?? record.detail?.ctxId ?? ''
-
-            return {
-              sessionId,
-              ctxId,
-              status: record.detail?.status ?? 'unknown',
-              adapter: record.detail?.adapter ?? record.resume?.taskOptions.adapter ?? '',
-              model: record.detail?.model ?? record.resume?.adapterOptions.model ?? '',
-              updatedAt: getUpdatedAt({
-                detailStartTime: record.detail?.startTime,
-                detailEndTime: record.detail?.endTime,
-                resumeUpdatedAt: record.resume?.updatedAt
-              }),
-              pid: record.detail?.pid,
-              description: record.detail?.description ?? record.resume?.description ?? '',
-              resumeCommand: sessionId === '' ? '' : formatResumeCommand(sessionId)
-            }
-          })
 
         if (rows.length === 0) {
           console.log('No cached sessions matched the requested filters.')
@@ -101,16 +212,8 @@ export function registerListCommand(program: Command) {
           return
         }
 
-        console.table(rows.map((row) => ({
-          Session: row.sessionId,
-          Status: row.status,
-          Adapter: row.adapter,
-          Model: row.model,
-          Updated: row.updatedAt === 0 ? '' : new Date(row.updatedAt).toLocaleString(),
-          PID: row.pid ?? '',
-          Description: truncate(row.description, 60),
-          Resume: row.resumeCommand
-        })))
+        console.table(renderListRows(rows, view))
+        printListHints(rows, view)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -18,6 +18,7 @@ import {
   isCliSessionStopActive,
   readCliSessionControl,
   resolveCliSession,
+  resolveCliSessionAdapter,
   writeCliSessionRecord
 } from '#~/session-cache.js'
 import type { CliSessionResumeRecord } from '#~/session-cache.js'
@@ -167,10 +168,12 @@ const configureRunCommand = (command: Command) => {
 Examples:
   vf "实现一个新的 list 筛选"
   vf run --adapter codex --print "读取 README 并总结"
+  vf list --view default
   vf --resume <sessionId>
 
 Notes:
   When using --resume, startup-only flags like --adapter, --model and --spec are loaded from cache and cannot be set again.
+  The resolved adapter is pinned in cache, so later default adapter changes do not affect resume.
 `
     )
     .action(async (descriptionArgs: string[], opts: RunOptions, command: Command) => {
@@ -209,6 +212,9 @@ Notes:
           : undefined
 
         const cachedSession = await initialResumeRecord
+        const cachedAdapter = cachedSession == null
+          ? undefined
+          : (resolveCliSessionAdapter(cachedSession) || undefined)
         const sessionId = cachedSession?.resume?.sessionId ?? generatedSessionId
         const ctxId = cachedSession?.resume?.ctxId ?? runTaskOptions?.ctxId ?? sessionId
         const outputFormat = getOutputFormat(
@@ -326,10 +332,13 @@ Notes:
             description: description || cachedSession?.resume?.description,
             createdAt: cachedSession?.resume?.createdAt ?? Date.now(),
             updatedAt: Date.now(),
-            taskOptions: cachedSession?.resume?.taskOptions ?? {
-              adapter: runTaskOptions?.adapter,
-              cwd,
-              ctxId
+            resolvedAdapter: cachedSession?.resume?.resolvedAdapter ?? cachedAdapter,
+            taskOptions: {
+              ...(cachedSession?.resume?.taskOptions ?? {
+                cwd,
+                ctxId
+              }),
+              adapter: cachedAdapter ?? runTaskOptions?.adapter
             },
             adapterOptions: cachedAdapterOptions,
             outputFormat
@@ -340,7 +349,7 @@ Notes:
             status: 'pending',
             startTime: cachedSession?.detail?.startTime ?? Date.now(),
             description: description || cachedSession?.detail?.description || cachedSession?.resume?.description,
-            adapter: cachedSession?.detail?.adapter ?? cachedSession?.resume?.taskOptions.adapter,
+            adapter: cachedSession?.detail?.adapter ?? cachedAdapter,
             model: cachedSession?.detail?.model ?? cachedSession?.resume?.adapterOptions.model
           }
         }
@@ -357,12 +366,14 @@ Notes:
           return persistQueue
         }
         const updateInitRecord = (info: SessionInitInfo, pid: number | undefined) => {
+          const resolvedAdapter = info.adapter ?? record.resume.resolvedAdapter ?? record.resume.taskOptions.adapter
           record.resume = {
             ...record.resume,
             updatedAt: Date.now(),
+            resolvedAdapter,
             taskOptions: {
               ...record.resume.taskOptions,
-              adapter: info.adapter ?? record.resume.taskOptions.adapter
+              adapter: resolvedAdapter
             },
             adapterOptions: {
               ...record.resume.adapterOptions,
@@ -374,7 +385,7 @@ Notes:
             ...record.detail,
             status: 'running',
             pid: pid ?? record.detail.pid,
-            adapter: info.adapter ?? record.detail.adapter,
+            adapter: resolvedAdapter ?? record.detail.adapter,
             model: info.model ?? record.detail.model
           }
           void persistRecord()
@@ -412,8 +423,8 @@ Notes:
           })()
         }
 
-        const { session } = await run({
-          adapter: record.resume.taskOptions.adapter,
+        const { session, resolvedAdapter } = await run({
+          adapter: record.resume.resolvedAdapter ?? record.resume.taskOptions.adapter,
           cwd: record.resume.taskOptions.cwd ?? record.resume.cwd,
           ctxId,
           env: process.env
@@ -442,10 +453,19 @@ Notes:
           }
         })
         boundSession = session
+        record.resume = {
+          ...record.resume,
+          resolvedAdapter: resolvedAdapter ?? record.resume.resolvedAdapter,
+          taskOptions: {
+            ...record.resume.taskOptions,
+            adapter: resolvedAdapter ?? record.resume.taskOptions.adapter
+          }
+        }
         record.detail = {
           ...record.detail,
           pid: session.pid ?? record.detail.pid,
-          status: record.detail.status === 'pending' ? 'running' : record.detail.status
+          status: record.detail.status === 'pending' ? 'running' : record.detail.status,
+          adapter: resolvedAdapter ?? record.detail.adapter
         }
         void persistRecord()
         exitController.bindSession(session)

--- a/apps/cli/src/commands/stop.ts
+++ b/apps/cli/src/commands/stop.ts
@@ -2,12 +2,22 @@ import process from 'node:process'
 
 import type { Command } from 'commander'
 
+import { formatListCommand, formatResumeCommand } from '#~/session-cache.js'
+
 import { signalCliSession } from './session-control'
 
 export function registerStopCommand(program: Command) {
   program
     .command('stop <sessionId>')
     .description('Stop a running CLI session')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  vf list --running
+  vf stop <sessionId>
+`
+    )
     .action(async (sessionId: string) => {
       try {
         const result = await signalCliSession({
@@ -16,6 +26,9 @@ export function registerStopCommand(program: Command) {
           signal: 'SIGTERM'
         })
         console.log(result.message)
+        console.log(
+          `Tips:\n  Check running sessions: ${formatListCommand({ running: true })}\n  Resume later: ${formatResumeCommand(sessionId)}`
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)

--- a/apps/cli/src/session-cache.ts
+++ b/apps/cli/src/session-cache.ts
@@ -15,6 +15,7 @@ export interface CliSessionResumeRecord {
   description?: string
   createdAt: number
   updatedAt: number
+  resolvedAdapter?: string
   taskOptions: RunTaskOptions
   adapterOptions: Omit<AdapterQueryOptions, 'description' | 'onEvent' | 'type'>
   outputFormat: CliOutputFormat
@@ -59,6 +60,37 @@ const getRecordUpdatedAt = (record: CliSessionRecord) =>
 const isSessionDirNameMatch = (value: string, target: string) => value === target || value.startsWith(target)
 
 export const formatResumeCommand = (sessionId: string) => `vf --resume ${sessionId}`
+export const formatStopCommand = (sessionId: string) => `vf stop ${sessionId}`
+export const formatKillCommand = (sessionId: string) => `vf kill ${sessionId}`
+export const formatListCommand = (params?: {
+  running?: boolean
+  view?: string
+}) => {
+  const args = ['vf', 'list']
+  if (params?.running) args.push('--running')
+  if (params?.view != null && params.view !== '') args.push('--view', params.view)
+  return args.join(' ')
+}
+
+export const resolveCliSessionId = (record: CliSessionRecord) =>
+  record.resume?.sessionId ?? record.detail?.sessionId ?? ''
+
+export const resolveCliSessionCtxId = (record: CliSessionRecord) =>
+  record.resume?.ctxId ?? record.detail?.ctxId ?? ''
+
+export const resolveCliSessionAdapter = (record: CliSessionRecord) =>
+  record.resume?.resolvedAdapter ??
+    record.detail?.adapter ??
+    record.resume?.taskOptions.adapter ??
+    ''
+
+export const resolveCliSessionModel = (record: CliSessionRecord) =>
+  record.detail?.model ?? record.resume?.adapterOptions.model ?? ''
+
+export const resolveCliSessionDescription = (record: CliSessionRecord) =>
+  record.detail?.description ?? record.resume?.description ?? ''
+
+export const resolveCliSessionUpdatedAt = (record: CliSessionRecord) => getRecordUpdatedAt(record)
 
 export const listCliSessions = async (cwd: string): Promise<CliSessionRecord[]> => {
   const cacheRoot = path.resolve(cwd, CACHE_ROOT)
@@ -115,14 +147,14 @@ export const resolveCliSession = async (cwd: string, id: string): Promise<CliSes
   if (prefixMatches.length === 1) return prefixMatches[0]!
   if (prefixMatches.length > 1) {
     const candidates = prefixMatches
-      .map((record) => record.resume?.sessionId ?? record.detail?.sessionId)
+      .map(resolveCliSessionId)
       .filter((value): value is string => value != null)
       .slice(0, 5)
       .join(', ')
     throw new Error(`Session id "${id}" is ambiguous: ${candidates}`)
   }
 
-  throw new Error(`Session "${id}" not found. Use "vf list" to inspect available sessions.`)
+  throw new Error(`Session "${id}" not found. Use "${formatListCommand({ view: 'full' })}" to inspect available sessions.`)
 }
 
 export const writeCliSessionRecord = async (

--- a/packages/task/__tests__/run.spec.ts
+++ b/packages/task/__tests__/run.spec.ts
@@ -159,6 +159,31 @@ describe('task run adapter init', () => {
     expect(queryMock).toHaveBeenCalledTimes(1)
   })
 
+  it('returns the resolved adapter used for the session', async () => {
+    const ctx = createCtx()
+    ctx.configs = [{
+      adapters: createAdapters({
+        codex: {},
+        'claude-code': {}
+      }),
+      defaultAdapter: 'claude-code'
+    }, undefined] as AdapterCtx['configs']
+    prepareMock.mockResolvedValue([ctx])
+
+    const result = await run({
+      cwd: ctx.cwd,
+      env: {}
+    }, {
+      type: 'create',
+      runtime: 'cli',
+      sessionId: 'session-resolved-adapter',
+      description: 'hello',
+      onEvent: vi.fn()
+    })
+
+    expect(result.resolvedAdapter).toBe('claude-code')
+  })
+
   it('resolves effort with explicit > model > adapter > config precedence', async () => {
     const ctx = createCtx()
     ctx.configs = [{

--- a/packages/task/src/run.ts
+++ b/packages/task/src/run.ts
@@ -339,5 +339,9 @@ export const run = async (
     }
   )
 
-  return { session: hookBridge.wrapSession(session), ctx }
+  return {
+    session: hookBridge.wrapSession(session),
+    ctx,
+    resolvedAdapter: adapterType
+  }
 }


### PR DESCRIPTION
## Summary
- pin the resolved adapter in CLI session cache so resume is stable even if defaults change
- add compact/default/full list views with contextual next-step hints
- improve CLI help text and cover the new behavior with task/cli tests

## Testing
- pnpm -C apps/cli test
- pnpm -C packages/task test
- pnpm exec eslint apps/cli/src/session-cache.ts apps/cli/src/commands/run.ts apps/cli/src/commands/list.ts apps/cli/src/commands/stop.ts apps/cli/src/commands/kill.ts apps/cli/src/cli.ts apps/cli/__tests__/session-cache.spec.ts packages/task/src/run.ts packages/task/__tests__/run.spec.ts .ai/rules/usage/cli.md
- pnpm exec tsc -p packages/tsconfigs/tsconfig.typecheck.node.test.json --noEmit 2>&1 | rg "^(apps/cli|packages/task)/" || true