### PR TITLE
chore(release): publish @vibe-forge/adapter-claude-code 0.10.2

### DIFF
--- a/changelog/0.10.2/adapter-claude-code.md
+++ b/changelog/0.10.2/adapter-claude-code.md
@@ -1,0 +1,18 @@
+# @vibe-forge/adapter-claude-code 0.10.2
+
+发布日期：2026-04-10
+
+## 发布范围
+
+- 发布 `@vibe-forge/adapter-claude-code@0.10.2`
+
+## 主要变更
+
+- Claude adapter 在初始化 mock home 时，会把真实 home 下的 `Library/Keychains` 软链到 `.ai/.mock/Library/Keychains`
+- 当 Claude 运行在 `HOME=.ai/.mock` 的隔离环境下时，仍然可以复用 macOS Keychain 中已有的认证材料
+- 如果当前运行拿不到真实 home，adapter 会清理 mock home 里旧的 `Library/Keychains` 软链，避免残留到过期路径
+
+## 兼容性说明
+
+- 不增加新的 CLI 参数或配置项
+- 变更只影响 `@vibe-forge/adapter-claude-code` 初始化 mock home 时的原生资产同步逻辑

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-claude-code",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Claude Code Adapter for Vibe Forge",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- bump @vibe-forge/adapter-claude-code to 0.10.2
- add the 0.10.2 single-package changelog entry

## Release basis
- runtime change since pkg/vibe-forge-adapter-claude-code/v0.10.1: Claude mock-home init now links real-home Library/Keychains and cleans stale links

## Validation
- npm whoami
- npm view @vibe-forge/adapter-claude-code version
- pnpm tools publish-plan -- --package @vibe-forge/adapter-claude-code --json
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/adapters/claude-code/__tests__/init.spec.ts
- cd packages/adapters/claude-code && npm pack --dry-run