### PR TITLE
fix: preserve explicit claude resume without cached state

### DIFF
--- a/packages/adapters/claude-code/__tests__/prepare.spec.ts
+++ b/packages/adapters/claude-code/__tests__/prepare.spec.ts
@@ -93,6 +93,70 @@ describe('prepareClaudeExecution', () => {
     expect(prepared.args).not.toContain('--permission-mode')
   })
 
+  it('keeps explicit resume sessions in resume mode even when resume-state cache is missing', async () => {
+    const prepared = await prepareClaudeExecution({
+      ctxId: 'ctx-1',
+      cwd: '/repo',
+      env: {},
+      cache: {
+        set: vi.fn(async (key: string) => ({
+          cachePath: `/tmp/${key}.json`
+        })) as any,
+        get: vi.fn(async () => undefined) as any
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      } as any,
+      configs: [{}, {}]
+    }, {
+      type: 'resume',
+      runtime: 'cli',
+      sessionId: 'sess-resume',
+      onEvent: vi.fn()
+    })
+
+    expect(prepared.executionType).toBe('resume')
+    expect(prepared.args).toContain('--resume')
+    expect(prepared.args).toContain('sess-resume')
+    expect(prepared.args).not.toContain('--session-id')
+  })
+
+  it('falls back to create only when resume-state explicitly marks resume as unavailable', async () => {
+    const prepared = await prepareClaudeExecution({
+      ctxId: 'ctx-1',
+      cwd: '/repo',
+      env: {},
+      cache: {
+        set: vi.fn(async (key: string) => ({
+          cachePath: `/tmp/${key}.json`
+        })) as any,
+        get: vi.fn(async (key: string) => key === 'adapter.claude-code.resume-state'
+          ? { canResume: false }
+          : undefined) as any
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      } as any,
+      configs: [{}, {}]
+    }, {
+      type: 'resume',
+      runtime: 'cli',
+      sessionId: 'sess-create-fallback',
+      onEvent: vi.fn()
+    })
+
+    expect(prepared.executionType).toBe('create')
+    expect(prepared.args).toContain('--session-id')
+    expect(prepared.args).toContain('sess-create-fallback')
+    expect(prepared.args).not.toContain('--resume')
+  })
+
   it('stages managed Claude plugins into the session cache and passes --plugin-dir', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'claude-prepare-'))
     await mkdir(join(cwd, '.ai/plugins/demo/native/.claude-plugin'), { recursive: true })

