### PR TITLE
fix(server): surface channel startup state

### DIFF
--- a/apps/server/__tests__/channels/index.spec.ts
+++ b/apps/server/__tests__/channels/index.spec.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loadChannelModule = vi.fn()
+const handleInboundEvent = vi.fn()
+const handleSessionEvent = vi.fn()
+const resolveBinding = vi.fn()
+const sendToolCallJsonFile = vi.fn()
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}
+
+vi.mock('#~/channels/loader.js', () => ({
+  loadChannelModule
+}))
+
+vi.mock('#~/channels/handlers.js', () => ({
+  handleInboundEvent,
+  handleSessionEvent
+}))
+
+vi.mock('#~/channels/state.js', () => ({
+  resolveBinding
+}))
+
+vi.mock('#~/channels/tool-call-file.js', () => ({
+  sendToolCallJsonFile
+}))
+
+vi.mock('#~/utils/logger.js', () => ({
+  logger
+}))
+
+describe('initChannels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('logs connected channels after startReceiving succeeds', async () => {
+    const startReceiving = vi.fn()
+
+    loadChannelModule.mockReturnValue({
+      definition: {
+        configSchema: z.object({
+          type: z.literal('lark'),
+          appId: z.string()
+        })
+      },
+      create: vi.fn().mockResolvedValue({
+        startReceiving,
+        close: vi.fn()
+      })
+    })
+
+    const { initChannels } = await import('#~/channels/index.js')
+    const manager = await initChannels([{
+      channels: {
+        'miniapp-gear': {
+          type: 'lark',
+          appId: 'cli_xxx'
+        }
+      }
+    }])
+
+    expect(startReceiving).toHaveBeenCalledOnce()
+    expect(manager.states.get('miniapp-gear')).toMatchObject({
+      key: 'miniapp-gear',
+      type: 'lark',
+      status: 'connected',
+      configSource: 'project'
+    })
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        channelKey: 'miniapp-gear',
+        channelType: 'lark',
+        configSource: 'project'
+      },
+      '[channels] channel connected'
+    )
+  })
+
+  it('logs validation failures instead of failing silently', async () => {
+    loadChannelModule.mockReturnValue({
+      definition: {
+        configSchema: z.object({
+          type: z.literal('lark'),
+          appId: z.string()
+        })
+      },
+      create: vi.fn()
+    })
+
+    const { initChannels } = await import('#~/channels/index.js')
+    const manager = await initChannels([{
+      channels: {
+        'miniapp-gear': {
+          type: 'lark'
+        }
+      }
+    }])
+
+    expect(manager.states.get('miniapp-gear')).toMatchObject({
+      key: 'miniapp-gear',
+      type: 'lark',
+      status: 'error',
+      configSource: 'project'
+    })
+
+    const [payload, message] = logger.error.mock.calls[0] ?? []
+    expect(message).toBe('[channels] channel config validation failed')
+    expect(payload).toEqual(expect.objectContaining({
+      channelKey: 'miniapp-gear',
+      channelType: 'lark',
+      configSource: 'project'
+    }))
+    expect(typeof payload.error).toBe('string')
+  })
+
+  it('logs init failures and closes the partially created connection', async () => {
+    const close = vi.fn()
+    const startReceiving = vi.fn().mockRejectedValue(new Error('connection rejected'))
+
+    loadChannelModule.mockReturnValue({
+      definition: {
+        configSchema: z.object({
+          type: z.literal('lark'),
+          appId: z.string()
+        })
+      },
+      create: vi.fn().mockResolvedValue({
+        startReceiving,
+        close
+      })
+    })
+
+    const { initChannels } = await import('#~/channels/index.js')
+    const manager = await initChannels([{
+      channels: {
+        'miniapp-gear': {
+          type: 'lark',
+          appId: 'cli_xxx'
+        }
+      }
+    }])
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(manager.states.get('miniapp-gear')).toMatchObject({
+      key: 'miniapp-gear',
+      type: 'lark',
+      status: 'error',
+      error: 'connection rejected',
+      configSource: 'project'
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        channelKey: 'miniapp-gear',
+        channelType: 'lark',
+        configSource: 'project',
+        error: 'connection rejected'
+      },
+      '[channels] channel initialization failed'
+    )
+  })
+})

