### PR TITLE
fix: stabilize runtime transpile metadata release

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.10.2-alpha.0",
+  "version": "0.10.2-alpha.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.10.2-alpha.1",
+  "version": "0.10.2",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.10.1",
+  "version": "0.10.2-alpha.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/changelog/0.10.2-alpha.0/register.md
+++ b/changelog/0.10.2-alpha.0/register.md
@@ -1,0 +1,18 @@
+# @vibe-forge/register 0.10.2-alpha.0
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 发布 `@vibe-forge/register@0.10.2-alpha.0`
+
+## 主要变更
+
+- `@vibe-forge/register/esbuild` 不再默认编译整个 `node_modules`
+- 运行时 transpile 改为包级元数据显式 opt-in，支持 `vibeForge.runtimeTranspile: true`
+- 继续兼容通过 `imports` / `exports` 中 `__vibe-forge__` 条件声明源码入口的包，避免已有源码包回退
+
+## 兼容性说明
+
+- 工作区源码仍默认走 runtime transpile
+- 第三方 `node_modules` 只有显式声明后才会被编译，避免误伤原生 ESM 依赖

--- a/changelog/0.10.2-alpha.0/server.md
+++ b/changelog/0.10.2-alpha.0/server.md
@@ -1,0 +1,18 @@
+# @vibe-forge/server 0.10.2-alpha.0
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 发布 `@vibe-forge/server@0.10.2-alpha.0`
+
+## 主要变更
+
+- 让 `@vibe-forge/server` 的 alpha 版本随同消费 `@vibe-forge/register@0.10.2-alpha.0`
+- 确保 `node_modules` 内跑源码的 server CLI 在消费者环境里也能拿到新的 runtime transpile 元数据策略
+- 避免消费仓仅升级 CLI 时，`ai app` 仍回退命中旧版 `register`
+
+## 兼容性说明
+
+- 不改 server 的源码启动设计
+- 这次 alpha 只调整发布版本与上游运行时依赖组合，用于把 `register` 修复真实传递到消费者

--- a/changelog/0.10.2-alpha.1/server.md
+++ b/changelog/0.10.2-alpha.1/server.md
@@ -1,0 +1,18 @@
+# @vibe-forge/server 0.10.2-alpha.1
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 发布 `@vibe-forge/server@0.10.2-alpha.1`
+
+## 主要变更
+
+- 使用 workspace 发布流程重新发布 `@vibe-forge/server`
+- 修正 alpha 包内依赖版本展开，确保消费者安装时不会残留 `workspace:^`
+- 保持对 `@vibe-forge/register@0.10.2-alpha.0` 的 runtime 修复透传
+
+## 兼容性说明
+
+- 不改 server 启动方式与源码入口
+- 这次 alpha 仅修正发布产物中的依赖元数据

--- a/changelog/0.10.2/register.md
+++ b/changelog/0.10.2/register.md
@@ -1,0 +1,18 @@
+# @vibe-forge/register 0.10.2
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 发布 `@vibe-forge/register@0.10.2`
+
+## 主要变更
+
+- `@vibe-forge/register/esbuild` 不再默认编译整个 `node_modules`
+- 运行时 transpile 改为包级元数据显式 opt-in，支持 `vibeForge.runtimeTranspile: true`
+- 继续兼容通过 `imports` / `exports` 中 `__vibe-forge__` 条件声明源码入口的包
+
+## 兼容性说明
+
+- 工作区源码仍默认走 runtime transpile
+- 第三方 `node_modules` 只有显式声明后才会被编译，避免误伤原生 ESM 依赖

--- a/changelog/0.10.2/server.md
+++ b/changelog/0.10.2/server.md
@@ -1,0 +1,18 @@
+# @vibe-forge/server 0.10.2
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 发布 `@vibe-forge/server@0.10.2`
+
+## 主要变更
+
+- 正式版 `@vibe-forge/server` 随同消费 `@vibe-forge/register@0.10.2`
+- 确保 `ai app` 在消费者环境里也能拿到新的 runtime transpile 元数据策略
+- 不改 server 走源码启动的设计，只修正最终发布依赖组合
+
+## 兼容性说明
+
+- 对外启动方式不变
+- 这次发布主要把 `register` 的 runtime 修复稳定透传到消费仓

