### PR TITLE
chore(release): prepare client 0.11.1, types 0.11.1, adapter-codex 0.11.2, server 0.11.3

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe-forge/client",
   "type": "module",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "imports": {
     "#~/*": [
       "./src/*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/changelog/0.11.1/client.md
+++ b/changelog/0.11.1/client.md
@@ -1,0 +1,19 @@
+# @vibe-forge/client 0.11.1
+
+发布日期：2026-04-14
+
+## 发布范围
+
+- 发布 `@vibe-forge/client@0.11.1`
+
+## 主要变更
+
+- 聊天页 header 新增 Git 控制区，支持查看仓库状态、切换/新建分支、同步远端，以及在会话内发起 commit / push。
+- Git 提交流程补齐 staged / working tree 摘要、amend、skip hooks、force push 和 worktree 感知，减少在多 worktree 场景下误切分支的风险。
+- 工具调用渲染继续整理，通用工具、Claude 工具和 Chrome DevTools 工具的字段展示与摘要结构更一致。
+- 会话切换时恢复消息历史与缓存的行为修正，避免来回切换后聊天记录短暂丢失或闪回旧状态。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不改客户端入口命令。
+- Git 控制区依赖服务端提供对应 Git API；若要启用完整能力，建议与 `@vibe-forge/server@0.11.3` 和 `@vibe-forge/types@0.11.1` 配套升级。

--- a/changelog/0.11.1/types.md
+++ b/changelog/0.11.1/types.md
@@ -1,0 +1,16 @@
+# @vibe-forge/types 0.11.1
+
+发布日期：2026-04-14
+
+## 发布范围
+
+- 发布 `@vibe-forge/types@0.11.1`
+
+## 主要变更
+
+- 新增共享 Git 类型定义，覆盖仓库状态、分支列表、worktree 列表、提交摘要，以及 commit / push 的请求载荷。
+- `index.ts` 补齐 Git 类型导出，client、server 和 adapter 可以直接复用同一份契约，减少重复声明与字段漂移。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，仅新增导出，不移除现有类型。

--- a/changelog/0.11.2/adapter-codex.md
+++ b/changelog/0.11.2/adapter-codex.md
@@ -1,0 +1,15 @@
+# @vibe-forge/adapter-codex 0.11.2
+
+发布日期：2026-04-14
+
+## 发布范围
+
+- 发布 `@vibe-forge/adapter-codex@0.11.2`
+
+## 主要变更
+
+- 结构化命令展示继续兼容 `argv` / `args` 两种 payload 形态，Codex 命令摘要在不同事件来源下会保持一致，不再因为字段落点不同而显示异常。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不改 adapter 入口与协议表面。

--- a/changelog/0.11.3/server.md
+++ b/changelog/0.11.3/server.md
@@ -1,0 +1,18 @@
+# @vibe-forge/server 0.11.3
+
+发布日期：2026-04-14
+
+## 发布范围
+
+- 发布 `@vibe-forge/server@0.11.3`
+
+## 主要变更
+
+- 新增会话级 Git API，支持读取仓库状态、列出分支和 worktree，以及执行 checkout、create branch、commit、push、sync。
+- Git 服务补齐 staged / working tree 摘要、HEAD commit、upstream / ahead-behind 统计和 worktree 解析，前端现在可以直接展示更完整的仓库上下文。
+- 分支切换会阻止切到已被其他 worktree 占用的本地分支，并对 commit / push 请求参数做显式校验，减少误操作和模糊错误。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，新增的 Git 路由只在会话工作区位于 Git 仓库内时生效。
+- 现有 session、channel 和非 Git 工作区流程不受影响。

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-codex",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Codex App Server Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/types",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Shared types for Vibe Forge",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- prepare patch releases for client 0.11.1, types 0.11.1, adapter-codex 0.11.2, and server 0.11.3
- record changelog entries for the Git session controls, shared Git contract, adapter-codex command display fix, and server Git APIs
- keep the branch rebased on current `origin/master`

## Verification
- `npx vitest run apps/client/__tests__/chat-git-branch-utils.spec.ts apps/client/__tests__/chat-git-commit-utils.spec.ts apps/client/__tests__/chat-git-operation-utils.spec.ts apps/client/__tests__/chat-git-worktree-utils.spec.ts apps/client/__tests__/chat-session-view-cache.spec.ts apps/client/__tests__/claude-tool-presentation.spec.ts apps/client/__tests__/generic-tool-presentation.spec.ts apps/client/__tests__/tool-summary.spec.ts apps/server/__tests__/services/git.spec.ts apps/server/__tests__/channels/middleware/commands.spec.ts packages/adapters/codex/__tests__/session-rpc.spec.ts packages/adapters/codex/__tests__/session-stream.spec.ts`
- `pnpm typecheck`
- `npm pack --dry-run --json` in `apps/client`, `apps/server`, `packages/adapters/codex`, and `packages/types`

## Notes
- `npm whoami` returned `401 Unauthorized`, so this PR prepares the release metadata but does not perform `npm publish`.