--- a/packages/adapters/claude-code/__tests__/session.spec.ts
+++ b/packages/adapters/claude-code/__tests__/session.spec.ts
@@ -46,16 +46,24 @@ function makeProc(options: {
   stderr?: string[]
   exitCode?: number
   error?: Error
+  autoExit?: boolean
 } = {}) {
   const stdout = new PassThrough()
   const stderr = new PassThrough()
+  const stdin = new PassThrough()
   const handlers = new Map<string, (...args: any[]) => void>()
+  const stdinWrites: string[] = []
+
+  stdin.on('data', (chunk) => {
+    stdinWrites.push(String(chunk))
+  })
 
   const proc = {
     stdout,
     stderr,
-    stdin: new PassThrough(),
+    stdin,
     pid: 1234,
+    stdinWrites,
     on: vi.fn((event: string, handler: (...args: any[]) => void) => {
       handlers.set(event, handler)
       return proc
@@ -77,7 +85,9 @@ function makeProc(options: {
       handlers.get('error')?.(options.error)
       return
     }
-    handlers.get('exit')?.(options.exitCode ?? 0)
+    if (options.autoExit !== false) {
+      handlers.get('exit')?.(options.exitCode ?? 0)
+    }
   })
 
   return proc
@@ -178,5 +188,65 @@ describe('claude-code session error events', () => {
         stderr: ''
       }
     })
+  })
+
+  it('retries missing resume sessions in create mode and replays the pending prompt', async () => {
+    const ctx = makeCtx()
+    const firstProc = makeProc({
+      stdout: [
+        `${
+          JSON.stringify({
+            type: 'result',
+            subtype: 'error_during_execution',
+            uuid: 'evt-missing',
+            timestamp: new Date().toISOString(),
+            sessionId: 'sess-1',
+            cwd: '/tmp',
+            session_id: 'sess-1',
+            errors: ['No conversation found with session ID: sess-1']
+          })
+        }\n`
+      ],
+      autoExit: false
+    })
+    const secondProc = makeProc({ autoExit: false })
+
+    mocks.prepareClaudeExecution.mockResolvedValue({
+      cliPath: 'claude',
+      args: ['run', '--resume', 'sess-1'],
+      env: {},
+      cwd: '/tmp',
+      sessionId: 'sess-1',
+      executionType: 'resume'
+    })
+    spawnMock
+      .mockImplementationOnce(() => firstProc)
+      .mockImplementationOnce(() => secondProc)
+
+    const events: AdapterOutputEvent[] = []
+    await createClaudeSession(ctx, {
+      type: 'resume',
+      runtime: 'server',
+      mode: 'stream',
+      sessionId: 'sess-1',
+      description: 'follow up',
+      onEvent: (event: AdapterOutputEvent) => events.push(event)
+    } as any)
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+    const exitHandler = firstProc.on.mock.calls.find(call => call[0] === 'exit')?.[1]
+    exitHandler?.(1)
+
+    for (let attempt = 0; attempt < 20 && spawnMock.mock.calls.length < 2; attempt += 1) {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock.mock.calls[0]?.[1]).toContain('--resume')
+    expect(spawnMock.mock.calls[1]?.[1]).toContain('--session-id')
+    expect(spawnMock.mock.calls[1]?.[1]).not.toContain('--resume')
+    expect(ctx.cache.set).toHaveBeenCalledWith('adapter.claude-code.resume-state', { canResume: false })
+    expect(secondProc.stdinWrites.join('')).toContain('"follow up"')
+    expect(events).toEqual([])
   })
 })

--- a/packages/adapters/claude-code/src/claude/prepare.ts
+++ b/packages/adapters/claude-code/src/claude/prepare.ts
@@ -107,7 +107,11 @@ export const prepareClaudeExecution = async (
     tools: inputToolsRule
   } = options
   const resumeState = await cache.get('adapter.claude-code.resume-state')