--- a/packages/register/__tests__/esbuild.spec.ts
+++ b/packages/register/__tests__/esbuild.spec.ts
@@ -11,11 +11,25 @@ const require = createRequire(import.meta.url)
 describe('register/esbuild', () => {
   const tempDirs: string[] = []
 
+  const runWithRegister = (entryPath: string) => spawnSync(
+    process.execPath,
+    [
+      '--conditions=__vibe-forge__',
+      '-r',
+      require.resolve('../esbuild.js'),
+      '-e',
+      `console.log(JSON.stringify(require(${JSON.stringify(entryPath)})))`
+    ],
+    {
+      encoding: 'utf8'
+    }
+  )
+
   afterEach(async () => {
     await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
   })
 
-  it('falls back from relative .js requests to sibling .ts files inside node_modules', async () => {
+  it('falls back from relative .js requests to sibling .ts files inside opted-in node_modules packages', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vf-register-esbuild-'))
     tempDirs.push(tempDir)
 
@@ -23,27 +37,110 @@ describe('register/esbuild', () => {
     await mkdir(packageDir, { recursive: true })
     await writeFile(
       path.join(packageDir, 'package.json'),
-      JSON.stringify({ name: 'fixture-package', version: '1.0.0' })
+      JSON.stringify({
+        name: 'fixture-package',
+        version: '1.0.0',
+        vibeForge: {
+          runtimeTranspile: true
+        }
+      })
     )
     await writeFile(path.join(packageDir, 'dep.ts'), 'module.exports = { value: 42 }\n')
     await writeFile(path.join(packageDir, 'entry.ts'), "module.exports = require('./dep.js')\n")
 
-    const result = spawnSync(
-      process.execPath,
-      [
-        '--conditions=__vibe-forge__',
-        '-r',
-        require.resolve('../esbuild.js'),
-        '-e',
-        `console.log(require(${JSON.stringify(path.join(packageDir, 'entry.ts'))}).value)`
-      ],
-      {
-        encoding: 'utf8'
-      }
-    )
+    const result = runWithRegister(path.join(packageDir, 'entry.ts'))
 
     expect(result.status).toBe(0)
-    expect(result.stdout.trim()).toBe('42')
+    expect(result.stdout.trim()).toBe(JSON.stringify({ value: 42 }))
+    expect(result.stderr).toBe('')
+  })
+
+  it('treats __vibe-forge__ source conditions as backward-compatible opt-in metadata', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vf-register-esbuild-'))
+    tempDirs.push(tempDir)
+
+    const packageDir = path.join(tempDir, 'node_modules', 'legacy-source-package')
+    await mkdir(packageDir, { recursive: true })
+    await writeFile(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: 'legacy-source-package',
+        version: '1.0.0',
+        exports: {
+          '.': {
+            '__vibe-forge__': {
+              default: './src/index.ts'
+            },
+            default: {
+              require: './dist/index.js'
+            }
+          }
+        }
+      })
+    )
+    await writeFile(path.join(packageDir, 'dep.ts'), 'module.exports = { value: 7 }\n')
+    await writeFile(path.join(packageDir, 'entry.ts'), "module.exports = require('./dep.js')\n")
+
+    const result = runWithRegister(path.join(packageDir, 'entry.ts'))
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe(JSON.stringify({ value: 7 }))
+    expect(result.stderr).toBe('')
+  })
+
+  it('does not transpile third-party module-sync esm dependencies from node_modules', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vf-register-esbuild-'))
+    tempDirs.push(tempDir)
+
+    const sourcePackageDir = path.join(tempDir, 'node_modules', 'source-package')
+    const thirdPartyPackageDir = path.join(tempDir, 'node_modules', 'third-party-package')
+    await mkdir(sourcePackageDir, { recursive: true })
+    await mkdir(thirdPartyPackageDir, { recursive: true })
+
+    await writeFile(
+      path.join(sourcePackageDir, 'package.json'),
+      JSON.stringify({
+        name: 'source-package',
+        version: '1.0.0',
+        vibeForge: {
+          runtimeTranspile: true
+        }
+      })
+    )
+    await writeFile(
+      path.join(sourcePackageDir, 'entry.ts'),
+      "module.exports = require('third-party-package')\n"
+    )
+
+    await writeFile(
+      path.join(thirdPartyPackageDir, 'package.json'),
+      JSON.stringify({
+        name: 'third-party-package',
+        version: '1.0.0',
+        exports: {
+          '.': [
+            {
+              'module-sync': './require.mjs',
+              default: './index.js'
+            },
+            './index.js'
+          ]
+        }
+      })
+    )
+    await writeFile(
+      path.join(thirdPartyPackageDir, 'index.js'),
+      'module.exports = { value: 42 }\n'
+    )
+    await writeFile(
+      path.join(thirdPartyPackageDir, 'require.mjs'),
+      "import value from './index.js';\n\nexport default value;\nexport { value as 'module.exports' };\n"
+    )
+
+    const result = runWithRegister(path.join(sourcePackageDir, 'entry.ts'))
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe(JSON.stringify({ value: 42 }))
     expect(result.stderr).toBe('')
   })
 })

