### PR TITLE
Refactor hook entrypoints and fix typecheck

### DIFF
--- a/apps/cli/__tests__/hooks.spec.ts
+++ b/apps/cli/__tests__/hooks.spec.ts
@@ -7,9 +7,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   listInstalledAdapterPackages,
   readInstalledAdapterScopeEntries,
-  resolveActiveNativeHookBridge
-} from '#~/hooks/bridge-loader.js'
-import { runHookEntrypoint } from '#~/hooks/entry.js'
+  resolveActiveNativeHookBridge,
+  runManagedHookEntrypoint
+} from '@vibe-forge/hooks'
 
 const tempDirs: string[] = []
 
@@ -122,7 +122,7 @@ describe('hook entrypoint', () => {
     const runHookBridge = vi.fn()
     const runHookCli = vi.fn()
 
-    await runHookEntrypoint({
+    await runManagedHookEntrypoint({
       resolveActiveNativeHookBridge: () => ({
         isNativeHookEnv: () => true,
         runHookBridge
@@ -137,7 +137,7 @@ describe('hook entrypoint', () => {
   it('falls back to the default hook cli when no native bridge is active', async () => {
     const runHookCli = vi.fn()
 
-    await runHookEntrypoint({
+    await runManagedHookEntrypoint({
       resolveActiveNativeHookBridge: () => undefined,
       runHookCli
     })
@@ -149,7 +149,7 @@ describe('hook entrypoint', () => {
     const runHookCli = vi.fn()
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await runHookEntrypoint({
+    await runManagedHookEntrypoint({
       resolveActiveNativeHookBridge: () => {
         throw new Error('load failed')
       },

--- a/apps/cli/src/AGENTS.md
+++ b/apps/cli/src/AGENTS.md
@@ -34,7 +34,7 @@ config、cache、definition、workspace asset 共享 contract 位于 `@vibe-forg
 优先入口：
 
 - `commands/run.ts`
-- `hooks/index.ts`
+- `../../packages/hooks/src/entry.ts`
 - `../../packages/cli-helper/loader.js`
 - `../../packages/hooks/call-hook.js`
 
@@ -45,7 +45,7 @@ hooks 相关问题先按这条链路看：
 - `packages/hooks/call-hook.js`
   - 通用 hook 进程入口
   - 负责把 `HOME` 指到工作区 `.ai/.mock`，再执行 hooks runtime
-- `apps/cli/src/hooks/index.ts`
+- `packages/hooks/src/entry.ts`
   - 动态发现已安装 adapter 的 `./hook-bridge`，命中 active env 后执行，否则回退默认 `runHookCli()`
 - `packages/hooks/src/runtime.ts`
   - 默认 hook runtime，负责读取输入、装载插件、执行 middleware

--- a/apps/cli/src/commands/run/types.ts
+++ b/apps/cli/src/commands/run/types.ts
@@ -42,10 +42,10 @@ export interface ExitControllableSession {
   stop?(): void
 }
 
-export interface CliInputControlEvent {
-  type: 'message' | 'interrupt' | 'stop'
-  content?: string | ChatMessageContent[]
-}
+export type CliInputControlEvent =
+  | { type: 'message'; content: string | ChatMessageContent[] }
+  | { type: 'interrupt' }
+  | { type: 'stop' }
 
 export interface CliInputSession {
   emit(

--- a/apps/cli/src/hooks/bridge-loader.ts
+++ b/apps/cli/src/hooks/bridge-loader.ts
@@ -1,7 +1,0 @@
-export {
-  listInstalledAdapterPackages,
-  readInstalledAdapterScopeEntries,
-  resolveActiveNativeHookBridge,
-  resolvePreferredNativeHookBridgePackage
-} from '@vibe-forge/hooks'
-export type { NativeHookBridgeLoaderDeps, NativeHookBridgeModule } from '@vibe-forge/hooks'

--- a/apps/cli/src/hooks/entry.ts
+++ b/apps/cli/src/hooks/entry.ts
@@ -1,1 +1,0 @@
-export { runManagedHookEntrypoint as runHookEntrypoint } from '@vibe-forge/hooks'

--- a/apps/cli/src/hooks/index.ts
+++ b/apps/cli/src/hooks/index.ts
@@ -1,3 +1,0 @@
-import { runHookEntrypoint } from './entry'
-
-void runHookEntrypoint()

--- a/apps/client/src/components/chat/sender/Sender.tsx
+++ b/apps/client/src/components/chat/sender/Sender.tsx
@@ -615,13 +615,13 @@ export function Sender({
           {permissionContext != null && (
             <div className='interaction-panel__context'>
               <div className='interaction-panel__meta'>
-                {permissionContext.currentMode != null && permissionContext.currentMode !== '' && (
+                {permissionContext.currentMode != null && (
                   <div className='interaction-panel__meta-item'>
                     <span className='interaction-panel__meta-label'>{t('chat.permissionCurrentMode')}</span>
                     <code>{permissionContext.currentMode}</code>
                   </div>
                 )}
-                {permissionContext.suggestedMode != null && permissionContext.suggestedMode !== '' && (
+                {permissionContext.suggestedMode != null && (
                   <div className='interaction-panel__meta-item'>
                     <span className='interaction-panel__meta-label'>{t('chat.permissionSuggestedMode')}</span>
                     <code>{permissionContext.suggestedMode}</code>

--- a/apps/server/src/channels/interaction.ts
+++ b/apps/server/src/channels/interaction.ts
@@ -133,6 +133,7 @@ export const buildInteractionText = (
   payload: AskUserQuestionParams
 ) => {
   const permissionContext = payload.kind === 'permission' ? payload.permissionContext : undefined
+  const permissionReasons = permissionContext?.reasons ?? []
   const lines = [
     ...(payload.kind === 'permission'
       ? [isEnglish(language) ? '[Permission Request]' : '[权限请求]']
@@ -150,9 +151,9 @@ export const buildInteractionText = (
       ? `Suggested mode: ${permissionContext?.suggestedMode}`
       : `建议模式：${permissionContext?.suggestedMode}`)
   }
-  if ((permissionContext?.reasons?.length ?? 0) > 0) {
+  if (permissionReasons.length > 0) {
     lines.push(isEnglish(language) ? 'Reason:' : '原因：')
-    lines.push(...permissionContext.reasons.map(reason => `- ${reason}`))
+    lines.push(...permissionReasons.map(reason => `- ${reason}`))
   }
 
   lines.push(...buildInteractionOptionLines(language, payload.options ?? []))

--- a/packages/adapters/claude-code/AGENTS.md
+++ b/packages/adapters/claude-code/AGENTS.md
@@ -39,7 +39,7 @@
 - `src/hooks/bridge.ts`
   - 负责把 Claude native payload 翻译成统一 hook 协议
 - `packages/hooks/call-hook.js`
-- `apps/cli/src/hooks/index.ts`
+- `packages/hooks/src/entry.ts`
 - `packages/hooks/src/native.ts`
 - `packages/hooks/src/bridge.ts`
 - `packages/task/src/run.ts`
@@ -190,7 +190,7 @@ Claude 维护时优先检查两点：
 先读：
 
 - `apps/cli/src/commands/init.ts`
-- `apps/cli/src/hooks/index.ts`
+- `packages/hooks/src/entry.ts`
 - `src/hooks/bridge.ts`
 - `src/hooks/native.ts`
 - `packages/utils/src/create-logger.ts`

--- a/packages/adapters/claude-code/src/claude/prepare.ts
+++ b/packages/adapters/claude-code/src/claude/prepare.ts
@@ -269,7 +269,6 @@ export const prepareClaudeExecution = async (
     args.push('--dangerously-skip-permissions')
   } else if (
     permissionMode != null &&
-    permissionMode !== '' &&
     permissionMode !== 'default'
   ) {
     args.push('--permission-mode', permissionMode)

--- a/packages/adapters/codex/AGENTS.md
+++ b/packages/adapters/codex/AGENTS.md
@@ -40,7 +40,7 @@ Primary implementation entrypoints for Codex hooks:
 - `src/hook-bridge.ts`
   - translates Codex native payloads into Vibe Forge hook input/output
 - `packages/hooks/call-hook.js`
-- `apps/cli/src/hooks/index.ts`
+- `packages/hooks/src/entry.ts`
 - `packages/hooks/src/native.ts`
 - `packages/hooks/src/bridge.ts`
 - `packages/task/src/run.ts`

--- a/scripts/chrome-debug.ts
+++ b/scripts/chrome-debug.ts
@@ -311,7 +311,10 @@ const createChromeCdpClient = async (webSocketDebuggerUrl: string) => {
       })
 
       const resultPromise = new Promise<TResult>((resolve, reject) => {
-        pending.set(id, { resolve, reject })
+        pending.set(id, {
+          resolve: value => resolve(value as TResult | PromiseLike<TResult>),
+          reject
+        })
       })
 
       socket.send(payload)


### PR DESCRIPTION
## Summary
- remove obsolete CLI hook shim entrypoints and point tests/docs at @vibe-forge/hooks directly
- tighten CLI input control event typing to reflect the real message/interrupt/stop shapes
- fix existing typecheck issues in Claude adapter, client permission UI, server interaction formatting, and chrome-debug pending requests

## Testing
- pnpm -C apps/cli test
- pnpm typecheck