### PR TITLE
fix: support lark session rebinding

### DIFF
--- a/apps/server/__tests__/channels/middleware/bind-session.spec.ts
+++ b/apps/server/__tests__/channels/middleware/bind-session.spec.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChannelContext } from '#~/channels/middleware/@types/index.js'
-import { bindSessionMiddleware } from '#~/channels/middleware/bind-session.js'
+import { bindChannelSession, bindSessionMiddleware } from '#~/channels/middleware/bind-session.js'
 import { createT, defineMessages } from '#~/channels/middleware/i18n.js'
-import { setBinding, setPendingUnack } from '#~/channels/state.js'
+import { deleteBinding, setBinding, setPendingUnack } from '#~/channels/state.js'
 import { getDb } from '#~/db/index.js'
 
 vi.mock('#~/db/index.js', () => ({
@@ -11,10 +11,14 @@ vi.mock('#~/db/index.js', () => ({
 }))
 
 vi.mock('#~/channels/state.js', () => ({
+  deleteBinding: vi.fn(),
   setBinding: vi.fn(),
   setPendingUnack: vi.fn()
 }))
 
+const deleteChannelSession = vi.fn()
+const getChannelSession = vi.fn()
+const getChannelSessionBySessionId = vi.fn()
 const upsertChannelSession = vi.fn()
 
 const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
@@ -55,7 +59,12 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(getDb).mockReturnValue({ upsertChannelSession } as any)
+  vi.mocked(getDb).mockReturnValue({
+    deleteChannelSession,
+    getChannelSession,
+    getChannelSessionBySessionId,
+    upsertChannelSession
+  } as any)
 })
 
 describe('bindSessionMiddleware', () => {
@@ -107,5 +116,43 @@ describe('bindSessionMiddleware', () => {
     const next = vi.fn().mockResolvedValue(undefined)
     await bindSessionMiddleware(makeCtx(), next)
     expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('clears the previous in-memory binding when the channel switches sessions', () => {
+    getChannelSession.mockReturnValue({ sessionId: 'sess-old' })
+
+    bindChannelSession({
+      channelType: 'lark',
+      sessionType: 'direct',
+      channelId: 'ch1',
+      channelKey: 'lark:default',
+      replyReceiveId: 'recv1',
+      replyReceiveIdType: 'chat_id',
+      sessionId: 'sess-new'
+    })
+
+    expect(deleteBinding).toHaveBeenCalledWith('sess-old')
+  })
+
+  it('transfers an existing session binding from another channel before rebinding', () => {
+    getChannelSessionBySessionId.mockReturnValue({
+      channelType: 'lark',
+      sessionType: 'group',
+      channelId: 'group-1',
+      channelKey: 'lark:ops',
+      sessionId: 'sess-abc'
+    })
+
+    bindChannelSession({
+      channelType: 'lark',
+      sessionType: 'direct',
+      channelId: 'ch1',
+      channelKey: 'lark:default',
+      replyReceiveId: 'recv1',
+      replyReceiveIdType: 'chat_id',
+      sessionId: 'sess-abc'
+    })
+
+    expect(deleteChannelSession).toHaveBeenCalledWith('lark', 'group', 'group-1')
   })
 })

--- a/apps/server/__tests__/channels/middleware/commands.spec.ts
+++ b/apps/server/__tests__/channels/middleware/commands.spec.ts
@@ -26,10 +26,15 @@ vi.mock('#~/services/session/index.js', () => ({
 }))
 
 const deleteChannelSessionBySessionId = vi.fn()
+const deleteChannelSession = vi.fn()
+const getChannelSession = vi.fn()
+const getChannelSessionBySessionId = vi.fn()
+const getSessions = vi.fn()
 const getSession = vi.fn()
 const updateSession = vi.fn()
 const updateSessionArchivedWithChildren = vi.fn()
 const upsertChannelPreference = vi.fn()
+const upsertChannelSession = vi.fn()
 
 const makeInbound = (overrides: Record<string, unknown> = {}) => ({
   channelType: 'lark',
@@ -60,6 +65,9 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => {
     reply: vi.fn().mockResolvedValue(undefined),
     pushFollowUps: vi.fn().mockResolvedValue(undefined),
     getBoundSession: vi.fn(),
+    searchSessions: vi.fn(),
+    bindSession: vi.fn(),
+    unbindSession: vi.fn(),
     resetSession: vi.fn(),
     stopSession: vi.fn(),
     restartSession: vi.fn().mockResolvedValue(undefined),
@@ -99,6 +107,92 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => {
   if (!overrides.getBoundSession) {
     ctx.getBoundSession = vi.fn(() => ctx.sessionId ? getSession(ctx.sessionId) : undefined)
   }
+  if (!overrides.searchSessions) {
+    ctx.searchSessions = vi.fn((query: string) => {
+      const normalized = query.trim().toLowerCase()
+      return getSessions()
+        .filter((session: any) => {
+          const haystack = [
+            session.id,
+            session.title,
+            session.lastMessage,
+            session.lastUserMessage,
+            session.model,
+            session.adapter,
+            ...(session.tags ?? [])
+          ]
+            .filter(Boolean)
+            .join('\n')
+            .toLowerCase()
+          return haystack.includes(normalized)
+        })
+        .map((session: any) => ({
+          session,
+          binding: getChannelSessionBySessionId(session.id)
+            ? {
+                channelType: getChannelSessionBySessionId(session.id).channelType,
+                sessionType: getChannelSessionBySessionId(session.id).sessionType,
+                channelId: getChannelSessionBySessionId(session.id).channelId,
+                channelKey: getChannelSessionBySessionId(session.id).channelKey
+              }
+            : undefined
+        }))
+    })
+  }
+  if (!overrides.bindSession) {
+    ctx.bindSession = vi.fn((sessionId: string) => {
+      const session = getSession(sessionId)
+      if (!session) {
+        return { alreadyBound: false }
+      }
+      const previous = getChannelSession(ctx.inbound.channelType, ctx.inbound.sessionType, ctx.inbound.channelId)
+      const transferred = getChannelSessionBySessionId(sessionId)
+      if (
+        transferred &&
+        (
+          transferred.channelType !== ctx.inbound.channelType ||
+          transferred.sessionType !== ctx.inbound.sessionType ||
+          transferred.channelId !== ctx.inbound.channelId
+        )
+      ) {
+        deleteChannelSession(transferred.channelType, transferred.sessionType, transferred.channelId)
+      }
+      upsertChannelSession({
+        channelType: ctx.inbound.channelType,
+        sessionType: ctx.inbound.sessionType,
+        channelId: ctx.inbound.channelId,
+        channelKey: ctx.channelKey,
+        replyReceiveId: ctx.inbound.replyTo?.receiveId,
+        replyReceiveIdType: ctx.inbound.replyTo?.receiveIdType,
+        sessionId
+      })
+      ctx.sessionId = sessionId
+      return {
+        alreadyBound: previous?.sessionId === sessionId,
+        session,
+        previousSessionId: previous?.sessionId !== sessionId ? previous?.sessionId : undefined,
+        transferredFrom: transferred == null
+          ? undefined
+          : {
+              channelType: transferred.channelType,
+              sessionType: transferred.sessionType,
+              channelId: transferred.channelId,
+              channelKey: transferred.channelKey
+            }
+      }
+    })
+  }
+  if (!overrides.unbindSession) {
+    ctx.unbindSession = vi.fn(() => {
+      const current = getChannelSession(ctx.inbound.channelType, ctx.inbound.sessionType, ctx.inbound.channelId)
+      if (!current?.sessionId) {
+        return { sessionId: undefined }
+      }
+      deleteChannelSession(ctx.inbound.channelType, ctx.inbound.sessionType, ctx.inbound.channelId)
+      ctx.sessionId = undefined
+      return { sessionId: current.sessionId }
+    })
+  }
   if (!overrides.resetSession) {
     ctx.resetSession = vi.fn(() => {
       if (ctx.sessionId) {
@@ -133,6 +227,8 @@ const makeCtx = (overrides: Partial<ChannelContext> = {}): ChannelContext => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  getChannelSession.mockReturnValue({ sessionId: 'sess-abc' })
+  getChannelSessionBySessionId.mockReturnValue(undefined)
   getSession.mockReturnValue({
     id: 'sess-abc',
     title: 'Session A',
@@ -144,12 +240,34 @@ beforeEach(() => {
     tags: ['tag-a'],
     isArchived: false,
     isStarred: true,
+    lastMessage: 'Investigate lark resume failure',
     createdAt: Date.now()
   })
+  getSessions.mockReturnValue([
+    getSession(),
+    {
+      id: 'sess-other',
+      title: 'Lark handoff window',
+      status: 'completed',
+      messageCount: 446,
+      model: 'gpt-responses,gpt-5.4-2026-03-05',
+      adapter: 'codex',
+      tags: ['channel:lark:group:oc_790b0dd9fff1f5e216ac15bfbc257556'],
+      isArchived: false,
+      isStarred: false,
+      lastMessage: 'Resume miniapp gear session after interruption',
+      createdAt: Date.now()
+    }
+  ])
   vi.mocked(getDb).mockReturnValue({
+    deleteChannelSession,
     deleteChannelSessionBySessionId,
+    getChannelSession,
+    getChannelSessionBySessionId,
     getSession,
+    getSessions,
     getChannelPreference: vi.fn().mockReturnValue(undefined),
+    upsertChannelSession,
     upsertChannelPreference,
     updateSession,
     updateSessionArchivedWithChildren
@@ -194,7 +312,7 @@ describe('/help command', () => {
     await channelCommandMiddleware(ctx, next)
 
     expect(ctx.reply).toHaveBeenCalledOnce()
-    expect(String(vi.mocked(ctx.reply).mock.calls[0][0])).toContain('第 1/2 页')
+    expect(String(vi.mocked(ctx.reply).mock.calls[0][0])).toContain('第 1/3 页')
     expect(ctx.pushFollowUps).toHaveBeenCalledWith({
       messageId: 'om-help-1',
       followUps: [{ content: '/help --page=2' }]
@@ -249,11 +367,11 @@ describe('/help command', () => {
 
     expect(ctx.reply).toHaveBeenCalledOnce()
     const message = String(vi.mocked(ctx.reply).mock.calls[0][0])
-    expect(message).toContain('第 2/2 页')
-    expect(message).toContain('/allow <field:sender|group|private|groupchat> <value>')
+    expect(message).toContain('第 2/3 页')
+    expect(message).toContain('/stop')
     expect(ctx.pushFollowUps).toHaveBeenCalledWith({
       messageId: undefined,
-      followUps: [{ content: '/help --page=1' }]
+      followUps: [{ content: '/help --page=1' }, { content: '/help --page=3' }]
     })
   })
 
@@ -278,6 +396,84 @@ describe('/session command', () => {
     expect(String(vi.mocked(ctx.reply).mock.calls[0][0])).toContain('Session A')
     expect(String(vi.mocked(ctx.reply).mock.calls[0][0])).toContain('gpt-test')
     expect(String(vi.mocked(ctx.reply).mock.calls[0][0])).toContain('上下文消息数：12')
+  })
+
+  it('/session search lists matching sessions with binding status', async () => {
+    getChannelSessionBySessionId.mockImplementation((sessionId: string) => (
+      sessionId === 'sess-other'
+        ? {
+            channelType: 'lark',
+            sessionType: 'group',
+            channelId: 'oc_790b0dd9fff1f5e216ac15bfbc257556',
+            channelKey: 'lark:miniapp-gear'
+          }
+        : {
+            channelType: 'lark',
+            sessionType: 'direct',
+            channelId: 'ch1',
+            channelKey: 'lark:default'
+          }
+    ))
+    const ctx = makeCtx({ commandText: '/session search miniapp gear', config: { type: 'lark' } as any })
+
+    await channelCommandMiddleware(ctx, vi.fn())
+
+    expect(ctx.reply).toHaveBeenCalledOnce()
+    const message = String(vi.mocked(ctx.reply).mock.calls[0][0])
+    expect(message).toContain('找到 1 个匹配会话')
+    expect(message).toContain('sess-other')
+    expect(message).toContain('已绑定 lark/group/oc_790b0dd9fff1f5e216ac15bfbc257556')
+  })
+
+  it('/session bind rebinds the current channel to an existing session', async () => {
+    getSession.mockImplementation((sessionId: string) => (
+      sessionId === 'sess-other'
+        ? {
+            id: 'sess-other',
+            title: 'Lark handoff window',
+            status: 'completed',
+            messageCount: 446,
+            model: 'gpt-responses,gpt-5.4-2026-03-05',
+            adapter: 'codex',
+            tags: [],
+            isArchived: false,
+            isStarred: false,
+            createdAt: Date.now()
+          }
+        : {
+            id: 'sess-abc',
+            title: 'Session A',
+            status: 'running',
+            messageCount: 12,
+            model: 'gpt-test',
+            adapter: 'codex',
+            tags: ['tag-a'],
+            isArchived: false,
+            isStarred: true,
+            createdAt: Date.now()
+          }
+    ))
+    const ctx = makeCtx({ commandText: '/session bind sess-other', config: { type: 'lark' } as any })
+
+    await channelCommandMiddleware(ctx, vi.fn())
+
+    expect(upsertChannelSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'sess-other'
+    }))
+    expect(ctx.reply).toHaveBeenCalledOnce()
+    const message = String(vi.mocked(ctx.reply).mock.calls[0][0])
+    expect(message).toContain('已将当前频道绑定到会话 sess-other')
+    expect(message).toContain('当前频道原先绑定的会话 sess-abc 已解除绑定')
+  })
+
+  it('/session unbind detaches the current channel without archiving the session', async () => {
+    const ctx = makeCtx({ commandText: '/session unbind', config: { type: 'lark' } as any })
+
+    await channelCommandMiddleware(ctx, vi.fn())
+
+    expect(deleteChannelSession).toHaveBeenCalledWith('lark', 'direct', 'ch1')
+    expect(updateSessionArchivedWithChildren).not.toHaveBeenCalled()
+    expect(ctx.reply).toHaveBeenCalledWith('已解除当前频道与会话 sess-abc 的绑定，会话内容已保留。')
   })
 })
 

--- a/apps/server/__tests__/channels/middleware/resolve-session.spec.ts
+++ b/apps/server/__tests__/channels/middleware/resolve-session.spec.ts
@@ -3,10 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChannelContext } from '#~/channels/middleware/@types/index.js'
 import { createT, defineMessages } from '#~/channels/middleware/i18n.js'
 import { resolveSessionMiddleware } from '#~/channels/middleware/resolve-session.js'
+import { setBinding } from '#~/channels/state.js'
 import { getDb } from '#~/db/index.js'
 
 vi.mock('#~/db/index.js', () => ({
   getDb: vi.fn()
+}))
+
+vi.mock('#~/channels/state.js', () => ({
+  setBinding: vi.fn()
 }))
 
 const makeCtx = (): ChannelContext => ({
@@ -42,7 +47,15 @@ beforeEach(() => vi.clearAllMocks())
 describe('resolveSessionMiddleware', () => {
   it('sets ctx.sessionId when the DB finds a matching session', async () => {
     vi.mocked(getDb).mockReturnValue({
-      getChannelSession: vi.fn().mockReturnValue({ sessionId: 'sess-abc' }),
+      getChannelSession: vi.fn().mockReturnValue({
+        channelType: 'lark',
+        sessionType: 'direct',
+        channelId: 'ch1',
+        channelKey: 'lark:default',
+        replyReceiveId: 'recv1',
+        replyReceiveIdType: 'chat_id',
+        sessionId: 'sess-abc'
+      }),
       getChannelPreference: vi.fn().mockReturnValue(undefined)
     } as any)
     const ctx = makeCtx()
@@ -51,6 +64,14 @@ describe('resolveSessionMiddleware', () => {
     await resolveSessionMiddleware(ctx, next)
 
     expect(ctx.sessionId).toBe('sess-abc')
+    expect(setBinding).toHaveBeenCalledWith('sess-abc', {
+      channelType: 'lark',
+      channelKey: 'lark:default',
+      channelId: 'ch1',
+      sessionType: 'direct',
+      replyReceiveId: 'recv1',
+      replyReceiveIdType: 'chat_id'
+    })
     expect(next).toHaveBeenCalledOnce()
   })
 

--- a/apps/server/__tests__/services/session-start.spec.ts
+++ b/apps/server/__tests__/services/session-start.spec.ts
@@ -562,6 +562,72 @@ describe('startAdapterSession', () => {
     expect(currentSession.status).toBe('failed')
   })
 
+  it('preserves the full model selector after adapter init reports a bare model id', async () => {
+    let onEvent: ((event: any) => void) | undefined
+
+    mocks.run
+      .mockImplementationOnce(async (_options: unknown, adapterOptions: any) => {
+        onEvent = adapterOptions.onEvent
+        return {
+          session: {
+            emit: vi.fn(),
+            kill: vi.fn()
+          }
+        }
+      })
+      .mockImplementationOnce(async (_options: unknown, adapterOptions: any) => {
+        expect(adapterOptions.type).toBe('resume')
+        expect(adapterOptions.model).toBe('gpt-responses,gpt-5.4-2026-03-05')
+        return {
+          session: {
+            emit: vi.fn(),
+            kill: vi.fn()
+          }
+        }
+      })
+
+    await startAdapterSession('sess-1', {
+      model: 'gpt-responses,gpt-5.4-2026-03-05',
+      adapter: 'codex',
+      permissionMode: 'default'
+    })
+
+    onEvent?.({
+      type: 'init',
+      data: {
+        uuid: 'sess-1',
+        model: 'gpt-5.4-2026-03-05',
+        adapter: 'codex',
+        version: 'unknown',
+        tools: [],
+        slashCommands: [],
+        cwd: process.cwd(),
+        agents: []
+      }
+    })
+
+    expect(currentSession.model).toBe('gpt-responses,gpt-5.4-2026-03-05')
+
+    currentSession = {
+      ...currentSession,
+      status: 'completed'
+    }
+    adapterSessionStore.clear()
+    getMessages.mockReturnValue([
+      {
+        type: 'message',
+        message: {
+          id: 'assist-1',
+          role: 'assistant',
+          content: 'previous answer',
+          createdAt: Date.now()
+        }
+      }
+    ])
+
+    await startAdapterSession('sess-1')
+  })
+
   it('restarts the adapter on demand when a follow-up user message arrives after completion', async () => {
     const emit = vi.fn()
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/apps/server/src/channels/handlers.ts
+++ b/apps/server/src/channels/handlers.ts
@@ -8,6 +8,7 @@ import { notifySessionUpdated } from '#~/services/session/runtime.js'
 import { getSessionLogger } from '#~/utils/logger.js'
 
 import { buildInteractionText } from './interaction'
+import { bindChannelSession } from './middleware/bind-session'
 import { pipeline } from './middleware'
 import type { ChannelContext, ChannelTextMessage } from './middleware/@types'
 import { defineMessages } from './middleware/i18n'
@@ -23,6 +24,26 @@ import {
 } from './state'
 import { buildToolCallSummaryText, extractToolCallSummary, mergeToolCallSummaries } from './tool-call-summary'
 import type { ChannelRuntimeState } from './types'
+
+const normalizeSearchText = (value: string | undefined) => value?.trim().toLowerCase() ?? ''
+
+const matchesSessionSearch = (session: ReturnType<ReturnType<typeof getDb>['getSession']>, query: string) => {
+  const normalizedQuery = normalizeSearchText(query)
+  if (normalizedQuery === '') return true
+  const haystack = [
+    session?.id,
+    session?.title,
+    session?.lastMessage,
+    session?.lastUserMessage,
+    session?.model,
+    session?.adapter,
+    ...(session?.tags ?? [])
+  ]
+    .map(value => normalizeSearchText(value))
+    .filter(Boolean)
+    .join('\n')
+  return haystack.includes(normalizedQuery)
+}
 
 export const handleInboundEvent = async (
   channelKey: string,
@@ -58,6 +79,68 @@ export const handleInboundEvent = async (
     getBoundSession: () => {
       if (!ctx.sessionId) return undefined
       return getDb().getSession(ctx.sessionId)
+    },
+    searchSessions: (query) => {
+      const db = getDb()
+      const sessions = db.getSessions('all')
+        .filter(session => matchesSessionSearch(session, query))
+      return sessions.map(session => {
+        const binding = db.getChannelSessionBySessionId(session.id)
+        return {
+          session,
+          binding: binding == null
+            ? undefined
+            : {
+                channelType: binding.channelType,
+                sessionType: binding.sessionType,
+                channelId: binding.channelId,
+                channelKey: binding.channelKey
+              }
+        }
+      })
+    },
+    bindSession: (sessionId) => {
+      const db = getDb()
+      const session = db.getSession(sessionId)
+      if (session == null) {
+        return { alreadyBound: false }
+      }
+      const bindingResult = bindChannelSession({
+        channelType: inbound.channelType,
+        sessionType: inbound.sessionType,
+        channelId: inbound.channelId,
+        channelKey,
+        replyReceiveId: inbound.replyTo?.receiveId,
+        replyReceiveIdType: inbound.replyTo?.receiveIdType,
+        sessionId
+      })
+      if (bindingResult.previousSessionId != null && bindingResult.previousSessionId !== sessionId) {
+        deleteBinding(bindingResult.previousSessionId)
+      }
+      ctx.sessionId = sessionId
+      return {
+        alreadyBound: bindingResult.alreadyBound,
+        session,
+        previousSessionId: bindingResult.previousSessionId,
+        transferredFrom: bindingResult.transferredFrom == null
+          ? undefined
+          : {
+              channelType: bindingResult.transferredFrom.channelType,
+              sessionType: bindingResult.transferredFrom.sessionType,
+              channelId: bindingResult.transferredFrom.channelId,
+              channelKey: bindingResult.transferredFrom.channelKey
+            }
+      }
+    },
+    unbindSession: () => {
+      const currentBinding = getDb().getChannelSession(inbound.channelType, inbound.sessionType, inbound.channelId)
+      const sessionId = currentBinding?.sessionId ?? ctx.sessionId
+      getDb().deleteChannelSession(inbound.channelType, inbound.sessionType, inbound.channelId)
+      if (sessionId) {
+        deleteBinding(sessionId)
+      }
+      ctx.sessionId = undefined
+      return { sessionId }
     },
     resetSession: () => {
       const { sessionId } = ctx

--- a/apps/server/src/channels/middleware/@types/index.ts
+++ b/apps/server/src/channels/middleware/@types/index.ts
@@ -9,6 +9,29 @@ import type {
 
 import type { LanguageCode, MessageArgs, MessageCatalog } from '../i18n'
 
+export interface ChannelSessionBindingInfo {
+  channelType: string
+  sessionType: string
+  channelId: string
+  channelKey: string
+}
+
+export interface ChannelSessionSearchResult {
+  session: Session
+  binding?: ChannelSessionBindingInfo
+}
+
+export interface ChannelBindSessionResult {
+  alreadyBound: boolean
+  session?: Session
+  previousSessionId?: string
+  transferredFrom?: ChannelSessionBindingInfo
+}
+
+export interface ChannelUnbindSessionResult {
+  sessionId?: string
+}
+
 export interface ChannelTextMessage {
   receiveId: string
   receiveIdType: string
@@ -61,6 +84,12 @@ export interface ChannelContext {
   // ── session operations ──
   /** Get the session bound to the current channel, or undefined */
   getBoundSession: () => Session | undefined
+  /** Search sessions that can be rebound into the current channel */
+  searchSessions: (query: string) => ChannelSessionSearchResult[]
+  /** Bind the current channel to an existing session */
+  bindSession: (sessionId: string) => ChannelBindSessionResult
+  /** Unbind the current channel from the current session without archiving it */
+  unbindSession: () => ChannelUnbindSessionResult
   /** Archive and unbind the current session */
   resetSession: () => void
   /** Stop the running session (kill the process) */

--- a/apps/server/src/channels/middleware/bind-session.ts
+++ b/apps/server/src/channels/middleware/bind-session.ts
@@ -2,8 +2,87 @@ import type { ChannelInboundEvent } from '@vibe-forge/core/channel'
 
 import { getDb } from '#~/db/index.js'
 
-import { setBinding, setPendingUnack } from '../state'
+import { deleteBinding, setBinding, setPendingUnack } from '../state'
 import type { ChannelMiddleware } from './@types'
+
+const isSameChannel = (
+  row: {
+    channelType: string
+    sessionType: string
+    channelId: string
+  },
+  input: {
+    channelType: string
+    sessionType: string
+    channelId: string
+  }
+) => (
+  row.channelType === input.channelType &&
+  row.sessionType === input.sessionType &&
+  row.channelId === input.channelId
+)
+
+export const bindChannelSession = (input: {
+  channelType: string
+  sessionType: string
+  channelId: string
+  channelKey: string
+  replyReceiveId?: string
+  replyReceiveIdType?: string
+  unack?: () => Promise<void>
+  sessionId: string
+}) => {
+  const {
+    channelType,
+    sessionType,
+    channelId,
+    channelKey,
+    replyReceiveId,
+    replyReceiveIdType,
+    unack,
+    sessionId
+  } = input
+  const db = getDb()
+  const previousChannelBinding = db.getChannelSession(channelType, sessionType, channelId)
+  const transferredBinding = db.getChannelSessionBySessionId(sessionId)
+
+  if (previousChannelBinding?.sessionId != null && previousChannelBinding.sessionId !== sessionId) {
+    deleteBinding(previousChannelBinding.sessionId)
+  }
+
+  if (transferredBinding != null && !isSameChannel(transferredBinding, { channelType, sessionType, channelId })) {
+    db.deleteChannelSession(transferredBinding.channelType, transferredBinding.sessionType, transferredBinding.channelId)
+  }
+
+  setPendingUnack(sessionId, unack)
+  db.upsertChannelSession({
+    channelType,
+    sessionType,
+    channelId,
+    channelKey,
+    replyReceiveId,
+    replyReceiveIdType,
+    sessionId
+  })
+  setBinding(sessionId, {
+    channelType,
+    channelKey,
+    channelId,
+    sessionType,
+    replyReceiveId,
+    replyReceiveIdType
+  })
+
+  return {
+    alreadyBound: previousChannelBinding?.sessionId === sessionId,
+    previousSessionId: previousChannelBinding?.sessionId !== sessionId
+      ? previousChannelBinding?.sessionId
+      : undefined,
+    transferredFrom: transferredBinding != null && !isSameChannel(transferredBinding, { channelType, sessionType, channelId })
+      ? transferredBinding
+      : undefined
+  }
+}
 
 export const syncChannelSessionBinding = (input: {
   channelKey: string
@@ -11,24 +90,15 @@ export const syncChannelSessionBinding = (input: {
   sessionId: string
 }) => {
   const { channelKey, inbound, sessionId } = input
-  const db = getDb()
-  setPendingUnack(sessionId, inbound.unack)
-  db.upsertChannelSession({
+  return bindChannelSession({
     channelType: inbound.channelType,
     sessionType: inbound.sessionType,
     channelId: inbound.channelId,
     channelKey,
     replyReceiveId: inbound.replyTo?.receiveId,
     replyReceiveIdType: inbound.replyTo?.receiveIdType,
+    unack: inbound.unack,
     sessionId
-  })
-  setBinding(sessionId, {
-    channelType: inbound.channelType,
-    channelKey,
-    channelId: inbound.channelId,
-    sessionType: inbound.sessionType,
-    replyReceiveId: inbound.replyTo?.receiveId,
-    replyReceiveIdType: inbound.replyTo?.receiveIdType
   })
 }
 

--- a/apps/server/src/channels/middleware/commands/AGENTS.md
+++ b/apps/server/src/channels/middleware/commands/AGENTS.md
@@ -9,7 +9,7 @@ commands/
   index.ts            ← 中间件入口，组装所有指令并分发（含权限拦截）
   command-system.ts   ← 指令类型系统、chain builder、解析器
   cmd.general.ts      ← 通用指令：help / whoami / lang（含 help 格式化）
-  cmd.session.ts      ← 会话指令：session / reset / stop / get / set / permissionMode
+  cmd.session.ts      ← 会话指令：session / search / bind / unbind / reset / stop / get / set / permissionMode
   cmd.access.ts       ← 权限指令：access / admins / admin / allow / block
   access.ts           ← 权限检查 & 频道配置写入工具
   i18n.ts             ← 国际化注册 API（defineMessages / t / createT）、LanguageCode 类型、系统级共享翻译

--- a/apps/server/src/channels/middleware/commands/cmd.session.ts
+++ b/apps/server/src/channels/middleware/commands/cmd.session.ts
@@ -7,6 +7,9 @@ import { command, requiredArg, restArg } from './command-system'
 
 defineMessages('zh', {
   'cmd.session.description': '查看当前会话状态',
+  'cmd.session.search.description': '搜索系统内的会话，方便重新绑定到当前频道',
+  'cmd.session.bind.description': '将当前频道绑定到指定会话',
+  'cmd.session.unbind.description': '解绑当前频道与会话，但保留会话本身',
   'cmd.reset.description': '归档并解绑当前会话',
   'cmd.stop.description': '停止当前运行中的会话',
   'cmd.permissionMode.description': '设置当前会话权限模式，或在无会话时设置下一次会话的权限模式',
@@ -57,6 +60,24 @@ defineMessages('zh', {
   'session.starred': ({ starred }) => `星标：${starred}`,
   'session.archived': ({ archived }) => `归档：${archived}`,
   'session.tags': ({ tags }) => `标签：${tags}`,
+  'session.search.noResults': ({ query }) => `未找到匹配“${query}”的会话。`,
+  'session.search.header': ({ count, query }) => `找到 ${count} 个匹配会话（关键词：${query}）：`,
+  'session.search.more': ({ remaining }) => `其余 ${remaining} 个结果未展示，请缩小关键词继续搜索。`,
+  'session.search.binding.current': '当前频道',
+  'session.search.binding.unbound': '未绑定',
+  'session.search.binding.other': ({ channelType, sessionType, channelId }) =>
+    `已绑定 ${channelType}/${sessionType}/${channelId}`,
+  'session.search.item': ({ index, id, title, status, count, model, binding }) =>
+    `${index}. ${id} | ${title} | ${status} | 消息 ${count} | ${model} | ${binding}`,
+  'bind.notFound': ({ id }) => `未找到会话 ${id}。`,
+  'bind.alreadyBound': ({ id, title }) => `当前频道已绑定到会话 ${id}（${title}），已刷新绑定信息。`,
+  'bind.success': ({ id, title }) => `已将当前频道绑定到会话 ${id}（${title}）。`,
+  'bind.replaced': ({ previousId }) => `当前频道原先绑定的会话 ${previousId} 已解除绑定。`,
+  'bind.transferred': ({ channelType, sessionType, channelId }) =>
+    `目标会话原先绑定于 ${channelType}/${sessionType}/${channelId}，已转移到当前频道。`,
+  'bind.followUp': '之后在当前频道发送消息会继续该会话。',
+  'unbind.noSession': '当前频道没有已绑定会话。',
+  'unbind.success': ({ id }) => `已解除当前频道与会话 ${id} 的绑定，会话内容已保留。`,
   'reset.success': '已归档并解绑当前会话，可以继续对话创建新会话。',
   'stop.noSession': '当前频道没有可停止的会话。',
   'stop.notRunning': ({ status }) => `当前会话状态为 ${status}，无需停止。`,
@@ -74,6 +95,9 @@ defineMessages('zh', {
 
 defineMessages('en', {
   'cmd.session.description': 'Show current session status',
+  'cmd.session.search.description': 'Search internal sessions so they can be rebound into this channel',
+  'cmd.session.bind.description': 'Bind this channel to an existing session',
+  'cmd.session.unbind.description': 'Unbind this channel from its session without archiving the session',
   'cmd.reset.description': 'Archive and unbind current session',
   'cmd.stop.description': 'Stop the current running session',
   'cmd.permissionMode.description':
@@ -127,6 +151,24 @@ defineMessages('en', {
   'session.starred': ({ starred }) => `Starred: ${starred}`,
   'session.archived': ({ archived }) => `Archived: ${archived}`,
   'session.tags': ({ tags }) => `Tags: ${tags}`,
+  'session.search.noResults': ({ query }) => `No sessions matched “${query}”.`,
+  'session.search.header': ({ count, query }) => `Found ${count} matching sessions (query: ${query}):`,
+  'session.search.more': ({ remaining }) => `${remaining} more results were omitted. Narrow the query and search again.`,
+  'session.search.binding.current': 'current channel',
+  'session.search.binding.unbound': 'unbound',
+  'session.search.binding.other': ({ channelType, sessionType, channelId }) =>
+    `bound to ${channelType}/${sessionType}/${channelId}`,
+  'session.search.item': ({ index, id, title, status, count, model, binding }) =>
+    `${index}. ${id} | ${title} | ${status} | ${count} msgs | ${model} | ${binding}`,
+  'bind.notFound': ({ id }) => `Session ${id} was not found.`,
+  'bind.alreadyBound': ({ id, title }) => `This channel is already bound to session ${id} (${title}). Binding refreshed.`,
+  'bind.success': ({ id, title }) => `This channel is now bound to session ${id} (${title}).`,
+  'bind.replaced': ({ previousId }) => `The previously bound session ${previousId} has been detached from this channel.`,
+  'bind.transferred': ({ channelType, sessionType, channelId }) =>
+    `The target session was previously bound to ${channelType}/${sessionType}/${channelId} and has been moved here.`,
+  'bind.followUp': 'Send the next message in this channel to continue that session.',
+  'unbind.noSession': 'No session is currently bound to this channel.',
+  'unbind.success': ({ id }) => `This channel has been detached from session ${id}. The session itself was kept.`,
   'reset.success': 'Session archived and unbound. You can continue chatting to create a new session.',
   'stop.noSession': 'No active session to stop.',
   'stop.notRunning': ({ status }) => `Session status is ${status}, no need to stop.`,
@@ -146,6 +188,8 @@ defineMessages('en', {
 
 const formatList = (ctx: ChannelContext, items: string[] | undefined) =>
   items != null && items.length > 0 ? items.join('、') : ctx.t('label.none')
+
+const SESSION_SEARCH_LIMIT = 8
 
 const PERMISSION_MODE_CHOICES = [
   {
@@ -286,10 +330,112 @@ const formatSessionSummary = (ctx: ChannelContext) => {
   ].join('\n')
 }
 
+const formatSearchBinding = (
+  ctx: ChannelContext,
+  binding: ReturnType<ChannelContext['searchSessions']>[number]['binding']
+) => {
+  if (binding == null) {
+    return ctx.t('session.search.binding.unbound')
+  }
+
+  if (
+    binding.channelType === ctx.inbound.channelType &&
+    binding.sessionType === ctx.inbound.sessionType &&
+    binding.channelId === ctx.inbound.channelId
+  ) {
+    return ctx.t('session.search.binding.current')
+  }
+
+  return ctx.t('session.search.binding.other', {
+    channelType: binding.channelType,
+    sessionType: binding.sessionType,
+    channelId: binding.channelId
+  })
+}
+
 export const sessionCommands = () => [
   command<ChannelContext>('session')
     .alias('status')
     .description('cmd.session.description')
+    .subcommand(
+      command<ChannelContext>('search')
+        .alias('find')
+        .description('cmd.session.search.description')
+        .adminOnly()
+        .argument(restArg('query'))
+        .action(async ({ ctx, args: [query] }) => {
+          const results = ctx.searchSessions(query as string)
+          if (results.length === 0) {
+            await ctx.reply(ctx.t('session.search.noResults', { query }))
+            return
+          }
+
+          const displayed = results.slice(0, SESSION_SEARCH_LIMIT)
+          const lines = [
+            ctx.t('session.search.header', { count: results.length, query }),
+            ...displayed.map((result, index) => ctx.t('session.search.item', {
+              index: index + 1,
+              id: result.session.id,
+              title: result.session.title ?? ctx.t('label.unnamed'),
+              status: result.session.status ?? 'unknown',
+              count: result.session.messageCount ?? 0,
+              model: result.session.model ?? ctx.t('label.notSet'),
+              binding: formatSearchBinding(ctx, result.binding)
+            }))
+          ]
+          if (results.length > displayed.length) {
+            lines.push(ctx.t('session.search.more', { remaining: results.length - displayed.length }))
+          }
+          await ctx.reply(lines.join('\n'))
+        })
+    )
+    .subcommand(
+      command<ChannelContext>('bind')
+        .alias('attach')
+        .description('cmd.session.bind.description')
+        .adminOnly()
+        .argument(requiredArg('sessionId'))
+        .action(async ({ ctx, args: [sessionId] }) => {
+          const result = ctx.bindSession(sessionId as string)
+          if (result.session == null) {
+            await ctx.reply(ctx.t('bind.notFound', { id: sessionId }))
+            return
+          }
+
+          const lines = [
+            ctx.t(result.alreadyBound ? 'bind.alreadyBound' : 'bind.success', {
+              id: result.session.id,
+              title: result.session.title ?? ctx.t('label.unnamed')
+            })
+          ]
+          if (result.previousSessionId != null) {
+            lines.push(ctx.t('bind.replaced', { previousId: result.previousSessionId }))
+          }
+          if (result.transferredFrom != null) {
+            lines.push(ctx.t('bind.transferred', {
+              channelType: result.transferredFrom.channelType,
+              sessionType: result.transferredFrom.sessionType,
+              channelId: result.transferredFrom.channelId
+            }))
+          }
+          lines.push(ctx.t('bind.followUp'))
+          await ctx.reply(lines.join('\n'))
+        })
+    )
+    .subcommand(
+      command<ChannelContext>('unbind')
+        .alias('detach')
+        .description('cmd.session.unbind.description')
+        .adminOnly()
+        .action(async ({ ctx }) => {
+          const result = ctx.unbindSession()
+          if (result.sessionId == null) {
+            await ctx.reply(ctx.t('unbind.noSession'))
+            return
+          }
+          await ctx.reply(ctx.t('unbind.success', { id: result.sessionId }))
+        })
+    )
     .action(async ({ ctx }) => {
       await ctx.reply(formatSessionSummary(ctx))
     }),

--- a/apps/server/src/channels/middleware/resolve-session.ts
+++ b/apps/server/src/channels/middleware/resolve-session.ts
@@ -1,5 +1,6 @@
 import { getDb } from '#~/db/index.js'
 
+import { setBinding } from '../state'
 import type { ChannelMiddleware } from './@types'
 
 export const resolveSessionMiddleware: ChannelMiddleware = async (ctx, next) => {
@@ -10,5 +11,15 @@ export const resolveSessionMiddleware: ChannelMiddleware = async (ctx, next) => 
   ctx.channelAdapter = preference?.adapter
   ctx.channelPermissionMode = preference?.permissionMode
   ctx.channelEffort = preference?.effort
+  if (result?.sessionId) {
+    setBinding(result.sessionId, {
+      channelType: result.channelType,
+      channelKey: result.channelKey,
+      channelId: result.channelId,
+      sessionType: result.sessionType,
+      replyReceiveId: result.replyReceiveId,
+      replyReceiveIdType: result.replyReceiveIdType
+    })
+  }
   await next()
 }

--- a/apps/server/src/db/channelSessions/repo.ts
+++ b/apps/server/src/db/channelSessions/repo.ts
@@ -84,6 +84,14 @@ export function createChannelSessionsRepo(db: SqliteDatabase) {
     return stmt.run(sessionId).changes
   }
 
+  const remove = (channelType: string, sessionType: string, channelId: string) => {
+    const stmt = db.prepare(`
+      DELETE FROM channel_sessions
+      WHERE channelType = ? AND sessionType = ? AND channelId = ?
+    `)
+    return stmt.run(channelType, sessionType, channelId).changes
+  }
+
   const getPreference = (
     channelType: string,
     sessionType: string,
@@ -128,6 +136,7 @@ export function createChannelSessionsRepo(db: SqliteDatabase) {
     get,
     getPreference,
     getBySessionId,
+    remove,
     removeBySessionId,
     upsert,
     upsertPreference

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -120,6 +120,10 @@ export class SqliteDb {
     return this.channelSessions.removeBySessionId(sessionId)
   }
 
+  deleteChannelSession(channelType: string, sessionType: string, channelId: string) {
+    return this.channelSessions.remove(channelType, sessionType, channelId)
+  }
+
   consumeChannelActionTokenNonce(nonce: string, action: string, expiresAt: number, consumedAt = Date.now()) {
     return this.channelActionTokens.consume({
       nonce,

--- a/apps/server/src/services/session/index.ts
+++ b/apps/server/src/services/session/index.ts
@@ -338,7 +338,18 @@ export async function startAdapterSession(
       deleteAdapterSessionRuntime(sessionId)
     }
 
-    serverLogger.info({ sessionId, type }, '[server] Starting new adapter process')
+    serverLogger.info({
+      sessionId,
+      type,
+      requestedModel: options.model,
+      persistedModel: existing?.model,
+      resolvedModel,
+      requestedAdapter: options.adapter,
+      persistedAdapter: existing?.adapter,
+      resolvedAdapter,
+      resolvedEffort,
+      resolvedPermissionMode
+    }, '[server] Starting new adapter process')
 
     if (existing == null) {
       serverLogger.info({ sessionId }, '[server] Session not found in DB, creating new entry')
@@ -454,13 +465,28 @@ export async function startAdapterSession(
           switch (event.type) {
             case 'init':
               if ('model' in (event.data as any)) {
+                const reportedModel = typeof (event.data as any).model === 'string'
+                  ? (event.data as any).model
+                  : undefined
+                const reportedAdapter = typeof (event.data as any).adapter === 'string'
+                  ? (event.data as any).adapter
+                  : undefined
+                const persistedModel = resolvedModel ?? reportedModel
+                const persistedAdapter = resolvedAdapter ?? reportedAdapter
+                serverLogger.info({
+                  sessionId,
+                  requestedModel: options.model,
+                  resolvedModel,
+                  reportedModel,
+                  persistedModel,
+                  requestedAdapter: options.adapter,
+                  resolvedAdapter,
+                  reportedAdapter,
+                  persistedAdapter
+                }, '[server] Adapter init received')
                 updateAndNotifySession(sessionId, {
-                  model: typeof (event.data as any).model === 'string'
-                    ? (event.data as any).model
-                    : resolvedModel,
-                  adapter: typeof (event.data as any).adapter === 'string'
-                    ? (event.data as any).adapter
-                    : resolvedAdapter,
+                  model: persistedModel,
+                  adapter: persistedAdapter,
                   effort: resolvedEffort,
                   permissionMode: resolvedPermissionMode
                 })

--- a/changelog/0.11.1/server.md
+++ b/changelog/0.11.1/server.md
@@ -1,0 +1,19 @@
+# @vibe-forge/server 0.11.1
+
+发布日期：2026-04-13
+
+## 发布范围
+
+- 发布 `@vibe-forge/server@0.11.1`
+
+## 主要变更
+
+- 新增 Lark 会话管理指令：`/session search`、`/session bind`、`/session unbind`，支持在当前窗口搜索、绑定和解除系统内已有会话，便于接力开发和上下文调整。
+- Channel 与系统会话的绑定关系现在支持跨窗口转移，并会在服务重启后从数据库自动恢复，避免重启后绑定关系丢失。
+- 会话启动日志补充 `requestedModel`、`persistedModel`、`resolvedModel` 等模型解析信息，便于排查 resume 过程中 provider 漂移和 channel 初始化问题。
+- Codex adapter 上报裸模型名时，不再覆盖服务端已解析出的完整模型选择器，避免 resume 后把 `gpt-responses,...` 错写成不带 provider 的模型串。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，现有 channel 与 session 数据结构可直接复用。
+- 新增 `/session` 指令仅对管理员开放，不改变普通消息流转行为。

--- a/changelog/0.11.1/task.md
+++ b/changelog/0.11.1/task.md
@@ -1,0 +1,17 @@
+# @vibe-forge/task 0.11.1
+
+发布日期：2026-04-13
+
+## 发布范围
+
+- 发布 `@vibe-forge/task@0.11.1`
+
+## 主要变更
+
+- 当显式指定裸模型名且多个 model service 存在同名模型时，优先使用 `defaultModelService` 解析目标 provider。
+- 修正 resume 场景下模型 service 选择漂移到非预期 provider 的问题，避免会话恢复后误落到 `gpt` 等默认顺序更靠前的 service。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不引入新的配置字段。
+- 若消费方此前依赖“同名模型按配置声明顺序命中”的隐式行为，升级后会优先遵循 `defaultModelService`。

--- a/packages/task/__tests__/query-selection.spec.ts
+++ b/packages/task/__tests__/query-selection.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveQuerySelection } from '#~/query-selection.js'
+
+describe('resolveQuerySelection', () => {
+  it('prefers defaultModelService when an explicit bare model matches multiple services', () => {
+    const selection = resolveQuerySelection({
+      config: {
+        adapters: {
+          codex: {},
+          'claude-code': {}
+        },
+        modelServices: {
+          gpt: {
+            apiBaseUrl: 'https://search.example.com/gpt',
+            apiKey: 'token-gpt',
+            models: ['gpt-5.4-2026-03-05']
+          },
+          'gpt-responses': {
+            apiBaseUrl: 'https://responses.example.com',
+            apiKey: 'token-responses',
+            models: ['gpt-5.4-2026-03-05']
+          }
+        },
+        defaultModelService: 'gpt-responses'
+      } as any,
+      userConfig: undefined,
+      inputModel: 'gpt-5.4-2026-03-05'
+    })
+
+    expect(selection.model).toBe('gpt-responses,gpt-5.4-2026-03-05')
+  })
+})

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/task",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Task runtime for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/task/src/query-selection.ts
+++ b/packages/task/src/query-selection.ts
@@ -34,10 +34,17 @@ export const resolveQuerySelection = (params: {
   }
   const availableAdapters = Object.keys(mergedAdapters ?? {})
   const serviceModels = listServiceModels(mergedModelServices)
+  const mergedDefaultModelService = pickFirstNonEmptyString(
+    [
+      params.userConfig?.defaultModelService,
+      params.config?.defaultModelService
+    ]
+  )
   const explicitAdapter = normalizeNonEmptyString(params.inputAdapter)
   const explicitModel = resolveModelSelection({
     value: params.inputModel,
     serviceModels,
+    preferredServiceKey: mergedDefaultModelService,
     preserveUnknown: true
   })
   const mergedDefaultAdapter = pickFirstNonEmptyString(
@@ -50,12 +57,6 @@ export const resolveQuerySelection = (params: {
     [
       params.userConfig?.defaultModel,
       params.config?.defaultModel
-    ]
-  )
-  const mergedDefaultModelService = pickFirstNonEmptyString(
-    [
-      params.userConfig?.defaultModelService,
-      params.config?.defaultModelService
     ]
   )
   const resolvedDefaultModel = resolveDefaultModelSelection({


### PR DESCRIPTION
## Summary
- add Lark session search/bind/unbind commands for handoff workflows
- persist and rehydrate channel-session bindings across rebinding and restart
- preserve full model selectors on resume and prefer defaultModelService for bare models
- release @vibe-forge/server and @vibe-forge/task 0.11.1

## Validation
- pnpm exec vitest run apps/server/__tests__/channels/middleware/bind-session.spec.ts apps/server/__tests__/channels/middleware/resolve-session.spec.ts apps/server/__tests__/channels/middleware/commands.spec.ts apps/server/__tests__/services/session-start.spec.ts packages/task/__tests__/query-selection.spec.ts
- pnpm exec eslint apps/server/src/channels/handlers.ts apps/server/src/channels/middleware/@types/index.ts apps/server/src/channels/middleware/bind-session.ts apps/server/src/channels/middleware/resolve-session.ts apps/server/src/channels/middleware/commands/cmd.session.ts apps/server/src/db/channelSessions/repo.ts apps/server/src/db/index.ts apps/server/__tests__/channels/middleware/bind-session.spec.ts apps/server/__tests__/channels/middleware/resolve-session.spec.ts apps/server/__tests__/channels/middleware/commands.spec.ts apps/server/src/services/session/index.ts apps/server/__tests__/services/session-start.spec.ts packages/task/src/query-selection.ts packages/task/__tests__/query-selection.spec.ts
- npm pack --dry-run (apps/server, packages/task)