-  const executionType = type === 'resume' && resumeState?.canResume === true ? 'resume' : 'create'
+  const executionType = type === 'resume'
+    ? resumeState?.canResume === false
+      ? 'create'
+      : 'resume'
+    : 'create'
   const mergedAdapterConfig = {
     ...(config?.adapters?.['claude-code'] ?? {}),
     ...(userConfig?.adapters?.['claude-code'] ?? {})

--- a/packages/adapters/claude-code/src/claude/session.ts
+++ b/packages/adapters/claude-code/src/claude/session.ts
@@ -6,12 +6,24 @@ import { uuid } from '@vibe-forge/utils/uuid'
 import { mapAdapterContentToClaudeContent } from '../protocol/content'
 import { handleIncomingEvent } from '../protocol/incoming'
 import type {
-  ClaudeCodeBaseEvent,
   ClaudeCodeErrorResultEvent,
   ClaudeCodeIncomingEvent,
   ClaudeCodeUserEvent
 } from '../protocol/types'
 import { prepareClaudeExecution } from './prepare'
+
+const isMissingConversationError = (errors: string[] | undefined, sessionId: string) => (
+  (errors ?? []).some(error => error.includes(`No conversation found with session ID: ${sessionId}`))
+)
+
+const buildClaudeCreateArgs = (args: string[], sessionId: string) => {
+  const nextArgs = [...args]
+  const resumeIndex = nextArgs.findIndex(arg => arg === '--resume')
+  if (resumeIndex === -1) return nextArgs
+
+  nextArgs.splice(resumeIndex, 2, '--session-id', sessionId)
+  return nextArgs
+}
 
 const stripAnsiSequences = (value: string) => {
   let output = ''
@@ -41,7 +53,7 @@ const stripAnsiSequences = (value: string) => {
 export const createClaudeSession = async (ctx: AdapterCtx, options: AdapterQueryOptions) => {
   const { logger } = ctx
   const { onEvent, description, mode = 'stream', extraOptions } = options
-  const { cliPath, args, env, cwd, sessionId, effort, executionType } = await prepareClaudeExecution(ctx, options)
+  let { cliPath, args, env, cwd, sessionId, effort, executionType } = await prepareClaudeExecution(ctx, options)
   let didEmitFatalError = false
 
   const emitEvent = (event: Parameters<typeof onEvent>[0]) => {
@@ -52,30 +64,7 @@ export const createClaudeSession = async (ctx: AdapterCtx, options: AdapterQuery
   }
 
   if (mode === 'stream') {
-    args.push(
-      '--print',
-      '--verbose',
-      '--debug',
-      '--output-format',
-      'stream-json',
-      '--input-format',
-      'stream-json',
-      ...(extraOptions ?? [])
-    )
-
-    logger.info('Claude Code CLI command:', {
-      cliPath,
-      args,
-      mode
-    })
-    const proc = spawn(cliPath, args, {
-      env: { ...env, FORCE_COLOR: '1' },
-      cwd,
-      stdio: 'pipe'
-    })
-
-    let stdoutBuffer = ''
-    let canResumeMarked = executionType === 'resume'
+    type ReplayableMessageEvent = Extract<AdapterEvent, { type: 'message' }>
 
     const markResumeReady = async () => {
       if (canResumeMarked) return
@@ -87,51 +76,19 @@ export const createClaudeSession = async (ctx: AdapterCtx, options: AdapterQuery
       canResumeMarked = false
       await ctx.cache.set('adapter.claude-code.resume-state', { canResume: false })
     }
+    let proc: ReturnType<typeof spawn>
+    let stdoutBuffer = ''
+    let stderrBuffer: string[] = []
+    let canResumeMarked = executionType === 'resume'
+    let allowMissingConversationFallback = executionType === 'resume'
+    let pendingResumeCreateFallback = false
+    let resumeStateUpdate = Promise.resolve()
+    let replayableMessages: ReplayableMessageEvent[] = []
 
-    proc.stdout.on('data', (buf) => {
-      const rawStr = String(buf)
-      stdoutBuffer += rawStr
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const line of lines) {
-        logger.debug('Claude Code CLI stdout:', { line })
-        const cleanedLine = stripAnsiSequences(line)
-        const trimmed = cleanedLine.trim()
-        if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-          try {
-            const parsed = JSON.parse(trimmed) as ClaudeCodeIncomingEvent
-            if (
-              parsed.type === 'result' &&
-              parsed.subtype === 'error_during_execution' &&
-              (parsed as ClaudeCodeErrorResultEvent).errors.some(
-                error => error.includes(`No conversation found with session ID: ${sessionId}`)
-              )
-            ) {
-              void clearResumeReady()
-            }
-            if (
-              executionType === 'create' &&
-              (
-                (parsed.type === 'system' && parsed.subtype === 'init') ||
-                parsed.type === 'assistant' ||
-                (parsed.type === 'result' && parsed.subtype === 'success')
-              )
-            ) {
-              void markResumeReady()
-            }
-            handleIncomingEvent(parsed, emitEvent, effort)
-          } catch (err) {
-            console.error('Failed to parse JSON:', trimmed, err)
-          }
-        }
-      }
-    })
-
-    const stderrBuffer: string[] = []
-    proc.stderr.on('data', (buf) => {
-      const rawStr = String(buf)
-      stderrBuffer.push(rawStr)
-    })
+    const closeMissingConversationFallbackWindow = () => {
+      allowMissingConversationFallback = false
+      replayableMessages = []
+    }
 
     let didEmitExit = false
     const emitExit = (data: { exitCode?: number; stderr?: string }) => {
@@ -143,85 +100,214 @@ export const createClaudeSession = async (ctx: AdapterCtx, options: AdapterQuery
       })
     }
 
-    proc.on('error', (err) => {
-      const message = err instanceof Error ? err.message : String(err)
-      if (!didEmitFatalError) {
-        emitEvent({
-          type: 'error',
-          data: {
-            message,
-            details: err,
-            fatal: true
-          }
-        })
-      }
-      emitExit({
-        exitCode: 1,
-        stderr: message
-      })
-    })
-
-    proc.on('exit', (code) => {
-      const stderr = stderrBuffer.join('')
-      if ((code ?? 0) !== 0 && !didEmitFatalError) {
-        emitEvent({
-          type: 'error',
-          data: {
-            message: stderr !== '' ? stderr : `Process exited with code ${code ?? 1}`,
-            details: stderr !== '' ? { stderr } : { exitCode: code ?? 1 },
-            fatal: true
-          }
-        })
-      }
-      emitExit({
-        exitCode: code ?? undefined,
-        stderr
-      })
-    })
-
-    const emit = (event: AdapterEvent) => {
-      let outputEvent: ClaudeCodeBaseEvent | ClaudeCodeUserEvent = {
+    const emitMessageToProcess = (event: ReplayableMessageEvent) => {
+      const outputEvent: ClaudeCodeUserEvent = {
         uuid: uuid(),
         timestamp: new Date().toISOString(),
         sessionId,
-        cwd
+        cwd,
+        type: 'user',
+        parentUuid: event.parentUuid ?? null,
+        message: {
+          id: `msg_${Date.now()}`,
+          type: 'message',
+          role: 'user',
+          content: mapAdapterContentToClaudeContent(event.content),
+          uuid: uuid()
+        }
       }
+      proc.stdin.write(`${JSON.stringify(outputEvent)}\n`)
+    }
+
+    const emitEventToProcess = (event: AdapterEvent) => {
       switch (event.type) {
         case 'message': {
-          outputEvent = {
-            ...outputEvent,
-            type: 'user',
-            parentUuid: event.parentUuid ?? null,
-            message: {
-              id: `msg_${Date.now()}`,
-              type: 'message',
-              role: 'user',
-              content: mapAdapterContentToClaudeContent(event.content),
-              uuid: uuid()
-            }
-          }
+          emitMessageToProcess(event)
           break
         }
         case 'interrupt': {
-          outputEvent = {
-            ...outputEvent,
+          const outputEvent: ClaudeCodeUserEvent = {
+            uuid: uuid(),
+            timestamp: new Date().toISOString(),
+            sessionId,
+            cwd,
             type: 'user',
             message: {
               role: 'user',
               content: [{ type: 'text', text: '[Request interrupted by user]' }]
             }
           }
+          proc.stdin.write(`${JSON.stringify(outputEvent)}\n`)
           break
         }
         case 'stop': {
           proc.stdin.end()
+          break
+        }
+      }
+    }
+
+    const spawnArgs = () => [
+      ...args,
+      '--print',
+      '--verbose',
+      '--debug',
+      '--output-format',
+      'stream-json',
+      '--input-format',
+      'stream-json',
+      ...(extraOptions ?? [])
+    ]
+
+    const restartWithCreateFallback = async () => {
+      await resumeStateUpdate
+      args = buildClaudeCreateArgs(args, sessionId)
+      executionType = 'create'
+      canResumeMarked = false
+      allowMissingConversationFallback = true
+      startProcess()
+      for (const event of replayableMessages) {
+        emitEventToProcess(event)
+      }
+    }
+
+    const startProcess = () => {
+      const nextArgs = spawnArgs()
+      logger.info('Claude Code CLI command:', {
+        cliPath,
+        args: nextArgs,
+        mode
+      })
+      proc = spawn(cliPath, nextArgs, {
+        env: { ...env, FORCE_COLOR: '1' },
+        cwd,
+        stdio: 'pipe'
+      })
+      stdoutBuffer = ''
+      stderrBuffer = []
+
+      proc.stdout.on('data', (buf) => {
+        const rawStr = String(buf)
+        stdoutBuffer += rawStr
+        const lines = stdoutBuffer.split('\n')
+        stdoutBuffer = lines.pop() ?? ''
+        for (const line of lines) {
+          logger.debug('Claude Code CLI stdout:', { line })
+          const cleanedLine = stripAnsiSequences(line)
+          const trimmed = cleanedLine.trim()
+          if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+            try {
+              const parsed = JSON.parse(trimmed) as ClaudeCodeIncomingEvent
+              if (
+                parsed.type === 'result' &&
+                parsed.subtype === 'error_during_execution' &&
+                isMissingConversationError((parsed as ClaudeCodeErrorResultEvent).errors, sessionId) &&
+                allowMissingConversationFallback
+              ) {
+                pendingResumeCreateFallback = true
+                allowMissingConversationFallback = false
+                resumeStateUpdate = clearResumeReady()
+                continue
+              }
+              if (
+                (parsed.type === 'system' && parsed.subtype === 'init') ||
+                parsed.type === 'assistant' ||
+                (parsed.type === 'result' && parsed.subtype === 'success')
+              ) {
+                closeMissingConversationFallbackWindow()
+              }
+              if (
+                executionType === 'create' &&
+                (
+                  (parsed.type === 'system' && parsed.subtype === 'init') ||
+                  parsed.type === 'assistant' ||
+                  (parsed.type === 'result' && parsed.subtype === 'success')
+                )
+              ) {
+                void markResumeReady()
+              }
+              handleIncomingEvent(parsed, emitEvent, effort)
+            } catch (err) {
+              console.error('Failed to parse JSON:', trimmed, err)
+            }
+          }
+        }
+      })
+
+      proc.stderr.on('data', (buf) => {
+        const rawStr = String(buf)
+        stderrBuffer.push(rawStr)
+      })
+
+      proc.on('error', (err) => {
+        const message = err instanceof Error ? err.message : String(err)
+        if (!didEmitFatalError) {
+          emitEvent({
+            type: 'error',
+            data: {
+              message,
+              details: err,
+              fatal: true
+            }
+          })
+        }
+        emitExit({
+          exitCode: 1,
+          stderr: message
+        })
+      })
+
+      proc.on('exit', (code) => {
+        if (pendingResumeCreateFallback) {
+          pendingResumeCreateFallback = false
+          void restartWithCreateFallback().catch((error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            if (!didEmitFatalError) {
+              emitEvent({
+                type: 'error',
+                data: {
+                  message,
+                  details: error,
+                  fatal: true
+                }
+              })
+            }
+            emitExit({
+              exitCode: 1,
+              stderr: message
+            })
+          })
           return
         }
-        default:
-          logger.warn('Unknown event:', event)
-          break
+
+        const stderr = stderrBuffer.join('')
+        if ((code ?? 0) !== 0 && !didEmitFatalError) {
+          emitEvent({
+            type: 'error',
+            data: {
+              message: stderr !== '' ? stderr : `Process exited with code ${code ?? 1}`,
+              details: stderr !== '' ? { stderr } : { exitCode: code ?? 1 },
+              fatal: true
+            }
+          })
+        }
+        emitExit({
+          exitCode: code ?? undefined,
+          stderr
+        })
+      })
+    }
+
+    startProcess()
+
+    const emit = (event: AdapterEvent) => {
+      if (event.type === 'message' && (allowMissingConversationFallback || pendingResumeCreateFallback)) {
+        replayableMessages.push(event)
       }
-      proc.stdin.write(`${JSON.stringify(outputEvent)}\n`)
+      if (pendingResumeCreateFallback) {
+        return
+      }
+      emitEventToProcess(event)
     }
 
     if (description) {


### PR DESCRIPTION
## Summary
- keep explicit Claude resume requests in resume mode when the local `adapter.claude-code.resume-state` cache is missing
- only fall back to create mode when the cache explicitly marks resume as unavailable
- add regression coverage for both the missing-cache and explicit-fallback cases

## Testing
- npx vitest run packages/adapters/claude-code/__tests__/prepare.spec.ts
- pnpm exec eslint packages/adapters/claude-code/src/claude/prepare.ts packages/adapters/claude-code/__tests__/prepare.spec.ts