### PR TITLE
chore(release): publish utils hooks mcp cli patches

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/changelog/0.11.1/hooks.md
+++ b/changelog/0.11.1/hooks.md
@@ -1,0 +1,17 @@
+# @vibe-forge/hooks 0.11.1
+
+发布日期：2026-04-15
+
+## 发布范围
+
+- 发布 `@vibe-forge/hooks@0.11.1`
+
+## 主要变更
+
+- 内置权限插件在 server 侧 `permission-check` 返回 `inherit` 时，不再直接放弃判断；它会继续读取本地 session/project permission mirror，让 `allow_session`、`allow_project` 这类恢复后的授权在 Claude Code、OpenCode 和 MCP 任务场景里真正生效。
+- `StartTasks` hook 的输入类型补齐了 `taskId` 和 `permissionMode`，方便 hook/plugin 在多任务场景里按任务粒度识别权限继承和后续恢复链路。
+
+## 兼容性说明
+
+- 不改 hooks runtime API。
+- 现有 hook 插件无需修改；若消费 `StartTasks` 类型，升级后只会看到更完整的字段。

--- a/changelog/0.11.1/mcp.md
+++ b/changelog/0.11.1/mcp.md
@@ -1,0 +1,19 @@
+# @vibe-forge/mcp 0.11.1
+
+发布日期：2026-04-15
+
+## 发布范围
+
+- 发布 `@vibe-forge/mcp@0.11.1`
+
+## 主要变更
+
+- `StartTasks` 现在会在任务未显式设置 `permissionMode` 时继承父会话权限模式，并把解析后的 `taskId`、`permissionMode` 一并传给 `StartTasks` hook 和 child session。
+- task runtime tools 补齐了阻塞恢复链路：`GetTaskInfo` / `ListTasks` 会返回 `pendingInput`、`lastError` 和下一步 guidance，新增 `SubmitTaskInput` 统一提交权限或普通输入，不再只能靠看日志猜问题。
+- `run tasks` 的日志和状态不再静默丢失交互事件。权限请求、`permission_required` 细节、server sync poll 失败，以及停止 blocked task 后同步回 child session 的终态，现在都会被明确记录。
+- `StopTask` 现在可以清掉已经进入 `waiting_input`、但底层进程已退出的 blocked task；对开启 server sync 的任务，还会把取消/失败事件同步回 child session，避免 server/UI 继续卡在等待输入。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不移除原有 task 工具。
+- `RespondTaskInteraction` 仍可继续使用，但推荐迁移到更通用的 `SubmitTaskInput`。

--- a/changelog/0.11.1/utils.md
+++ b/changelog/0.11.1/utils.md
@@ -1,0 +1,17 @@
+# @vibe-forge/utils 0.11.1
+
+发布日期：2026-04-15
+
+## 发布范围
+
+- 发布 `@vibe-forge/utils@0.11.1`
+
+## 主要变更
+
+- 权限工具名归一化新增对 `adapter:<adapter>:<tool>` 形式的处理，像 `adapter:claude-code:Write` 这类原生工具名会先还原成真实工具，再参与 session/project 权限匹配。
+- markdown logger 会转义多行日志和错误堆栈里的 fenced code block 起始行，避免日志正文自带的 ``` 破坏外围日志格式。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不新增导出入口。
+- 已有权限 key 和日志调用方式继续可用，调整主要用于收敛边界场景。

--- a/changelog/0.11.2/cli.md
+++ b/changelog/0.11.2/cli.md
@@ -1,0 +1,17 @@
+# @vibe-forge/cli 0.11.2
+
+发布日期：2026-04-15
+
+## 发布范围
+
+- 发布 `@vibe-forge/cli@0.11.2`
+
+## 主要变更
+
+- `vf --print` 遇到权限或其他输入请求时，只会在 `--input-format stream-json` 下继续保持可交互；`text` / `json` 模式现在会明确打印请求后退出，避免会话看起来还活着但其实无法回复输入。
+- `vf --resume ... --print` 的权限恢复缓存改成在“成功写入授权结果”前不删除。用户选择 `cancel`，或 project/session 权限落盘失败时，挂起的权限请求会被保留下来，后续还能继续恢复。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布。
+- 若你依赖 print 模式下的 live interaction 回复，请统一使用 `--input-format stream-json`。

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Vibe Forge MCP server",
   "imports": {
     "#~/*.js": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/utils",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Shared runtime utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {


### PR DESCRIPTION
## Summary\n- prepare @vibe-forge/utils 0.11.1\n- prepare @vibe-forge/hooks 0.11.1\n- prepare @vibe-forge/mcp 0.11.1\n- prepare @vibe-forge/cli 0.11.2\n\n## Verification\n- pnpm typecheck\n- pnpm exec vitest run --workspace vitest.workspace.ts apps/cli/__tests__/run.spec.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/__tests__/task-manager.spec.ts packages/mcp/__tests__/task-tool.spec.ts packages/mcp/__tests__/sync.spec.ts packages/hooks/__tests__/runtime.spec.ts packages/hooks/__tests__/managed-runtime.spec.ts packages/utils/__tests__/create-logger.spec.ts packages/utils/__tests__/managed-plugin.spec.ts\n- pnpm exec eslint apps/cli/src/commands/run/command.ts apps/cli/src/commands/run/input-decision.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/src/tools/task/presentation.ts\n- pnpm exec dprint check apps/cli/src/commands/run/command.ts apps/cli/src/commands/run/input-decision.ts apps/cli/__tests__/run-interaction.spec.ts packages/mcp/src/tools/task/presentation.ts apps/cli/package.json packages/hooks/package.json packages/mcp/package.json packages/utils/package.json changelog/0.11.1/utils.md changelog/0.11.1/hooks.md changelog/0.11.1/mcp.md changelog/0.11.2/cli.md\n- npm pack --dry-run in packages/utils, packages/hooks, packages/mcp, apps/cli