### PR TITLE
docs(runtime): explain node path probe

### DIFF
--- a/packages/cli-helper/loader.js
+++ b/packages/cli-helper/loader.js
@@ -20,6 +20,8 @@ const resolvePackageNodePaths = (packageDir) => {
 
   try {
     const packageRequire = Module.createRequire(path.resolve(packageDir, 'package.json'))
+    // Probe package resolution with a synthetic name so Node returns the
+    // lookup paths for dependencies installed around the project package.
     return packageRequire.resolve.paths('@vibe-forge/cli-helper-node-path-probe') ?? []
   } catch {
     return []

--- a/packages/hooks/call-hook.js
+++ b/packages/hooks/call-hook.js
@@ -18,6 +18,8 @@ const resolvePackageNodePaths = (packageDir) => {
 
   try {
     const packageRequire = Module.createRequire(path.resolve(packageDir, 'package.json'))
+    // Probe package resolution with a synthetic name so Node returns the
+    // lookup paths for dependencies installed around the project package.
     return packageRequire.resolve.paths('@vibe-forge/hooks-node-path-probe') ?? []
   } catch {
     return []


### PR DESCRIPTION
## Summary
- explain why cli-helper uses a synthetic package name to probe Node resolution paths
- explain the equivalent hooks probe for dependency lookup paths

## Testing
- not run (comment-only change)
