### PR TITLE
docs: document message actions maintenance flow

### DIFF
--- a/.ai/rules/DEVELOPMENT.md
+++ b/.ai/rules/DEVELOPMENT.md
@@ -37,6 +37,7 @@ pnpm exec eslint .
 pnpm exec dprint check
 pnpm exec dprint fmt
 pnpm typecheck
+pnpm tools message-actions verify
 pnpm tools commitmsg-check <base> <head>
 pnpm -C apps/cli test
 pnpm -C packages/hooks test

--- a/.ai/rules/MAINTENANCE.md
+++ b/.ai/rules/MAINTENANCE.md
@@ -8,6 +8,8 @@ description: 仓库通用维护与验证规则，包含启动、lint、格式化
 本文件保留常用维护入口；日志消费与排查经验见：
 
 - [日志消费与排查](./maintenance/logs.md)
+- [消息级操作开发经验](./maintenance/message-actions.md)
+- [消息级操作维护工具](./maintenance/tooling.md)
 
 ## 开发环境启动
 
@@ -34,6 +36,8 @@ description: 仓库通用维护与验证规则，包含启动、lint、格式化
   - 场景：在重构或修改共享包 (`packages/core`) 后，确保全量类型安全。
 - **提交信息检查**: `pnpm tools commitmsg-check <base> <head>`
   - 场景：在 CI 中校验一个 commit range 内的提交标题是否符合 Conventional Commit 约定；GitHub merge commit 例外。
+- **消息级操作回归**: `pnpm tools message-actions verify`
+  - 场景：修改消息级 `编辑 / 撤回 / 分叉 / 复制原文` 后，固定跑一遍质量检查与回归测试组合，并拿到真实 Chrome 回归清单。
 - **单元测试**: `pnpm -C apps/client test` / `pnpm -C apps/cli test` / `npx vitest run <path>`
   - 场景：修改核心逻辑或 API 适配器后验证功能正确性。
   - 注意：运行单个用例或目录时需使用 `vitest run <path>`，不要直接执行 `vitest <path>`。

