### PR TITLE
fix: resolve post-merge typecheck regressions

### DIFF
--- a/apps/cli/__tests__/run-interaction.spec.ts
+++ b/apps/cli/__tests__/run-interaction.spec.ts
@@ -178,7 +178,7 @@ describe('run command interaction handling', () => {
     const stdin = new PassThrough()
     const decisionPromise = readCliPermissionDecision({
       format: 'stream-json',
-      stdin: stdin as NodeJS.ReadStream
+      stdin
     })
 
     stdin.end('{"type":"submit_input","data":"allow_once"}\n')

--- a/apps/cli/src/commands/run/command.ts
+++ b/apps/cli/src/commands/run/command.ts
@@ -56,6 +56,11 @@ import { createSessionExitController } from './session-exit-controller'
 import type { ActiveCliSessionRecord, ExitControllableSession, RunOptions } from './types'
 import { RUN_INPUT_FORMATS, RUN_OUTPUT_FORMATS } from './types'
 
+type PrintInputCapableSession = ExitControllableSession & {
+  pid?: number
+  respondInteraction?: (id: string, data: string | string[]) => void | Promise<void>
+}
+
 const configureRunCommand = (command: Command) => {
   command
     .argument('[description...]')
@@ -388,23 +393,21 @@ Notes:
 
         await persistRecord()
 
-        let boundSession: (ExitControllableSession & { pid?: number }) | undefined
+        let boundSession: PrintInputCapableSession | undefined
         let stopInputBridge: (() => void) | undefined
         const permissionToolUseCache = new Map<string, string>()
-        let permissionRecoveryQueue = Promise.resolve()
+        let permissionRecoveryQueue: Promise<void> = Promise.resolve()
         const submitPrintInput = async (params: { interactionId?: string; data: string | string[] }) => {
           const interactionId = params.interactionId ?? pendingInteraction?.id
           if (interactionId == null || interactionId.trim() === '') {
             throw new TypeError('No pending interaction is available. Wait for an interaction_request event first.')
           }
-          if (
-            typeof (boundSession as { respondInteraction?: unknown } | undefined)?.respondInteraction !== 'function'
-          ) {
+          const respondInteraction = boundSession?.respondInteraction
+          if (typeof respondInteraction !== 'function') {
             throw new TypeError('The current session does not support submit_input events.')
           }
 
-          await (boundSession as { respondInteraction: (id: string, data: string | string[]) => Promise<void> | void })
-            .respondInteraction(interactionId, params.data)
+          await respondInteraction(interactionId, params.data)
 
           if (pendingInteraction?.id === interactionId) {
             pendingInteraction = undefined
@@ -471,7 +474,9 @@ Notes:
               if (permissionRecovery != null) {
                 permissionRecoveryQueue = permissionRecoveryQueue
                   .catch(() => {})
-                  .then(() => writeCliSessionPermissionRecovery(cwd, ctxId, sessionId, permissionRecovery))
+                  .then(async () => {
+                    await writeCliSessionPermissionRecovery(cwd, ctxId, sessionId, permissionRecovery)
+                  })
                 if (shouldPrintOutput) {
                   const nextState = handlePrintEvent({
                     event: {

--- a/apps/cli/src/commands/run/input-decision.ts
+++ b/apps/cli/src/commands/run/input-decision.ts
@@ -4,6 +4,10 @@ import { createInterface } from 'node:readline'
 import { parseCliInputControlEvent } from './input-control'
 import type { RunInputFormat } from './types'
 
+type PermissionDecisionInput = NodeJS.ReadableStream & {
+  setEncoding(encoding: BufferEncoding): void
+}
+
 const resolveDecisionFromPayload = (payload: unknown) => {
   const event = parseCliInputControlEvent(payload)
   if (event.type === 'submit_input') {
@@ -15,7 +19,7 @@ const resolveDecisionFromPayload = (payload: unknown) => {
   throw new TypeError('Permission recovery expects submit_input or a plain text decision like allow_once.')
 }
 
-const readFirstLine = async (stdin: NodeJS.ReadStream) =>
+const readFirstLine = async (stdin: PermissionDecisionInput) =>
   await new Promise<string>((resolve, reject) => {
     const rl = createInterface({ input: stdin, crlfDelay: Infinity })
     let settled = false
@@ -44,7 +48,7 @@ const readFirstLine = async (stdin: NodeJS.ReadStream) =>
     stdin.once('error', onError)
   })
 
-const readAll = async (stdin: NodeJS.ReadStream) =>
+const readAll = async (stdin: PermissionDecisionInput) =>
   await new Promise<string>((resolve, reject) => {
     const chunks: string[] = []
     const onData = (chunk: string | Buffer) => {
@@ -70,7 +74,7 @@ const readAll = async (stdin: NodeJS.ReadStream) =>
 
 export const readCliPermissionDecision = async (params: {
   format: RunInputFormat
-  stdin: NodeJS.ReadStream
+  stdin: PermissionDecisionInput
 }) => {
   params.stdin.setEncoding('utf8')
   if (params.format === 'stream-json') {

--- a/packages/mcp/src/tools/task/presentation.ts
+++ b/packages/mcp/src/tools/task/presentation.ts
@@ -76,14 +76,20 @@ export const serializeTaskInfo = (params: {
   info?: TaskInfo
 }) => {
   const info = params.info
-  const { session, onStop, serverSync, createdAt, ...safeInfo } = info ?? {}
+  const safeInfo = (() => {
+    if (info == null) {
+      return undefined
+    }
+    const { session, onStop, serverSync, createdAt, ...rest } = info
+    return rest
+  })()
   return {
     taskId: params.taskId,
     description: params.description ?? info?.description,
     status: info?.status ?? params.status,
     logs: info?.logs ?? [],
-    pendingInput: safeInfo.pendingInteraction,
+    pendingInput: safeInfo?.pendingInteraction,
     ...safeInfo,
-    guidance: buildTaskGuidance(safeInfo)
+    guidance: buildTaskGuidance(safeInfo ?? {})
   }
 }


### PR DESCRIPTION
## Summary
- fix Task presentation serialization typing after task interaction changes
- tighten CLI print interaction typing for respondInteraction and permission recovery queue
- widen stdin typing for permission decision tests to accept PassThrough streams

## Verification
- pnpm typecheck
- pnpm exec vitest run --workspace vitest.workspace.ts apps/cli/__tests__/run.spec.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/__tests__/task-manager.spec.ts packages/mcp/__tests__/task-tool.spec.ts packages/mcp/__tests__/sync.spec.ts packages/hooks/__tests__/runtime.spec.ts packages/hooks/__tests__/managed-runtime.spec.ts packages/utils/__tests__/create-logger.spec.ts packages/utils/__tests__/managed-plugin.spec.ts
- pnpm exec eslint apps/cli/src/commands/run/command.ts apps/cli/src/commands/run/input-decision.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/src/tools/task/presentation.ts
- pnpm exec dprint check apps/cli/src/commands/run/command.ts apps/cli/src/commands/run/input-decision.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/src/tools/task/presentation.ts