### PR TITLE
chore(release): prepare 0.11.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe-forge/client",
   "type": "module",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "imports": {
     "#~/*": [
       "./src/*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/changelog/0.11.0/readme.md
+++ b/changelog/0.11.0/readme.md
@@ -1,0 +1,22 @@
+# 0.11.0
+
+发布日期：2026-04-12
+
+## 发布范围
+
+- 统一发布全部 public workspace 包到 `0.11.0`
+- 覆盖 CLI、Server、Client、MCP、Task、Hooks、Config、Utils、Types、Benchmark、Lark channel、内置 adapter、plugins 以及 support 包
+
+## 主要变更
+
+- Lark channel 与 server 补齐 session companion MCP、tool call 详情链路和更稳定的深链接/动作链接处理。
+- Web Chat 继续重构工具调用展示，改进 tool summary、diff/renderer 结构，并补上聊天消息与工具定位的深链接体验。
+- adapter runtime 进一步加强原生 skills 与 mock home 同步；Codex runtime 自动同步 workspace skills 并默认关闭启动更新检查，Claude adapter 提升 resume 容错并补上 Kimi CCR transformer 兼容。
+- 默认内置 Vibe Forge MCP 现在可直接启用，同时修复 managed runtime 插件解析、register runtime transpile 判断和任务侧 project skill 查询链路。
+- Chrome 调试与 channel 自动化稳定性继续提升，补强 OpenAPI domain 处理和 messenger automation 的可靠性。
+
+## 兼容性说明
+
+- 本次为协调式整体版本升级，所有 public workspace 包统一提升到 `0.11.0`，建议消费方按同一版本线整体升级。
+- 默认 MCP 启用与 runtime / adapter 行为在多个包中联动；若消费方只单独升级局部包，建议至少同步 `@vibe-forge/config`、`@vibe-forge/hooks`、`@vibe-forge/mcp`、`@vibe-forge/app-runtime`、`@vibe-forge/task` 与对应 adapter。
+- 聊天深链接、Lark tool call detail 与 companion MCP 属于增量能力；现有接入通常可继续工作，但如果你消费相关 URL、卡片或工具事件表现，建议同步做一次联调验证。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-forge-dev",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "start": "./start.sh",

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-claude-code",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Claude Code Adapter for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-codex",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Codex App Server Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-opencode",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "OpenCode Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/app-runtime",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "App-facing runtime facade for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/benchmark",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Benchmark discovery and execution for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/channels/lark/package.json
+++ b/packages/channels/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/channel-lark",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/cli-helper/package.json
+++ b/packages/cli-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli-helper",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": {
     ".": "./loader.js",
     "./entry": "./entry.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/config",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared config IO for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/definition-core/package.json
+++ b/packages/definition-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared definition-domain helpers for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/definition-loader/package.json
+++ b/packages/definition-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-loader",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared definition loading utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Vibe Forge MCP server",
   "imports": {
     "#~/*.js": {

--- a/packages/plugins/chrome-devtools/package.json
+++ b/packages/plugins/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-chrome-devtools",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/logger/package.json
+++ b/packages/plugins/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-logger",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/standard-dev/package.json
+++ b/packages/plugins/standard-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-standard-dev",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "exports": {
     "./package.json": "./package.json"
   }

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/register",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "exports": {
     "./dotenv": {
       "types": "./dotenv.d.ts",

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/task",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Task runtime for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/tsconfigs/package.json
+++ b/packages/tsconfigs/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vibe-forge/tsconfigs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TSConfig for Vibe Forge"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/types",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Shared types for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/utils",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Shared runtime utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/workspace-assets/package.json
+++ b/packages/workspace-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/workspace-assets",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Workspace asset resolution and adapter asset planning for Vibe Forge",
   "imports": {
     "#~/*.js": {


### PR DESCRIPTION
## Summary
- bump all public workspace packages and root metadata to 0.11.0
- add the overall release note at changelog/0.11.0/readme.md
- refresh this worktree with pnpm install before validating the release plan

## Verification
- pnpm tools publish-plan --
- pnpm exec dprint check package.json apps/cli/package.json apps/client/package.json apps/server/package.json packages/adapters/claude-code/package.json packages/adapters/codex/package.json packages/adapters/opencode/package.json packages/app-runtime/package.json packages/benchmark/package.json packages/channels/lark/package.json packages/cli-helper/package.json packages/config/package.json packages/core/package.json packages/definition-core/package.json packages/definition-loader/package.json packages/hooks/package.json packages/mcp/package.json packages/plugins/chrome-devtools/package.json packages/plugins/logger/package.json packages/plugins/standard-dev/package.json packages/register/package.json packages/task/package.json packages/tsconfigs/package.json packages/types/package.json packages/utils/package.json packages/workspace-assets/package.json changelog/0.11.0/readme.md