--- a/.ai/rules/maintenance/message-actions.md
+++ b/.ai/rules/maintenance/message-actions.md
@@ -1,0 +1,71 @@
+# 消息级操作开发经验
+
+本文沉淀消息级 `编辑 / 撤回 / 分叉 / 复制原文` 相关开发的高频结论，便于后续继续演进时快速对齐约束、回归点与常见坑位。
+
+## 功能边界
+
+- `fork` 只允许用户消息；不要只在前端隐藏按钮，后端也必须拒绝 assistant message 的分叉请求。
+- `edit` 目前语义不是“原会话就地改写”，而是“基于选中消息创建新分支会话并继续回复”。
+- `recall` 也走分支会话，而不是直接截断原会话历史。
+- `copy` 复制的是原始文本/markdown，不是渲染后的 DOM 文本。
+
+## 关键实现约束
+
+### 1. 分支会话必须保留完整历史种子
+
+- `historySeed` 不能只保留纯文本；如果被裁切区间内有工具调用，还要保留 `tool_use` / `tool_result` / 旧版 `message.toolCall` 的上下文。
+- 否则新分支会话虽然能创建，但 adapter 看到的是缺失工具背景的历史，后续回复容易失真。
+
+### 2. 基于历史种子的分支会话必须走 `create`，不能走 `resume`
+
+- 只要会话依赖 `historySeedPending` 回放历史，就应该启动全新的 adapter runtime。
+- 如果错误复用成 `resume`，runtime 会带上旧上下文，导致“看起来是新会话，实际继续了旧运行态”的混合状态。
+
+### 3. 编辑态必须复用 sender，而不是单独维护一套 textarea
+
+- Inline edit 应直接复用底部 sender 的 composer 结构，保证图片上传、资源类型扩展和后续交互一致。
+- 同时只能允许一条消息进入编辑态；编辑中的消息 id 必须上提到列表父层统一管理。
+- 正在编辑时要隐藏底部主 sender，避免出现“历史编辑 + 新消息发送”并行输入。
+
+### 4. 联合类型必须显式收窄到可编辑内容
+
+- `ChatMessageContent[]` 包含 `text / image / tool_use / tool_result`。
+- 编辑链路只接受 `text / image`，否则前端在 `url / name / size / mimeType` 上会出现类型错误，CI `typecheck` 会失败。
+- 推荐做法是单独声明 `EditableMessageItem`，再用类型守卫收窄。
+
+### 5. i18n 与按钮语义要一起收口
+
+- 消息 footer 的文案不能继续写死在组件里，应同步维护中英文 locale。
+- 编辑确认按钮语义固定为 `发送`，不要混入“保存并分叉”这类实现导向文案。
+
+## 本次开发里真实踩过的坑
+
+### 1. 本地通过但 PR `typecheck` 失败
+
+- 原因通常不是 CI 特殊，而是本地只跑了局部命令，没有覆盖到 `bundler.web` 的完整类型路径。
+- 处理方式：优先用 `pnpm typecheck`，不要只跑 `pnpm -r exec tsc --noEmit` 替代。
+
+### 2. PR `format-check` 失败
+
+- `dprint` 对 JSX 缩进和 import 排序比肉眼更严格。
+- 提交前直接跑 `pnpm exec dprint check`；如果失败，用 `pnpm exec dprint fmt <files...>` 修，不要手工对格式。
+
+### 3. `commit-message` 失败不一定是 commit title 本身有问题
+
+- 这次的实际问题是 workflow 里 `actions/setup-node` 在 `pnpm/action-setup` 之前执行，`cache: pnpm` 找不到可执行文件。
+- 看到 `Unable to locate executable file: pnpm` 时，先检查 CI workflow 顺序，不要误判成 commit range 计算错误。
+
+### 4. 临时浏览器脚本会被界面文案变更击穿
+
+- 之前的临时 Playwright 脚本依赖按钮名 `保存并分叉`，改成 `发送` 后脚本直接卡死。
+- 浏览器验证脚本如果继续维护，优先绑定稳定语义（`aria-label` / 结构断言），不要强依赖易变文案。
+
+## 推荐回归清单
+
+- 用户消息 hover 后能看到 `编辑 / 撤回 / 复制原文`，assistant 消息没有 `fork`。
+- 编辑态替换原消息气泡，原 markdown 不再同时渲染。
+- 同时只允许一条消息编辑；第二次尝试会提示已有编辑中的消息。
+- 编辑时底部 sender 隐藏，取消后恢复。
+- `copy` 拿到的是 markdown 原文。
+- `edit / recall / fork` 后新分支会话会继续触发一轮新的 assistant 回复。
+- 分支历史如果包含工具调用，生成的新会话仍能看到完整上下文。