--- a/apps/server/__tests__/channels/loader.spec.ts
+++ b/apps/server/__tests__/channels/loader.spec.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requireMock = vi.fn()
+
+vi.mock('node:module', () => ({
+  createRequire: vi.fn(() => requireMock)
+}))
+
+describe('loadChannelModule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('ignores missing optional mcp exports', async () => {
+    const createChannelConnection = vi.fn()
+
+    requireMock.mockImplementation((specifier: string) => {
+      if (specifier === '@vibe-forge/channel-lark') {
+        return {
+          channelDefinition: {
+            configSchema: z.object({
+              type: z.literal('lark')
+            })
+          }
+        }
+      }
+
+      if (specifier === '@vibe-forge/channel-lark/connection') {
+        return { createChannelConnection }
+      }
+
+      if (specifier === '@vibe-forge/channel-lark/mcp') {
+        const error = new Error(
+          'Package subpath \'./mcp\' is not defined by "exports" in /tmp/node_modules/@vibe-forge/channel-lark/package.json'
+        ) as Error & { code?: string }
+        error.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+        throw error
+      }
+
+      throw new Error(`Unexpected specifier: ${specifier}`)
+    })
+
+    const { loadChannelModule } = await import('#~/channels/loader.js')
+    const loaded = loadChannelModule('lark')
+
+    expect(loaded.create).toBe(createChannelConnection)
+    expect(loaded.resolveSessionMcpServers).toBeUndefined()
+  })
+
+  it('rethrows unrelated mcp loading errors', async () => {
+    requireMock.mockImplementation((specifier: string) => {
+      if (specifier === '@vibe-forge/channel-lark') {
+        return {
+          channelDefinition: {
+            configSchema: z.object({
+              type: z.literal('lark')
+            })
+          }
+        }
+      }
+
+      if (specifier === '@vibe-forge/channel-lark/connection') {
+        return { createChannelConnection: vi.fn() }
+      }
+
+      if (specifier === '@vibe-forge/channel-lark/mcp') {
+        const error = new Error('bad export target') as Error & { code?: string }
+        error.code = 'ERR_INVALID_PACKAGE_TARGET'
+        throw error
+      }
+
+      throw new Error(`Unexpected specifier: ${specifier}`)
+    })
+
+    const { loadChannelModule } = await import('#~/channels/loader.js')
+
+    expect(() => loadChannelModule('lark')).toThrow('bad export target')
+  })
+})

