### PR TITLE
docs: add native plugin marketplace usage guide

### DIFF
--- a/.ai/rules/USAGE.md
+++ b/.ai/rules/USAGE.md
@@ -14,6 +14,7 @@ description: 仅在处理项目接入、安装、运行 Vibe Forge 服务、CLI 
 - [Web UI 与 Terminal 视图](./usage/web.md)
 - [CLI 与示例](./usage/cli.md)
 - [插件与数据资产](./usage/plugins.md)
+- [Adapter 原生插件与 Marketplace](./usage/native-plugins.md)
 
 ## 接入目标
 

--- a/.ai/rules/usage/native-plugins.md
+++ b/.ai/rules/usage/native-plugins.md
@@ -1,0 +1,177 @@
+# Adapter 原生插件与 Marketplace
+
+返回入口：[USAGE.md](../USAGE.md)
+
+## 适用场景
+
+这页讲的是 adapter 自己的原生插件格式，不是顶层 `plugins` 配置里的统一 Vibe Forge 插件。
+
+当前完整支持的只有 Claude：
+
+- 安装 Claude Code 原生插件到项目级 `.ai/plugins`
+- 从配置里的 marketplace 解析 `plugin@marketplace`
+- 把 Claude 插件里可复用的能力接入到当前项目
+
+如果你要配置统一 Vibe Forge 插件，继续看 [插件与数据资产](./plugins.md)。
+
+对用户来说，重点不是 Claude 插件内部目录结构，而是：
+
+- 你可以直接安装 Claude 原生插件
+- Vibe Forge 会自动处理和项目统一资产层之间的转换
+- 后续运行 Claude adapter 时会自动启用这些项目级插件
+
+## 安装命令
+
+命令入口是：
+
+```bash
+npx vf plugin --adapter claude add <source>
+```
+
+当前支持的常见 source 形式：
+
+- 本地路径：`./plugins/my-claude-plugin`
+- GitHub shorthand：`obra/superpowers`
+- 显式 GitHub：`github:obra/superpowers`
+- Git URL：`https://github.com/obra/superpowers.git#main`
+- npm：`npm:@scope/pkg`、`npm:pkg@1.2.3`
+- marketplace 引用：`plugin-name@marketplace-name`
+
+注意：
+
+- `plugin@marketplace` 会优先按 marketplace 解析
+- 如果你本来想装 npm 包并且 spec 里带 `@`，要显式写成 `npm:...`
+- 例如 `npm:superpowers@latest`、`npm:@acme/claude-plugin@1.2.3`
+
+## Marketplace 配置
+
+在项目根目录的 `.ai.config.yaml`、`.ai.config.json`、`.ai.dev.config.yaml` 或 `.ai.dev.config.json` 中配置 `marketplaces`。
+
+Claude marketplace entry 的格式是：
+
+```yaml
+marketplaces:
+  <marketplace-name>:
+    type: claude-code
+    enabled: true
+    options:
+      source: ...
+```
+
+`options.source` 当前支持这些来源：
+
+- `github`
+- `git`
+- `directory`
+- `url`
+- `settings`
+
+其中最常见的是：
+
+- `github`：直接指向一个 marketplace 仓库
+- `settings`：在你的项目配置里直接内联一个最小 catalog
+
+## 示例：接入 Superpowers Marketplace
+
+如果你想直接使用 Superpowers 维护的 Claude marketplace，可以这样配：
+
+```yaml
+marketplaces:
+  superpowers-marketplace:
+    type: claude-code
+    enabled: true
+    options:
+      source:
+        source: github
+        repo: obra/superpowers-marketplace
+        ref: main
+```
+
+然后安装：
+
+```bash
+npx vf plugin --adapter claude add superpowers@superpowers-marketplace
+npx vf plugin --adapter claude add superpowers-developing-for-claude-code@superpowers-marketplace
+npx vf plugin --adapter claude add private-journal-mcp@superpowers-marketplace
+```
+
+如果你还想装浏览器插件，也可以继续装：
+
+```bash
+npx vf plugin --adapter claude add superpowers-chrome@superpowers-marketplace
+```
+
+前提是这个 plugin 名字已经存在于该 marketplace 的 `marketplace.json` 里。
+
+## 示例：项目内联一个最小 Marketplace
+
+如果你不想依赖整个外部 marketplace，也可以只在项目里声明你真正要用的几个插件：
+
+```yaml
+marketplaces:
+  superpowers:
+    type: claude-code
+    enabled: true
+    options:
+      source:
+        source: settings
+        plugins:
+          - name: superpowers
+            source:
+              source: github
+              repo: obra/superpowers
+              ref: main
+          - name: superpowers-chrome
+            source:
+              source: github
+              repo: obra/superpowers-chrome
+              ref: main
+          - name: private-journal-mcp
+            source:
+              source: github
+              repo: obra/private-journal-mcp
+              ref: main
+```
+
+然后安装：
+
+```bash
+npx vf plugin --adapter claude add superpowers@superpowers
+npx vf plugin --adapter claude add superpowers-chrome@superpowers
+npx vf plugin --adapter claude add private-journal-mcp@superpowers
+```
+
+说明：
+
+- `source: settings` 适合把项目依赖锁到你自己指定的仓库和 ref
+- 这种内联 catalog 里的 `plugins[].source` 必须写显式对象，不能写相对路径字符串
+- 相对路径插件源只适用于目录型 marketplace，因为只有目录型 marketplace 才有本地 root 可解析
+
+## 用户视角下的行为
+
+执行 `vf plugin --adapter claude add ...` 之后，你可以把它理解成两件事：
+
+1. 这个 Claude 插件被安装成了当前项目的一部分
+2. Vibe Forge 会自动抹平 Claude 原生插件格式和项目统一资产层之间的差异
+
+效果上：
+
+- Claude 插件里的可转换能力会进入项目统一资产层
+- Claude adapter 运行时会自动启用对应的项目级原生插件
+- 你不需要再手动维护额外的 Claude 用户目录配置
+
+## 当前限制
+
+- 当前只有 `--adapter claude` 实现了 native plugin installer
+- marketplace 里的插件源最终需要能解析成标准 Claude plugin root；只暴露裸 `skills/` 目录的 catalog 目前还不能直接安装
+- Claude 插件如果声明 `userConfig`，安装会被拒绝；Vibe Forge 还没有把 marketplace 选项映射到这类插件配置
+- marketplace 名称必须先在 `marketplaces` 里配置好；否则 `foo@bar` 会报歧义错误，而不是自动猜成 npm spec
+- `hostPattern` 类型的 Claude marketplace 目前不能直接被 installer 拉取
+
+## 相关文档
+
+- [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
+- [Claude Code Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Superpowers](https://github.com/obra/superpowers)
+- [Superpowers Marketplace](https://github.com/obra/superpowers-marketplace)
+- [Superpowers Chrome](https://github.com/obra/superpowers-chrome)

--- a/.ai/rules/usage/plugins.md
+++ b/.ai/rules/usage/plugins.md
@@ -2,6 +2,15 @@
 
 返回入口：[USAGE.md](../USAGE.md)
 
+## 两套插件体系
+
+Vibe Forge 现在有两套并行的插件使用方式：
+
+- 统一 Vibe Forge 插件：通过 `plugins` 配置加载 npm 包里的 `rules / skills / specs / entities / mcp / hooks`
+- adapter 原生插件：通过 `npx vf plugin --adapter <adapter> add ...` 安装 adapter 自己的原生插件格式，再转成项目可复用的 Vibe Forge 资产
+
+如果你要安装 Claude Code 插件、配置 marketplace，继续看 [Adapter 原生插件与 Marketplace](./native-plugins.md)。
+
 ## 安装方式
 
 - 插件通过 npm 安装到你的项目 workspace。
@@ -107,12 +116,16 @@ pnpm add -D @vibe-forge/plugin-standard-dev @vibe-forge/plugin-logger
 - `opencode/modes`
 - `opencode/plugins`
 
-当前还不支持：
+另外，当前已支持一条 adapter-native 插件安装链路：
 
-- Claude 原生 plugin format 兼容层
-- Codex 原生 plugin format 兼容层
+- `claude-code`: 支持 Claude 原生插件安装与 marketplace 解析，Vibe Forge 会自动处理项目侧的兼容接入
 
-也就是说，同一个 Vibe Forge 插件可以同时服务 `claude-code`、`codex`、`opencode`，但如果你写的是 OpenCode 原生目录结构，只有 OpenCode adapter 会消费这些 native 资产。
+当前还未接入：
+
+- Codex 原生 plugin format 安装链路
+- OpenCode 原生 plugin marketplace 安装链路
+
+也就是说，同一个 Vibe Forge 插件可以同时服务 `claude-code`、`codex`、`opencode`；如果你安装的是 Claude 原生插件，Vibe Forge 会尽量把它抹平成项目统一插件层可用的能力，并在 Claude adapter 下自动接入。
 
 ## 示例：标准开发流插件
 


### PR DESCRIPTION
## Summary
- add a user-facing guide for adapter-native Claude plugin installation and marketplace usage
- clarify the split between unified Vibe Forge plugins and adapter-native plugins
- document the current support boundary for Claude marketplace plugin sources

## Validation
- pnpm exec dprint check .ai/rules/USAGE.md .ai/rules/usage/plugins.md .ai/rules/usage/native-plugins.md