--- a/.ai/rules/maintenance/tooling.md
+++ b/.ai/rules/maintenance/tooling.md
@@ -1,0 +1,113 @@
+# 消息级操作维护工具
+
+本文收口这次开发里反复使用、后续也建议复用的工具链与调用方式。
+
+## 统一入口
+
+新增了一个 repo 内固定命令：
+
+```bash
+pnpm tools message-actions verify
+```
+
+用途：
+
+- 跑 `eslint`
+- 跑 `dprint check`
+- 跑 `pnpm typecheck`
+- 跑消息级操作相关的 server/db/websocket 回归测试
+- 最后打印真实 Chrome 手工回归清单
+
+如果只想看步骤结果，不想流式打印子进程输出：
+
+```bash
+pnpm tools message-actions verify --quiet
+```
+
+## 质量检查命令
+
+### 全量质量检查
+
+```bash
+pnpm exec eslint .
+pnpm exec dprint check
+pnpm typecheck
+```
+
+适用场景：
+
+- 准备提交前
+- PR review 修复后
+- CI 失败需要本地复现时
+
+### 目标回归测试
+
+```bash
+pnpm exec vitest run --workspace vitest.workspace.ts \
+  apps/server/__tests__/db/index.spec.ts \
+  apps/server/__tests__/db/schema.spec.ts \
+  apps/server/__tests__/services/session-history.spec.ts \
+  apps/server/__tests__/services/session-interaction.spec.ts \
+  apps/server/__tests__/services/session-start.spec.ts \
+  apps/server/__tests__/services/session.spec.ts \
+  apps/server/__tests__/websocket/server.spec.ts
+```
+
+适用场景：
+
+- 修改消息分叉、历史裁切、runtime 启动类型、session runtime state 时
+
+## PR / CI 工具
+
+### 查看 PR 检查状态
+
+```bash
+gh pr checks <pr-number>
+gh pr view <pr-number> --json mergeStateStatus,mergeable,statusCheckRollup
+```
+
+### 读取失败 job 日志
+
+```bash
+gh run view <run-id> --job <job-id> --log
+```
+
+用途：
+
+- 区分是代码问题，还是 workflow 配置问题
+- 尤其适合排查 `typecheck`、`format-check`、`commit-message`
+
+### 持续等待检查完成
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+### 本地复现 commit range 校验
+
+```bash
+pnpm tools commitmsg-check <base> <head>
+```
+
+或者：
+
+```bash
+node scripts/check-commit-messages.mjs <base> <head>
+```
+
+## 真实 Chrome 回归
+
+自动化检查不能替代真实界面验证。消息级操作改动完成后，至少手工确认下面几项：
+
+1. 编辑进入后，原消息内容被编辑器替换，不会“原消息 + 编辑框”并存。
+2. 编辑确认按钮文案为 `发送`。
+3. 同时只能有一条消息编辑；再次点编辑会出现提示。
+4. 编辑期间底部 sender 隐藏。
+5. assistant 消息没有 fork，`复制原文` 能复制原始 markdown/text。
+6. `edit / recall / fork` 进入新分支后，会触发新的 assistant 回复，而不是停在静态分支页。
+
+## 使用建议
+
+- 开始提 PR 前先跑一次 `pnpm tools message-actions verify`。
+- 如果 PR 上某个质量检查失败，先用 `gh run view --job --log` 看真实错误，再决定是修代码还是修 workflow。
+- 只有在本地质量检查和真实 Chrome 回归都通过后，再执行合并。

--- a/apps/client/AGENTS.md
+++ b/apps/client/AGENTS.md
@@ -5,6 +5,7 @@
 - `src/components/layout/`：全局布局组件，当前放置 `AppShell` 这类应用骨架。
 - `src/components/`：可复用视图组件和页面内部面板，不承担路由匹配职责。
 - `src/components/chat/`：聊天页子视图，包含 header、history、timeline、settings、sender 和工具渲染。
+  - 消息级 `编辑 / 撤回 / 分叉 / 复制原文` 的更细维护说明见 `src/components/chat/AGENTS.md`。
 - `src/hooks/`：跨页面通用 hooks；`src/hooks/chat/` 专门承载聊天会话相关状态和交互逻辑。
 - `src/api/`：HTTP API 封装与响应类型，页面和 hooks 统一通过这里访问后端。
 - `src/store/`：全局状态原子。
@@ -35,3 +36,48 @@
 - 页面级列表或详情拉取优先放在 route 或对应页面 hook 中，不要散落在纯展示组件内。
 - API 请求统一走 `src/api/`，避免在组件里直接手写 `fetch`。
 - 能复用的状态逻辑优先抽到 hooks，不在 route 和 view 间复制业务逻辑。
+
+## 聊天消息操作维护
+
+如果任务涉及聊天消息级交互，优先读这些入口：
+
+- `src/components/chat/ChatHistoryView.tsx`
+  - 列表级状态，包含 `editingMessageId`、编辑冲突提示、编辑期间隐藏底部 sender。
+- `src/components/chat/messages/MessageItem.tsx`
+  - 单条消息的 `编辑 / 撤回 / 分叉 / 复制原文` UI，以及 inline edit 挂载点。
+- `src/components/chat/sender/Sender.tsx`
+  - 底部 sender 和 inline edit 共用的 composer；图片上传和资源型输入都从这里走。
+- `src/hooks/chat/use-chat-session-actions.ts`
+  - 消息操作的前端 action 入口。
+- `src/api/sessions.ts`
+  - 会话/消息分支相关 API 封装。
+
+进一步经验与工具说明：
+
+- 经验沉淀：`../../.ai/rules/maintenance/message-actions.md`
+- 工具与使用法：`../../.ai/rules/maintenance/tooling.md`
+
+## 消息级调试与回归
+
+推荐先跑：
+
+```bash
+pnpm tools message-actions verify
+```
+
+这个命令会串行执行：
+
+- `eslint`
+- `dprint check`
+- `pnpm typecheck`
+- 消息级操作相关回归测试
+- 真实 Chrome 手工验证清单输出
+
+真实 Chrome 最低回归项：
+
+1. 编辑态替换原消息，不允许“原消息 + 编辑器”并存。
+2. 编辑确认按钮文案是 `发送`。
+3. 同时只能编辑一条消息；再次点编辑会提示已有编辑中的消息。
+4. 编辑时底部 sender 隐藏，取消后恢复。
+5. assistant 消息不允许 fork，`复制原文` 复制的是原始 markdown/text。
+6. `edit / recall / fork` 后新分支会继续触发 assistant 回复。

