### PR TITLE
fix(codex-adapter): disable startup update checks by default

### DIFF
--- a/packages/adapters/codex/AGENTS.md
+++ b/packages/adapters/codex/AGENTS.md
@@ -120,6 +120,9 @@ export default defineConfig({
       effort: 'medium',
       maxOutputTokens: 4096,
       clientInfo: { name: 'vibe-forge', title: 'Vibe Forge', version: '0.1.0' },
+      configOverrides: {
+        check_for_update_on_startup: false
+      },
       features: {
         shell_snapshot: true,
         unified_exec: false
@@ -165,6 +168,15 @@ Notable flags:
 | `web_search_request` | true    | Live web search                                                          |
 | `remote_models`      | false   | Refresh remote model list at startup                                     |
 | `codex_hooks`        | false   | Native `SessionStart/UserPromptSubmit/PreToolUse/PostToolUse/Stop` hooks |
+
+### `configOverrides`
+
+Raw Codex `-c key=value` overrides forwarded to every Codex spawn.
+
+The adapter currently defaults `check_for_update_on_startup = false` so managed
+Codex sessions do not surface startup version-update prompts by default.
+Set `adapters.codex.configOverrides.check_for_update_on_startup = true` if you
+need to restore Codex's built-in startup update check.
 
 ### Native hooks
 

--- a/packages/adapters/codex/__tests__/session-rpc.spec.ts
+++ b/packages/adapters/codex/__tests__/session-rpc.spec.ts
@@ -339,6 +339,60 @@ describe('createCodexSession RPC approval policy mapping', () => {
     session.kill()
   })
 
+  it('disables codex startup update checks by default', async () => {
+    process.env.HOME = '/tmp'
+    const { proc } = makeProc()
+    spawnMock.mockReturnValue(proc)
+
+    const session = await createCodexSession(makeCtx(), {
+      type: 'create',
+      runtime: 'server',
+      sessionId: 'session-default-update-check',
+      description: 'Reply with pong.',
+      onEvent: () => {}
+    } as any)
+
+    const spawnArgs = spawnMock.mock.calls[0]?.[1] as string[]
+    const overrides = getConfigOverrides(spawnArgs)
+    expect(overrides).toContain('check_for_update_on_startup=false')
+
+    session.kill()
+  })
+
+  it('allows configOverrides to re-enable codex startup update checks', async () => {
+    process.env.HOME = '/tmp'
+    const { proc } = makeProc()
+    spawnMock.mockReturnValue(proc)
+
+    const session = await createCodexSession(
+      makeCtx({
+        configs: [{
+          adapters: {
+            codex: {
+              configOverrides: {
+                check_for_update_on_startup: true
+              }
+            }
+          }
+        }, undefined]
+      }),
+      {
+        type: 'create',
+        runtime: 'server',
+        sessionId: 'session-custom-update-check',
+        description: 'Reply with pong.',
+        onEvent: () => {}
+      } as any
+    )
+
+    const spawnArgs = spawnMock.mock.calls[0]?.[1] as string[]
+    const overrides = getConfigOverrides(spawnArgs)
+    expect(overrides).toContain('check_for_update_on_startup=true')
+    expect(overrides).not.toContain('check_for_update_on_startup=false')
+
+    session.kill()
+  })
+
   it('enables native codex hooks and injects runtime metadata when available', async () => {
     process.env.HOME = '/tmp'
     const { proc } = makeProc()

--- a/packages/adapters/codex/src/adapter-config.ts
+++ b/packages/adapters/codex/src/adapter-config.ts
@@ -25,6 +25,8 @@ declare module '@vibe-forge/types' {
       /**
        * Raw Codex config overrides encoded as dotted keys and values,
        * serialized to repeated `-c key=value` flags.
+       * The adapter defaults `check_for_update_on_startup` to `false`
+       * unless explicitly overridden here.
        */
       configOverrides?: Record<string, unknown>
       /**

--- a/packages/adapters/codex/src/runtime/session-common.ts
+++ b/packages/adapters/codex/src/runtime/session-common.ts
@@ -126,6 +126,10 @@ const normalizeProviderBaseUrl = (apiBaseUrl: string | undefined, wireApi: strin
     : apiBaseUrl
 }
 
+const DEFAULT_CODEX_CONFIG_OVERRIDES: Record<string, unknown> = {
+  check_for_update_on_startup: false
+}
+
 /**
  * Encode a flat string→string record as a TOML inline table: `{key = "value", …}`.
  */
@@ -174,6 +178,11 @@ const encodeCodexConfigValue = (value: unknown): string | undefined => {
   }
   return undefined
 }
+
+const mergeCodexConfigOverrides = (overrides: Record<string, unknown>) => ({
+  ...DEFAULT_CODEX_CONFIG_OVERRIDES,
+  ...Object.fromEntries(Object.entries(overrides).filter(([, value]) => value !== undefined))
+})
 
 const buildNativeConfigOverrideArgs = (overrides: Record<string, unknown>) => {
   const args: string[] = []
@@ -523,7 +532,9 @@ export async function resolveSessionBase(
     ...(userConfig?.modelServices ?? {})
   }
 
-  const configOverrides = isPlainObject(configOverridesValue) ? configOverridesValue : {}
+  const configOverrides = mergeCodexConfigOverrides(
+    isPlainObject(configOverridesValue) ? configOverridesValue : {}
+  )
   const nativeReasoningEffort = normalizeCodexReasoningEffort(configOverrides.model_reasoning_effort)
   const requestedEffort = options.effort ?? configuredEffort
   const requestedReasoningEffort = mapPublicEffortToCodex(requestedEffort)


### PR DESCRIPTION
## Summary
- default the codex adapter to `check_for_update_on_startup = false`
- allow `adapters.codex.configOverrides` to override that default explicitly
- document the behavior and add regression coverage for the generated `-c` overrides

## Testing
- pnpm exec vitest run packages/adapters/codex/__tests__/session-rpc.spec.ts
- pnpm exec dprint check packages/adapters/codex/src/runtime/session-common.ts packages/adapters/codex/src/adapter-config.ts packages/adapters/codex/__tests__/session-rpc.spec.ts packages/adapters/codex/AGENTS.md