### PR TITLE
fix(cli): avoid exit 143 after --print stop

### DIFF
--- a/apps/cli/__tests__/run.spec.ts
+++ b/apps/cli/__tests__/run.spec.ts
@@ -11,7 +11,8 @@ import {
   resolveDefaultVibeForgeMcpServerOption,
   resolveInjectDefaultSystemPromptOption,
   resolvePrintableStopText,
-  resolveRunMode
+  resolveRunMode,
+  shouldPrintResumeHint
 } from '#~/commands/run.js'
 
 describe('run command print output', () => {
@@ -95,10 +96,8 @@ describe('run command print output', () => {
       kill: () => {
         killCount += 1
       },
-      emit: (event) => {
-        if (event.type === 'stop') {
-          stopCount += 1
-        }
+      stop: () => {
+        stopCount += 1
       }
     })
     controller.requestExit(0)
@@ -122,15 +121,28 @@ describe('run command print output', () => {
       kill: () => {
         killCount += 1
       },
-      emit: (event) => {
-        if (event.type === 'stop') {
-          stopCount += 1
-        }
+      stop: () => {
+        stopCount += 1
       }
     })
 
     expect(killCount).toBe(0)
     expect(stopCount).toBe(1)
+  })
+
+  it('falls back to kill when successful exit is requested without adapter stop support', () => {
+    let killCount = 0
+    const controller = createSessionExitController()
+
+    controller.bindSession({
+      kill: () => {
+        killCount += 1
+      }
+    })
+
+    controller.requestExit(0)
+
+    expect(killCount).toBe(1)
   })
 
   it('keeps cached stream mode when resume does not override print behavior', () => {
@@ -337,36 +349,19 @@ describe('run command print output', () => {
     expect(requestExit).not.toHaveBeenCalled()
   })
 
-  it('suppresses fatal exit errors after a successful stop was already requested', () => {
-    const log = vi.fn()
-    const errorLog = vi.fn()
-    const requestExit = vi.fn()
-
-    const nextState = handlePrintEvent({
-      event: {
-        type: 'error',
-        data: {
-          message: 'Process exited with code 143',
-          details: { exitCode: 143 },
-          fatal: true
-        }
-      },
-      outputFormat: 'text',
-      lastAssistantText: 'final answer',
-      didExitAfterError: false,
-      suppressFatalError: true,
-      log,
-      errorLog,
-      requestExit
-    })
-
-    expect(nextState).toEqual({
-      lastAssistantText: 'final answer',
-      didExitAfterError: false
-    })
-    expect(log).not.toHaveBeenCalled()
-    expect(errorLog).not.toHaveBeenCalled()
-    expect(requestExit).not.toHaveBeenCalled()
+  it('suppresses the resume hint for successful print sessions', () => {
+    expect(shouldPrintResumeHint({
+      shouldPrintOutput: true,
+      status: 'completed'
+    })).toBe(false)
+    expect(shouldPrintResumeHint({
+      shouldPrintOutput: true,
+      status: 'failed'
+    })).toBe(true)
+    expect(shouldPrintResumeHint({
+      shouldPrintOutput: false,
+      status: 'completed'
+    })).toBe(true)
   })
 
   it('rejects unsupported output format values at parse time', async () => {

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -57,7 +57,7 @@ interface ActiveCliSessionRecord {
 
 interface ExitControllableSession {
   kill(): void
-  emit?: (event: { type: 'stop' }) => void
+  stop?(): void
 }
 
 export const createSessionExitController = <T extends ExitControllableSession>(params?: {
@@ -69,8 +69,8 @@ export const createSessionExitController = <T extends ExitControllableSession>(p
   let didExit = false
   const exit = params?.exit ?? process.exit
   const signalSessionExit = (target: T) => {
-    if (pendingExitCode === 0 && typeof target.emit === 'function') {
-      target.emit({ type: 'stop' })
+    if (pendingExitCode === 0 && typeof target.stop === 'function') {
+      target.stop()
       return
     }
     target.kill()
@@ -417,20 +417,23 @@ Notes:
               ...record.resume,
               updatedAt: endedAt
             }
+            const status = persistedDetail?.status === 'stopped' || isCliSessionStopActive(control, endedAt)
+              ? 'stopped'
+              : exitCode === 0
+              ? 'completed'
+              : 'failed'
             record.detail = {
               ...record.detail,
               endTime: endedAt,
               exitCode,
-              status: persistedDetail?.status === 'stopped' || isCliSessionStopActive(control, endedAt)
-                ? 'stopped'
-                : exitCode === 0
-                ? 'completed'
-                : 'failed'
+              status
             }
             await persistRecord()
             await persistQueue
             await clearCliSessionControl(cwd, ctxId, sessionId)
-            console.error(formatResumeCommand(sessionId))
+            if (shouldPrintResumeHint({ shouldPrintOutput, status })) {
+              console.error(formatResumeCommand(sessionId))
+            }
             exitController.handleSessionExit(exitCode)
           })()
         }
@@ -447,15 +450,11 @@ Notes:
               updateInitRecord(event.data, boundSession?.pid)
             }
             if (shouldPrintOutput) {
-              const shouldSuppressFatalError = event.type === 'error' &&
-                event.data.fatal !== false &&
-                exitController.getPendingExitCode() === 0
               const nextState = handlePrintEvent({
                 event,
                 outputFormat,
                 lastAssistantText,
                 didExitAfterError,
-                suppressFatalError: shouldSuppressFatalError,
                 log: (message) => console.log(message),
                 errorLog: (message) => console.error(message),
                 requestExit: (code) => exitController.requestExit(code)
@@ -533,12 +532,16 @@ export const getAdapterErrorMessage = (data: AdapterErrorData) => {
   return details ? `${data.message}\n${details}` : data.message
 }
 
+export const shouldPrintResumeHint = (input: {
+  shouldPrintOutput: boolean
+  status: TaskDetail['status']
+}) => !(input.shouldPrintOutput && input.status === 'completed')
+
 export const handlePrintEvent = (input: {
   event: AdapterOutputEvent
   outputFormat: RunOutputFormat
   lastAssistantText: string | undefined
   didExitAfterError: boolean
-  suppressFatalError?: boolean
   log: (message: string) => void
   errorLog: (message: string) => void
   requestExit: (code: number) => void
@@ -549,12 +552,6 @@ export const handlePrintEvent = (input: {
 
   if (input.event.type === 'error') {
     const isFatal = input.event.data.fatal !== false
-    if (isFatal && input.suppressFatalError) {
-      return {
-        lastAssistantText: nextAssistantText,
-        didExitAfterError: input.didExitAfterError
-      }
-    }
 
     switch (input.outputFormat) {
       case 'stream-json':

--- a/packages/adapters/claude-code/src/claude/session.ts
+++ b/packages/adapters/claude-code/src/claude/session.ts
@@ -235,6 +235,7 @@ export const createClaudeSession = async (ctx: AdapterCtx, options: AdapterQuery
 
     return {
       kill: () => proc.kill(),
+      stop: () => proc.stdin.end(),
       emit,
       pid: proc.pid
     }

--- a/packages/adapters/opencode/__tests__/session-runtime-stream.spec.ts
+++ b/packages/adapters/opencode/__tests__/session-runtime-stream.spec.ts
@@ -63,6 +63,29 @@ describe('createOpenCodeSession stream runtime', () => {
     })
   })
 
+  it('emits exit when stop() is called after a successful stream turn', async () => {
+    mockExecFileJsonResponses(execFileMock, [
+      { id: 'sess_stop', title: 'Vibe Forge:session-stop', updatedAt: '2026-03-26T00:00:00.000Z' }
+    ])
+    spawnMock.mockImplementation(() => makeProc({ stdout: 'pong\n' }))
+
+    const events: AdapterOutputEvent[] = []
+    const { ctx } = makeCtx()
+    const session = await createOpenCodeSession(ctx, {
+      type: 'create',
+      runtime: 'server',
+      sessionId: 'session-stop',
+      description: 'Reply with exactly pong.',
+      onEvent: (event: AdapterOutputEvent) => events.push(event)
+    } as any)
+
+    await flushAsyncWork()
+    session.stop?.()
+
+    expect(events.map(event => event.type)).toEqual(['init', 'message', 'stop', 'exit'])
+    expect(events.at(-1)).toEqual({ type: 'exit', data: { exitCode: 0 } })
+  })
+
   it('reuses the cached OpenCode session id for later turns', async () => {
     mockExecFileJsonResponses(execFileMock, [{
       id: 'sess_1',

--- a/packages/adapters/opencode/src/runtime/session/stream.ts
+++ b/packages/adapters/opencode/src/runtime/session/stream.ts
@@ -65,12 +65,18 @@ export const createStreamOpenCodeSession = async (
   let currentKill: (() => void) | undefined
   let opencodeSessionId = cachedSession?.opencodeSessionId
   let didEmitFatalError = false
+  let didEmitExit = false
 
   const emitEvent = (event: AdapterOutputEvent) => {
     if (event.type === 'error' && event.data.fatal !== false) {
       didEmitFatalError = true
     }
     options.onEvent(event)
+  }
+  const emitExit = (data: { exitCode: number; stderr?: string }) => {
+    if (didEmitExit) return
+    didEmitExit = true
+    emitEvent({ type: 'exit', data })
   }
 
   const emitUnexpectedExit = (error: unknown) => {
@@ -80,7 +86,7 @@ export const createStreamOpenCodeSession = async (
     currentKill = undefined
     ctx.logger.error('OpenCode session turn failed unexpectedly', { err: error })
     emitEvent({ type: 'error', data: toAdapterErrorData(error) })
-    emitEvent({ type: 'exit', data: { exitCode: 1, stderr: getErrorMessage(error) } })
+    emitExit({ exitCode: 1, stderr: getErrorMessage(error) })
   }
 
   const runTurn = async (content: Extract<AdapterEvent, { type: 'message' }>, allowRetry: boolean): Promise<void> => {
@@ -154,7 +160,7 @@ export const createStreamOpenCodeSession = async (
           })
         })
       }
-      emitEvent({ type: 'exit', data: { exitCode: result.exitCode, stderr: result.stderr || result.stdout } })
+      emitExit({ exitCode: result.exitCode, stderr: result.stderr || result.stdout })
       return
     }
 
@@ -198,6 +204,14 @@ export const createStreamOpenCodeSession = async (
     kill: () => {
       destroyed = true
       currentKill?.()
+    },
+    stop: () => {
+      if (destroyed) return
+      destroyed = true
+      currentKill?.()
+      if (currentPid == null) {
+        emitExit({ exitCode: 0 })
+      }
     },
     emit: (event) => {
       if (destroyed) return

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -100,6 +100,7 @@ export interface AdapterQueryOptions {
 
 export interface AdapterSession {
   kill: () => void
+  stop?: () => void
   emit: (event: AdapterEvent) => void
   pid?: number
 }


### PR DESCRIPTION
## Summary
- make CLI success exits prefer adapter stop signaling instead of immediately killing the session
- suppress fatal adapter exit errors that arrive after a successful stop has already been requested
- add regression coverage for graceful stop signaling and the suppressed 143 error path

## Testing
- pnpm exec vitest run apps/cli/__tests__/run.spec.ts
- pnpm exec tsc -p tsconfig.json --noEmit