--- a/apps/client/src/components/chat/AGENTS.md
+++ b/apps/client/src/components/chat/AGENTS.md
@@ -1,0 +1,81 @@
+# Chat 组件维护说明
+
+本目录承载聊天页内部视图。涉及消息级交互时，优先从这里读起，而不是只看顶层 route。
+
+## 关键文件职责
+
+- `ChatHistoryView.tsx`
+  - 会话消息列表的父层编排。
+  - 管理 `editingMessageId`。
+  - 负责“已有一条消息正在编辑”的冲突提示。
+  - 负责编辑期间隐藏底部主 sender。
+- `messages/MessageItem.tsx`
+  - 单条消息渲染。
+  - 消息 footer 操作按钮。
+  - inline edit 的消息内挂载点。
+  - 原始文本复制逻辑。
+- `messages/MessageFooter.tsx`
+  - 消息 footer 的统一承载层。
+  - 改 footer 文案或按钮时，优先改这里，不要散落到 `MessageItem`。
+- `sender/Sender.tsx`
+  - 默认 sender 和 inline edit 共用的 composer。
+  - 文本输入、图片上传、工具/模型/权限模式选择都在这里。
+- `sender/Sender.scss`
+  - sender 和 inline edit 的共同样式来源。
+
+## 消息级操作的当前约束
+
+- assistant 消息不允许 fork；前端不显示按钮，后端也会拒绝。
+- inline edit 必须复用 `Sender`，不要另造一套 textarea/composer。
+- 编辑期间底部主 sender 必须隐藏，避免出现双输入源。
+- 同一时间只允许一条消息进入编辑态；冲突时保留当前编辑器并提示用户。
+- `复制原文` 复制的是原始 markdown/text，不是渲染后的可见 DOM 文本。
+- 编辑确认按钮固定使用 `发送`，不要改回实现导向文案。
+
+## 改动时容易漏掉的地方
+
+### 1. i18n
+
+- 新增或调整消息操作文案时，同时更新：
+  - `src/resources/locales/zh.json`
+  - `src/resources/locales/en.json`
+
+### 2. 可编辑内容类型
+
+- `Sender` 支持 `ChatMessageContent[]`，但 inline edit 只应该接受 `text / image`。
+- 如果在 `MessageItem` 里直接把 `ChatMessageContent[]` 当成可编辑内容使用，`typecheck` 很容易在 `tool_use / tool_result` 分支上失败。
+
+### 3. 真实界面验证
+
+- 这块交互非常依赖真实布局、hover 和按钮语义。
+- 只跑单测或后端测试不够；改完必须用真实 Chrome 回归。
+
+### 4. 临时脚本脆弱性
+
+- 浏览器验证不要强依赖易变按钮文案。
+- 更稳妥的是依赖 `aria-label`、稳定类名或结构断言。
+
+## 推荐调试顺序
+
+1. 先看 `ChatHistoryView.tsx`，确认父层状态是不是放对了。
+2. 再看 `MessageItem.tsx`，确认消息级入口和 sender 挂载点。
+3. 如涉及输入能力，再看 `Sender.tsx`。
+4. 如涉及消息操作请求，再看 `src/hooks/chat/use-chat-session-actions.ts` 和 `src/api/sessions.ts`。
+5. 最后回到真实 Chrome 做界面验证。
+
+## 推荐回归命令
+
+```bash
+pnpm tools message-actions verify
+```
+
+如果需要只看最终结果，不看中间子命令输出：
+
+```bash
+pnpm tools message-actions verify --quiet
+```
+
+进一步的经验和工具说明见：
+
+- `../../../../../.ai/rules/maintenance/message-actions.md`
+- `../../../../../.ai/rules/maintenance/tooling.md`

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -25,6 +25,8 @@
   - 在当前 Feishu messenger 页里悬停某条消息，并点击它的 reply 按钮
 - `pnpm tools chrome-debug messenger-click-text <conversation> <text>`
   - 在当前 Feishu messenger 页里按可见文本点击一个右侧会话内的按钮或快捷气泡
