### PR TITLE
release: prepare plugin-logger 0.11.1

### DIFF
--- a/changelog/0.11.1/plugin-logger.md
+++ b/changelog/0.11.1/plugin-logger.md
@@ -1,0 +1,18 @@
+# @vibe-forge/plugin-logger 0.11.1
+
+发布日期：2026-04-15
+
+## 发布范围
+
+- 发布 `@vibe-forge/plugin-logger@0.11.1`
+
+## 主要变更
+
+- `logger` 插件记录 Bash `PostToolUse` 输出时，会对行首的 Markdown code fence 自动转义，避免 `stdout`、`stderr`、命令描述或命令文本里包含 `\`\`\`bash` 等内容时截断日志渲染。
+- 共享 markdown logger 现在也会在 YAML folded 多行文本和 error text block 中做同样的 fence 转义，保持 plugin hook 日志与主会话日志的渲染行为一致。
+- 补充了 `plugin-logger` 与共享 logger 的定向回归测试，覆盖日志正文中嵌套 code fence 的场景。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不改变插件导出面和 hook 事件契约。
+- 现有日志结构保持不变，仅修正包含 Markdown fence 的文本在 `.log.md` 中的展示稳定性。

--- a/packages/plugins/logger/__tests__/hooks.spec.ts
+++ b/packages/plugins/logger/__tests__/hooks.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import loggerPlugin from '#~/hooks.js'
+
+describe('logger plugin', () => {
+  it('escapes markdown fence lines in bash tool logs', async () => {
+    const info = vi.fn()
+    const next = vi.fn().mockResolvedValue({ continue: true })
+    const postToolUse = loggerPlugin.PostToolUse
+
+    expect(postToolUse).toBeTypeOf('function')
+
+    const result = await postToolUse?.(
+      {
+        logger: { info }
+      } as never,
+      {
+        toolName: 'Bash',
+        adapter: 'codex',
+        toolInput: {
+          description: 'Bash output\n```bash\ncat README.md\n```',
+          command: 'printf "demo"\n```bash\ncat README.md\n```'
+        },
+        toolResponse: {
+          stdout: 'stdout line\n```bash\necho "ok"\n```',
+          stderr: '```bash\necho "err"\n```'
+        }
+      } as never,
+      next
+    )
+
+    expect(result).toEqual({ continue: true })
+    expect(next).toHaveBeenCalledOnce()
+    expect(info).toHaveBeenCalledOnce()
+
+    const [toolName, description, textBlock] = info.mock.calls[0] ?? []
+
+    expect(toolName).toBe('Bash')
+    expect(description).toBe('Bash output\n\\`\\`\\`bash\ncat README.md\n\\`\\`\\`')
+    expect(textBlock).toContain('\n```text\n')
+    expect(textBlock).toContain('> printf "demo"\n\\`\\`\\`bash\ncat README.md\n\\`\\`\\`')
+    expect(textBlock).toContain('stdout: stdout line\n\\`\\`\\`bash\necho "ok"\n\\`\\`\\`')
+    expect(textBlock).toContain('stderr: \\`\\`\\`bash\necho "err"\n\\`\\`\\`')
+    expect(textBlock).toContain('\n```')
+  })
+})

--- a/packages/plugins/logger/package.json
+++ b/packages/plugins/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-logger",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/logger/src/hooks.ts
+++ b/packages/plugins/logger/src/hooks.ts
@@ -8,6 +8,7 @@ const asRecord = (value: unknown): Record<string, unknown> => (
 
 const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_PATTERN = /api[-_]?key|token|secret|authorization|password|cookie|session[-_]?token|bearer/i
+const MARKDOWN_FENCE_LINE_PATTERN = /(^|\n)([ \t]{0,3})```/g
 
 const sanitizeEnvRecord = (value: unknown) => {
   const record = asRecord(value)
@@ -17,6 +18,18 @@ const sanitizeEnvRecord = (value: unknown) => {
     keys: Object.keys(record).sort()
   }
 }
+
+const escapeMarkdownFenceLines = (value: string) => (
+  value
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(
+      MARKDOWN_FENCE_LINE_PATTERN,
+      (_match, lineStart: string, indent: string) => `${lineStart}${indent}\\\`\\\`\\\``
+    )
+)
+
+const formatLogText = (value: unknown) => escapeMarkdownFenceLines(String(value ?? ''))
 
 const sanitizeHookLogValue = (
   value: unknown,
@@ -92,16 +105,20 @@ export default definePlugin({
       case 'adapter:codex:Bash': {
         const toolInput = asRecord(sanitizeHookLogValue(input.toolInput, 'toolInput'))
         const toolResponse = asRecord(sanitizeHookLogValue(input.toolResponse, 'toolResponse'))
+        const description = formatLogText(toolInput.description)
+        const command = formatLogText(toolInput.command)
+        const stdout = formatLogText(toolResponse.stdout ?? input.toolResponse ?? '<no stdout>')
+        const stderr = formatLogText(toolResponse.stderr ?? '<no stderr>')
         logger.info(
           input.toolName,
-          toolInput.description,
+          description,
           '\n```text\n' +
             `isImage: ${toolResponse.isImage ?? ''}\n` +
             `interrupted: ${toolResponse.interrupted ?? ''}\n` +
-            `> ${toolInput.command ?? ''}\n\n` +
-            `stdout: ${toolResponse.stdout ?? input.toolResponse ?? '<no stdout>'}\n` +
+            `> ${command}\n\n` +
+            `stdout: ${stdout}\n` +
             '-----------------------------------------\n' +
-            `stderr: ${toolResponse.stderr ?? '<no stderr>'}\n` +
+            `stderr: ${stderr}\n` +
             '\n```'
         )
         break

--- a/packages/utils/__tests__/create-logger.spec.ts
+++ b/packages/utils/__tests__/create-logger.spec.ts
@@ -141,4 +141,27 @@ describe('createLogger', () => {
     expect(content).toContain('    1233')
     expect(content).toContain('    456')
   })
+
+  it('escapes markdown fence lines inside folded yaml strings', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'vf-create-logger-'))
+    tempDirs.push(cwd)
+
+    const logger = createLogger(cwd, 'task-1', 'session-1')
+    logger.info({
+      prompt: 'before\n```bash\necho "hi"\n```\nafter'
+    })
+    await new Promise<void>((resolve) => {
+      logger.stream.end(() => resolve())
+    })
+
+    const canonicalPath = join(cwd, '.ai/logs/task-1/session-1.log.md')
+    const content = await readFile(canonicalPath, 'utf8')
+    expect(content).toContain('```yaml')
+    expect(content).toContain('prompt: >-')
+    expect(content).toContain('  before')
+    expect(content).toContain('  \\`\\`\\`bash')
+    expect(content).toContain('  echo "hi"')
+    expect(content).toContain('  \\`\\`\\`')
+    expect(content).toContain('  after')
+  })
 })