--- a/apps/server/src/channels/index.ts
+++ b/apps/server/src/channels/index.ts
@@ -24,6 +24,15 @@ const collectChannelEntries = (
 
 let channelManager: ChannelManager | null = null
 
+const getChannelLogContext = (key: string, type: string, configSource: 'project' | 'user') => ({
+  channelKey: key,
+  channelType: type,
+  configSource
+})
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
 export const initChannels = async (
   configs: ReadonlyArray<{ channels?: Record<string, unknown> } | undefined>
 ): Promise<ChannelManager> => {
@@ -31,24 +40,41 @@ export const initChannels = async (
   const states = new Map<string, ChannelRuntimeState>()
   for (const [key, entry] of channels.entries()) {
     const value = entry.value
-    if (value == null || typeof value !== 'object') continue
+    if (value == null || typeof value !== 'object') {
+      logger.warn(
+        { channelKey: key, configSource: entry.source, valueType: value == null ? 'nullish' : typeof value },
+        '[channels] skipped invalid channel config entry'
+      )
+      continue
+    }
     const rawConfig = value as Record<string, unknown>
     const type = rawConfig.type
-    if (typeof type !== 'string' || type === '') continue
+    if (typeof type !== 'string' || type === '') {
+      logger.warn(
+        { channelKey: key, configSource: entry.source },
+        '[channels] skipped channel config without a valid type'
+      )
+      continue
+    }
 
+    const logContext = getChannelLogContext(key, type, entry.source)
+    let connection: ChannelRuntimeState['connection']
     try {
       const mod = loadChannelModule(type)
       if (rawConfig.enabled === false) {
         states.set(key, { key, type, status: 'disabled', configSource: entry.source })
+        logger.info(logContext, '[channels] channel disabled by config')
         continue
       }
       const parsed = mod.definition.configSchema.safeParse(rawConfig)
       if (parsed.success === false) {
-        states.set(key, { key, type, status: 'error', error: parsed.error?.message, configSource: entry.source })
+        const error = parsed.error?.message ?? 'Invalid channel config'
+        states.set(key, { key, type, status: 'error', error, configSource: entry.source })
+        logger.error({ ...logContext, error }, '[channels] channel config validation failed')
         continue
       }
       const connectionConfig = parsed.success ? parsed.data : rawConfig
-      const connection = await mod.create(connectionConfig, { logger })
+      connection = await mod.create(connectionConfig, { logger })
       const state: ChannelRuntimeState = {
         key,
         type,
@@ -57,21 +83,35 @@ export const initChannels = async (
         config: connectionConfig as ChannelBaseConfig,
         configSource: entry.source
       }
-      states.set(key, state)
       await connection.startReceiving?.({
         handlers: {
           message: async (event: ChannelInboundEvent) =>
             await handleInboundEvent(key, event, connection, state.config, state.configSource)
         }
       })
+      states.set(key, state)
+      logger.info(logContext, '[channels] channel connected')
     } catch (err) {
+      if (connection != null) {
+        try {
+          await connection.close?.()
+        } catch (closeError) {
+          logger.warn(
+            { ...logContext, error: getErrorMessage(closeError) },
+            '[channels] failed to close channel connection after init failure'
+          )
+        }
+      }
+
+      const error = getErrorMessage(err)
       states.set(key, {
         key,
         type,
         status: 'error',
-        error: String((err as Error).message ?? err),
+        error,
         configSource: entry.source
       })
+      logger.error({ ...logContext, error }, '[channels] channel initialization failed')
     }
   }
 

--- a/apps/server/src/channels/loader.ts
+++ b/apps/server/src/channels/loader.ts
@@ -10,11 +10,22 @@ export interface LoadedChannel {
   resolveSessionMcpServers?: ResolveChannelSessionMcpServersFn
 }
 
-const isOptionalMcpModuleMissing = (error: unknown, specifier: string) =>
-  error instanceof Error &&
-  'code' in error &&
-  error.code === 'MODULE_NOT_FOUND' &&
-  error.message.includes(specifier)
+const isOptionalMcpModuleMissing = (error: unknown, specifier: string) => {
+  if (!(error instanceof Error) || !('code' in error)) {
+    return false
+  }
+
+  if (error.code === 'MODULE_NOT_FOUND') {
+    return error.message.includes(specifier)
+  }
+
+  return (
+    error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
+    specifier.endsWith('/mcp') &&
+    error.message.includes("Package subpath './mcp'") &&
+    error.message.includes('"exports"')
+  )
+}
 
 export const loadChannelModule = (type: string): LoadedChannel => {
   const mainSpecifier = `@vibe-forge/channel-${type}`

--- a/changelog/0.11.0/readme.md
+++ b/changelog/0.11.0/readme.md
@@ -10,6 +10,7 @@
 ## 主要变更
 
 - Lark channel 与 server 补齐 session companion MCP、tool call 详情链路和更稳定的深链接/动作链接处理。
+- Channel 初始化现在会把 connected / disabled / error 状态写进启动日志，并兼容旧版 Lark 发布包缺失 `./mcp` export 的场景。
 - Web Chat 继续重构工具调用展示，改进 tool summary、diff/renderer 结构，并补上聊天消息与工具定位的深链接体验。
 - adapter runtime 进一步加强原生 skills 与 mock home 同步；Codex runtime 自动同步 workspace skills 并默认关闭启动更新检查，Claude adapter 提升 resume 容错并补上 Kimi CCR transformer 兼容。
 - 默认内置 Vibe Forge MCP 现在可直接启用，同时修复 managed runtime 插件解析、register runtime transpile 判断和任务侧 project skill 查询链路。


### PR DESCRIPTION
## Summary
- surface channel init success and failure in startup logs
- tolerate optional channel mcp exports that are missing from older published packages
- add regression tests for optional mcp loading and channel init logging