+- `pnpm tools message-actions verify [--quiet]`
+  - 跑消息级 `编辑 / 撤回 / 分叉 / 复制原文` 的固定质量检查组合，并打印真实 Chrome 回归清单
 - `pnpm tools commitmsg-check [base] [head]`
   - 校验一个 git range 里的 commit title 是否符合 Conventional Commit；GitHub 默认 merge commit 例外
 - `pnpm tools publish-plan -- [args]`

--- a/scripts/__tests__/cli.spec.ts
+++ b/scripts/__tests__/cli.spec.ts
@@ -13,6 +13,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -34,6 +35,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -64,6 +66,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan
     })
 
@@ -82,6 +85,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -103,6 +107,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend,
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -138,6 +143,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -164,6 +170,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply,
       runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -198,6 +205,7 @@ describe('scripts cli', () => {
       runChromeDebugMessengerSend: vi.fn(async () => {}),
       runChromeDebugMessengerClickReply: vi.fn(async () => {}),
       runChromeDebugMessengerClickText,
+      runMessageActionsVerify: vi.fn(async () => {}),
       runPublishPlan: vi.fn(async () => ({}))
     })
 
@@ -216,6 +224,27 @@ describe('scripts cli', () => {
       conversation: '二介',
       text: '/help --page=2',
       settleMs: 1000
+    })
+  })
+
+  it('dispatches message actions verification with quiet mode', async () => {
+    const runMessageActionsVerify = vi.fn(async () => {})
+    const cli = createScriptsCli({
+      runAdapterSuite: vi.fn(async () => []),
+      runAdapterVitest: vi.fn(async () => {}),
+      runChromeDebugTargets: vi.fn(async () => {}),
+      runChromeDebugMessengerConversations: vi.fn(async () => {}),
+      runChromeDebugMessengerSend: vi.fn(async () => {}),
+      runChromeDebugMessengerClickReply: vi.fn(async () => {}),
+      runChromeDebugMessengerClickText: vi.fn(async () => {}),
+      runMessageActionsVerify,
+      runPublishPlan: vi.fn(async () => ({}))
+    })
+
+    await cli.parseAsync(['node', 'vf-dev', 'message-actions', 'verify', '--quiet'])
+
+    expect(runMessageActionsVerify).toHaveBeenCalledWith({
+      quiet: true
     })
   })
 })

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -13,6 +13,7 @@ import {
   runChromeDebugMessengerSend,
   runChromeDebugTargets
 } from './chrome-debug'