--- a/packages/utils/src/create-logger.ts
+++ b/packages/utils/src/create-logger.ts
@@ -24,6 +24,7 @@ const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
 const YAML_INDENT = '  '
 const YAML_RESERVED_PATTERN =
   /^(?:[-+]?\.inf|\.nan|[-+]?(?:0|[1-9]\d*)(?:\.\d+)?(?:e[-+]?\d+)?|true|false|null|[~yn]|yes|no|on|off)$/i
+const MARKDOWN_FENCE_LINE_PATTERN = /(^|\n)([ \t]{0,3})```/g
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => (
   value != null &&
@@ -62,6 +63,15 @@ const formatYamlInlineValue = (value: YamlLogValue): string => {
 }
 
 const normalizeMultilineString = (value: string) => value.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+const escapeMarkdownFenceLines = (value: string) => (
+  value.replace(
+    MARKDOWN_FENCE_LINE_PATTERN,
+    (_match, lineStart: string, indent: string) => `${lineStart}${indent}\\\`\\\`\\\``
+  )
+)
+
+const formatMultilineLogString = (value: string) => escapeMarkdownFenceLines(normalizeMultilineString(value))
 
 const toYamlLogValue = (value: unknown, stack = new WeakSet<object>()): YamlLogValue => {
   if (value == null) return null
@@ -142,7 +152,7 @@ const renderYamlMultilineString = (value: string, indentLevel: number): string[]
   const childIndent = YAML_INDENT.repeat(indentLevel + 1)
   return [
     `${indent}>-`,
-    ...normalizeMultilineString(value)
+    ...formatMultilineLogString(value)
       .split('\n')
       .map(line => `${childIndent}${line}`)
   ]
@@ -161,7 +171,7 @@ const renderYamlLines = (value: YamlLogValue, indentLevel = 0): string[] => {
       if (typeof item === 'string' && isMultilineString(item)) {
         return [
           `${indent}- >-`,
-          ...normalizeMultilineString(item)
+          ...formatMultilineLogString(item)
             .split('\n')
             .map(line => `${YAML_INDENT.repeat(indentLevel + 1)}${line}`)
         ]
@@ -191,7 +201,7 @@ const renderYamlLines = (value: YamlLogValue, indentLevel = 0): string[] => {
       if (typeof entryValue === 'string' && isMultilineString(entryValue)) {
         return [
           `${indent}${renderedKey}: >-`,
-          ...normalizeMultilineString(entryValue)
+          ...formatMultilineLogString(entryValue)
             .split('\n')
             .map(line => `${YAML_INDENT.repeat(indentLevel + 1)}${line}`)
         ]
@@ -217,9 +227,10 @@ export const formatLoggerMessage = (...args: unknown[]) => (
         return arg
       }
       if (arg instanceof Error) {
+        const errorText = formatMultilineLogString(arg.stack ?? String(arg))
         return (
           '\n```text\n' +
-          `${arg.stack}\n` +
+          `${errorText}\n` +
           '```'
         )
       }


### PR DESCRIPTION
## Summary
- fix `@vibe-forge/plugin-logger` so embedded markdown code fences in Bash tool logs are escaped instead of breaking `.log.md` rendering
- escape the same fence pattern in the shared markdown logger for folded YAML strings and error text blocks
- bump `@vibe-forge/plugin-logger` to `0.11.1` and add `changelog/0.11.1/plugin-logger.md`

## Validation
- `pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/utils/__tests__/create-logger.spec.ts packages/plugins/logger/__tests__/hooks.spec.ts packages/hooks/__tests__/runtime.spec.ts`
- `npm pack --dry-run` (in `packages/plugins/logger`)
- `pnpm exec dprint check packages/plugins/logger/package.json changelog/0.11.1/plugin-logger.md packages/plugins/logger/src/hooks.ts packages/utils/src/create-logger.ts packages/utils/__tests__/create-logger.spec.ts packages/plugins/logger/__tests__/hooks.spec.ts`

## Release Note
- This PR prepares the formal `@vibe-forge/plugin-logger@0.11.1` patch release. Per repo release rules, actual publish/tag should happen after merge to `master`.