--- a/packages/register/esbuild.js
+++ b/packages/register/esbuild.js
@@ -1,6 +1,94 @@
+const { existsSync, readFileSync } = require('node:fs')
 const Module = require('node:module')
 const path = require('node:path')
 const process = require('node:process')
+
+const VIBE_FORGE_SOURCE_CONDITION = '__vibe-forge__'
+const packageRuntimeTranspileCache = new Map()
+
+const normalizePath = (filename) => filename.split(path.sep).join('/')
+
+const isPlainObject = (value) => (
+  value != null &&
+  typeof value === 'object' &&
+  !Array.isArray(value)
+)
+
+const containsVibeForgeSourceCondition = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(containsVibeForgeSourceCondition)
+  }
+
+  if (!isPlainObject(value)) {
+    return false
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, VIBE_FORGE_SOURCE_CONDITION)) {
+    return true
+  }
+
+  return Object.values(value).some(containsVibeForgeSourceCondition)
+}
+
+const packageOptsIntoRuntimeTranspile = (packageJson) => {
+  const explicitOptIn = packageJson?.vibeForge?.runtimeTranspile
+
+  if (typeof explicitOptIn === 'boolean') {
+    return explicitOptIn
+  }
+
+  return containsVibeForgeSourceCondition(packageJson?.imports) ||
+    containsVibeForgeSourceCondition(packageJson?.exports)
+}
+
+const findNearestPackageJsonPath = (filename) => {
+  let currentDir = path.dirname(filename)
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'package.json')
+    if (existsSync(packageJsonPath)) {
+      return packageJsonPath
+    }
+
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) {
+      return undefined
+    }
+    currentDir = parentDir
+  }
+}
+
+// Files outside node_modules are workspace sources and should always compile.
+// Files inside node_modules must opt in through package metadata so third-party
+// ESM stays on Node's native loader path.
+const shouldCompileWithEsbuild = (filename) => {
+  const normalizedFilename = normalizePath(filename)
+  if (!normalizedFilename.includes('/node_modules/')) {
+    return true
+  }
+
+  const packageJsonPath = findNearestPackageJsonPath(filename)
+  if (packageJsonPath == null) {
+    return false
+  }
+
+  const cached = packageRuntimeTranspileCache.get(packageJsonPath)
+  if (cached != null) {
+    return cached
+  }
+
+  let shouldCompile = false
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+    shouldCompile = packageOptsIntoRuntimeTranspile(packageJson)
+  } catch {
+    shouldCompile = false
+  }
+
+  packageRuntimeTranspileCache.set(packageJsonPath, shouldCompile)
+  return shouldCompile
+}
 
 const isRelativeOrAbsoluteRequest = (request) => (
   typeof request === 'string' &&
@@ -57,5 +145,6 @@ Module._resolveFilename = function patchedResolveFilename(request, parent, isMai
 
 require('esbuild-register/dist/node.js').register({
   target: `node${process.version.slice(1)}`,
-  hookIgnoreNodeModules: false
+  hookIgnoreNodeModules: false,
+  hookMatcher: shouldCompileWithEsbuild
 })

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/register",
-  "version": "0.10.1",
+  "version": "0.10.2-alpha.0",
   "exports": {
     "./dotenv": {
       "types": "./dotenv.d.ts",

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/register",
-  "version": "0.10.2-alpha.0",
+  "version": "0.10.2",
   "exports": {
     "./dotenv": {
       "types": "./dotenv.d.ts",


### PR DESCRIPTION
## Summary\n- gate runtime transpile inside node_modules by package metadata\n- publish-ready 0.10.2 manifests for @vibe-forge/register and @vibe-forge/server\n- keep server source startup design while propagating the register fix to consumers\n\n## Validation\n- pnpm exec eslint packages/register/esbuild.js packages/register/__tests__/esbuild.spec.ts\n- npx vitest run packages/register/__tests__/esbuild.spec.ts\n- npm pack --dry-run in packages/register\n- pnpm pack for apps/server and inspected package.json dependencies