+import { runMessageActionsVerify } from './message-actions'
 
 const runVitestAdapterE2E = async (input: {
   selection: string | undefined
@@ -62,6 +63,7 @@ interface ScriptsCliDeps {
   runChromeDebugMessengerSend: typeof runChromeDebugMessengerSend
   runChromeDebugMessengerClickReply: typeof runChromeDebugMessengerClickReply
   runChromeDebugMessengerClickText: typeof runChromeDebugMessengerClickText
+  runMessageActionsVerify: typeof runMessageActionsVerify
   runPublishPlan: (args: string[]) => Promise<unknown>
 }
 
@@ -91,6 +93,7 @@ const defaultDeps: ScriptsCliDeps = {
   runChromeDebugMessengerSend,
   runChromeDebugMessengerClickReply,
   runChromeDebugMessengerClickText,
+  runMessageActionsVerify,
   runPublishPlan: async (args) => {
     const { runPublishPlanCli } = await import('./publish-plan-core.mjs')
     return runPublishPlanCli(args)
@@ -276,6 +279,22 @@ export const createScriptsCli = (inputDeps: Partial<ScriptsCliDeps> = {}) => {
         conversation,
         text,
         settleMs: options.settleMs
+      })
+    })
+
+  const messageActionsCommand = program
+    .command('message-actions')
+    .description('Run reusable verification flows for message-level chat actions')
+
+  messageActionsCommand
+    .command('verify')
+    .description('Run code-quality and regression checks for message edit/recall/fork changes')
+    .option('--quiet', 'Do not stream child command output', false)
+    .action(async (options: {
+      quiet?: boolean
+    }) => {
+      await deps.runMessageActionsVerify({
+        quiet: options.quiet ?? false
       })
     })
 

--- a/scripts/message-actions.ts
+++ b/scripts/message-actions.ts
@@ -1,0 +1,79 @@
+import process from 'node:process'
+
+import { runProcess } from './adapter-e2e/runtime'
+
+interface MessageActionsVerificationStep {
+  label: string
+  command: string
+  args: string[]
+}
+
+export interface MessageActionsVerifyInput {
+  quiet: boolean
+}
+
+const messageActionVerificationSteps: MessageActionsVerificationStep[] = [
+  {
+    label: 'Run ESLint',
+    command: 'pnpm',
+    args: ['exec', 'eslint', '.']
+  },
+  {
+    label: 'Run dprint format check',
+    command: 'pnpm',
+    args: ['exec', 'dprint', 'check']
+  },
+  {
+    label: 'Run typecheck',
+    command: 'pnpm',
+    args: ['typecheck']
+  },
+  {
+    label: 'Run targeted session/message regression tests',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'vitest',
+      'run',
+      '--workspace',
+      'vitest.workspace.ts',
+      'apps/server/__tests__/db/index.spec.ts',
+      'apps/server/__tests__/db/schema.spec.ts',
+      'apps/server/__tests__/services/session-history.spec.ts',
+      'apps/server/__tests__/services/session-interaction.spec.ts',
+      'apps/server/__tests__/services/session-start.spec.ts',
+      'apps/server/__tests__/services/session.spec.ts',
+      'apps/server/__tests__/websocket/server.spec.ts'
+    ]
+  }
+]
+
+const browserChecklist = [
+  '[message-actions] Browser validation checklist',
+  '1. Start the app with `pnpm start` and ensure `http://localhost:5173/ui` + `http://localhost:8787/api/sessions` are reachable.',
+  '2. In real Chrome, verify inline edit replaces the original bubble and the confirm button label is `发送`.',
+  '3. While one message is editing, verify a second edit attempt shows the warning and does not open another editor.',
+  '4. While editing, verify the bottom sender is hidden and restored after cancel.',
+  '5. Verify assistant messages do not expose fork, and `复制原文` copies raw markdown/text.',
+  '6. Verify edit/fork still produce a branched continuation with a fresh assistant reply.'
+].join('\n')
+
+export const runMessageActionsVerify = async (input: MessageActionsVerifyInput) => {
+  for (const step of messageActionVerificationSteps) {
+    process.stdout.write(`\n[message-actions] ${step.label}\n`)
+
+    const result = await runProcess({
+      command: step.command,
+      args: step.args,
+      env: process.env,
+      passthroughStdIO: !input.quiet
+    })
+
+    if (result.code !== 0) {
+      process.exitCode = result.code
+      return
+    }
+  }
+
+  process.stdout.write(`\n${browserChecklist}\n`)
+}


### PR DESCRIPTION
## Summary

- document the message-level chat action maintenance flow in repo docs and client AGENTS
- add a reusable `pnpm tools message-actions verify` command
- add CLI coverage for the new maintenance command

## Validation

- `pnpm tools message-actions verify --quiet`
- `pnpm exec vitest run --workspace vitest.workspace.ts scripts/__tests__/cli.spec.ts apps/client/__tests__/sender-interaction-request.spec.ts`
- `pnpm exec dprint check`
