### PR TITLE
fix: update codex and claude code adapters

### DIFF
--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -60,7 +60,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.87",
+    "@anthropic-ai/claude-code": "2.1.109",
     "@musistudio/claude-code-router": "1.0.73",
     "@vibe-forge/config": "workspace:^",
     "@vibe-forge/core": "workspace:^",

--- a/packages/adapters/codex/__tests__/native-hooks.spec.ts
+++ b/packages/adapters/codex/__tests__/native-hooks.spec.ts
@@ -171,4 +171,42 @@ describe('ensureCodexNativeHooksInstalled', () => {
     expect(hooks.hooks?.PostToolUse).toHaveLength(1)
     expect(hooks.hooks?.Stop).toHaveLength(1)
   })
+
+  it('prefers the workspace mock home when HOME still points to the real home', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+
+    const ctx = {
+      cwd: workspace,
+      env: {
+        HOME: realHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: [
+          {
+            id: 'hookPlugin:project:logger'
+          }
+        ]
+      }
+    } as any
+
+    const installed = await ensureCodexNativeHooksInstalled(ctx)
+    const hooks = JSON.parse(
+      await readFile(join(mockHome, '.codex', 'hooks.json'), 'utf8')
+    ) as {
+      hooks?: Record<string, Array<{ matcher?: string }>>
+    }
+
+    expect(installed).toBe(true)
+    expect(hooks.hooks?.SessionStart).toHaveLength(1)
+    await expect(readFile(join(realHome, '.codex', 'hooks.json'), 'utf8')).rejects.toThrow()
+  })
 })

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -62,7 +62,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@openai/codex": "0.117.0",
+    "@openai/codex": "0.120.0",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",

--- a/packages/adapters/codex/src/runtime/session-common.ts
+++ b/packages/adapters/codex/src/runtime/session-common.ts
@@ -639,8 +639,8 @@ export async function resolveSessionBase(
   configFingerprintArgs.push(...mcpConfigArgs)
 
   const binaryPath = resolveCodexBinaryPath(env)
-  await mkdir(resolve(process.env.HOME!, '.codex'), { recursive: true })
   const spawnEnv = buildSpawnEnv(env)
+  await mkdir(resolve(spawnEnv.HOME ?? process.env.HOME!, '.codex'), { recursive: true })
 
   if (env.__VF_PROJECT_AI_CODEX_NATIVE_HOOKS_AVAILABLE__ === '1') {
     features.codex_hooks = true

--- a/packages/hooks/src/native.ts
+++ b/packages/hooks/src/native.ts
@@ -38,8 +38,18 @@ export const resolveMockHome = (
   cwd: string,
   env: Record<string, string | null | undefined>
 ) => {
+  const fallbackMockHome = resolveProjectAiPath(cwd, env, '.mock')
   const explicitHome = env.HOME?.trim() || process.env.HOME?.trim()
-  return explicitHome ? resolve(explicitHome) : resolveProjectAiPath(cwd, env, '.mock')
+  const realHome = env.__VF_PROJECT_REAL_HOME__?.trim() || process.env.__VF_PROJECT_REAL_HOME__?.trim()
+  const resolvedExplicitHome = explicitHome ? resolve(explicitHome) : undefined
+  const resolvedRealHome = realHome ? resolve(realHome) : undefined
+
+  if (resolvedExplicitHome == null) return fallbackMockHome
+  if (resolvedRealHome != null && resolvedExplicitHome === resolvedRealHome) {
+    return fallbackMockHome
+  }
+
+  return resolvedExplicitHome
 }
 
 export const resolveManagedHookPackageDir = () => {

--- a/packages/task/__tests__/generate-adapter-query-options.spec.ts
+++ b/packages/task/__tests__/generate-adapter-query-options.spec.ts
@@ -295,4 +295,76 @@ describe('generateAdapterQueryOptions', () => {
     expect(resolvedConfig.systemPrompt).toContain('# vf-cli-quickstart')
     expect(resolvedConfig.systemPrompt).toContain('> Skill description: CLI 快速入门')
   })
+
+  it('merges injected plugins with workspace config plugins in the returned asset bundle', async () => {
+    const workspace = await createWorkspace()
+    const cliPluginDir = join(workspace, 'node_modules', '@vibe-forge', 'plugin-cli-skills')
+    const loggerPluginDir = join(workspace, 'node_modules', '@vibe-forge', 'plugin-logger')
+
+    await writeDocument(
+      join(workspace, '.ai.config.json'),
+      JSON.stringify(
+        {
+          plugins: [
+            {
+              id: 'logger'
+            }
+          ]
+        },
+        null,
+        2
+      )
+    )
+    await writeDocument(
+      join(cliPluginDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@vibe-forge/plugin-cli-skills',
+          version: '0.11.0'
+        },
+        null,
+        2
+      )
+    )
+    await writeDocument(
+      join(cliPluginDir, 'skills', 'vf-cli-quickstart', 'SKILL.md'),
+      '---\ndescription: CLI 快速入门\n---\n先执行 vf list 再恢复会话'
+    )
+    await writeDocument(
+      join(loggerPluginDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@vibe-forge/plugin-logger',
+          version: '0.11.0'
+        },
+        null,
+        2
+      )
+    )
+    await writeDocument(
+      join(loggerPluginDir, 'hooks.js'),
+      'module.exports = { TaskStart: async (_ctx, _input, next) => next() }\n'
+    )
+
+    const [, resolvedConfig] = await generateAdapterQueryOptions(
+      undefined,
+      undefined,
+      workspace,
+      {
+        plugins: [
+          {
+            id: '@vibe-forge/plugin-cli-skills'
+          }
+        ]
+      }
+    )
+
+    expect(resolvedConfig.assetBundle?.pluginConfigs).toEqual([
+      { id: 'logger' },
+      { id: '@vibe-forge/plugin-cli-skills' }
+    ])
+    expect(resolvedConfig.assetBundle?.hookPlugins.map(asset => asset.packageId)).toEqual([
+      '@vibe-forge/plugin-logger'
+    ])
+  })
 })

--- a/packages/task/__tests__/prepare.spec.ts
+++ b/packages/task/__tests__/prepare.spec.ts
@@ -204,4 +204,62 @@ describe('prepare', () => {
     expect(mocks.syncConfiguredMarketplacePlugins).not.toHaveBeenCalled()
     expect(mocks.resolveWorkspaceAssetBundle).not.toHaveBeenCalled()
   })
+
+  it('merges run-scoped plugins with project config plugins when resolving assets', async () => {
+    const { prepare } = await import('#~/prepare.js')
+    mocks.loadConfig.mockResolvedValue([
+      {
+        plugins: [
+          { id: 'logger' }
+        ]
+      },
+      {
+        plugins: [
+          { id: 'standard-dev', scope: 'std' }
+        ]
+      }
+    ])
+    mocks.mergeConfigs.mockImplementation((left, right) => ({
+      ...(left ?? {}),
+      ...(right ?? {}),
+      ...(left?.plugins != null || right?.plugins != null
+        ? {
+          plugins: [
+            ...((left?.plugins as any[]) ?? []),
+            ...((right?.plugins as any[]) ?? [])
+          ]
+        }
+        : {})
+    }))
+
+    await prepare({
+      cwd: '/tmp/project',
+      env: {},
+      plugins: [
+        { id: '@vibe-forge/plugin-cli-skills' }
+      ]
+    }, {
+      type: 'create',
+      runtime: 'cli',
+      sessionId: 'session-plugin-merge',
+      onEvent: vi.fn()
+    } as any)
+
+    expect(mocks.resolveWorkspaceAssetBundle).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: '/tmp/project',
+      configs: [
+        {
+          plugins: [{ id: 'logger' }]
+        },
+        {
+          plugins: [{ id: 'standard-dev', scope: 'std' }]
+        }
+      ],
+      plugins: [
+        { id: 'logger' },
+        { id: 'standard-dev', scope: 'std' },
+        { id: '@vibe-forge/plugin-cli-skills' }
+      ]
+    }))
+  })
 })

--- a/packages/task/src/generate-adapter-query-options.ts
+++ b/packages/task/src/generate-adapter-query-options.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 
-import { buildConfigJsonVariables, loadConfig } from '@vibe-forge/config'
+import { buildConfigJsonVariables, loadConfig, mergeConfigs } from '@vibe-forge/config'
 import type { AdapterQueryOptions, PluginConfig } from '@vibe-forge/types'
 import { resolvePromptAssetSelection, resolveWorkspaceAssetBundle } from '@vibe-forge/workspace-assets'
 
@@ -19,10 +19,21 @@ export async function generateAdapterQueryOptions(
 ) {
   const jsonVariables = buildConfigJsonVariables(cwd, process.env)
   const [config, userConfig] = await loadConfig({ cwd, jsonVariables })
+  const mergedPlugins = mergeConfigs(
+    {
+      plugins: mergeConfigs(
+        { plugins: config?.plugins },
+        { plugins: userConfig?.plugins }
+      )?.plugins
+    },
+    {
+      plugins: input?.plugins
+    }
+  )?.plugins
   const bundle = await resolveWorkspaceAssetBundle({
     cwd,
     configs: [config, userConfig],
-    plugins: input?.plugins
+    plugins: mergedPlugins
   })
   const selection = resolveQuerySelection({
     config,

--- a/packages/task/src/prepare.ts
+++ b/packages/task/src/prepare.ts
@@ -61,6 +61,17 @@ export const prepare = async (
   const jsonVariables = buildConfigJsonVariables(cwd, env)
   const [config, userConfig] = await loadConfig({ cwd, jsonVariables })
   const mergedConfig = mergeConfigs(config, userConfig)
+  const mergedPlugins = mergeConfigs(
+    {
+      plugins: mergeConfigs(
+        { plugins: config?.plugins },
+        { plugins: userConfig?.plugins }
+      )?.plugins
+    },
+    {
+      plugins: options.plugins
+    }
+  )?.plugins
   const assets = adapterOptions.assetBundle ?? await (async () => {
     if (adapterOptions.type === 'create') {
       const syncResults = await syncConfiguredMarketplacePlugins({
@@ -78,7 +89,7 @@ export const prepare = async (
     return resolveWorkspaceAssetBundle({
       cwd,
       configs: [config, userConfig],
-      plugins: options.plugins,
+      plugins: mergedPlugins,
       useDefaultVibeForgeMcpServer: resolveUseDefaultVibeForgeMcpServer({
         runtimeValue: adapterOptions.useDefaultVibeForgeMcpServer,
         projectConfig: config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,12 +103,12 @@ importers:
       '@vibe-forge/hooks':
         specifier: workspace:^
         version: link:../../packages/hooks
-      '@vibe-forge/plugin-cli-skills':
-        specifier: workspace:^
-        version: link:../../packages/plugins/cli-skills
       '@vibe-forge/managed-plugins':
         specifier: workspace:^
         version: link:../../packages/managed-plugins
+      '@vibe-forge/plugin-cli-skills':
+        specifier: workspace:^
+        version: link:../../packages/plugins/cli-skills
       '@vibe-forge/register':
         specifier: workspace:^
         version: link:../../packages/register
@@ -338,8 +338,8 @@ importers:
   packages/adapters/claude-code:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 2.1.87
-        version: 2.1.87
+        specifier: 2.1.109
+        version: 2.1.109
       '@musistudio/claude-code-router':
         specifier: 1.0.73
         version: 1.0.73(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
@@ -362,8 +362,8 @@ importers:
   packages/adapters/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.117.0
-        version: 0.117.0
+        specifier: 0.120.0
+        version: 0.120.0
       '@vibe-forge/core':
         specifier: workspace:^
         version: link:../../core
@@ -780,8 +780,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==, tarball: https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz}
 
-  '@anthropic-ai/claude-code@2.1.87':
-    resolution: {integrity: sha512-R40p85lv270MsOmuP0VrgZlsBnq6HIoW/aIrPwny6AfhPUmsChPNLkxv/F8Mf6g9iYpGNEfICt5CDw++tKZD0g==, tarball: https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.87.tgz}
+  '@anthropic-ai/claude-code@2.1.109':
+    resolution: {integrity: sha512-jVy1TcNWzFP/PFbrVfKYNSWoxXe4HJw7wjnZxR72S+X/kSG4Q1d1gVrUsr4Ej7udHBSaCiStqkOI0vGiy9aKlg==, tarball: https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.109.tgz}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1625,43 +1625,43 @@ packages:
     resolution: {integrity: sha512-0Jsaoxp/9HJqCa3GzEzJcoi4+VfupD/o+1pBG0qJ0X3d+sKbbfSej2Faiyp0fTHH36mhsdAKi2TahEx9JV08ZA==, tarball: https://registry.npmjs.org/@nolyfill/function-bind/-/function-bind-1.0.21.tgz}
     engines: {node: '>=12.4.0'}
 
-  '@openai/codex@0.117.0':
-    resolution: {integrity: sha512-UmWo39UCGqFB2ImWwtI/TOnVQ1M2JIbCeDVBzOtG57WuTIPBNvDyluPNrzNv6eAcTYpyDLC5+nT5k49LrzEwow==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0.tgz}
+  '@openai/codex@0.120.0':
+    resolution: {integrity: sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0.tgz}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.117.0-darwin-arm64':
-    resolution: {integrity: sha512-atIlp7v15chsfMpypW8/4PBp6kOca8wBZoC0hdAWGl/PKZ76/cTC+LKi2XhRfMqKY25nUxnXnm1DnLHqWGKRXA==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-darwin-arm64.tgz}
+  '@openai/codex@0.120.0-darwin-arm64':
+    resolution: {integrity: sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-arm64.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.117.0-darwin-x64':
-    resolution: {integrity: sha512-/TWwOtzo44flOQptQTyu+zozESNpsm/jLlK+6vEjOVikXF+kxeA7sgJHRQQ78dFvnHTW+EpkUYew5qNawREtgw==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-darwin-x64.tgz}
+  '@openai/codex@0.120.0-darwin-x64':
+    resolution: {integrity: sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-x64.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.117.0-linux-arm64':
-    resolution: {integrity: sha512-rgQIYipgkMRGvDlK3qbI9v/3NxB1tO3OoNYkWW9onOcev8Jno+hZC0ZEcVamxC5XGspVuPv2Wg+e9hw6jA65FA==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-linux-arm64.tgz}
+  '@openai/codex@0.120.0-linux-arm64':
+    resolution: {integrity: sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-arm64.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.117.0-linux-x64':
-    resolution: {integrity: sha512-kvOZtyLAgFEFSFRJXVzTnFYoZgZya9ttpxDYHR+diBgDBlcBp1B6pRiIGUmCOauxpHtTFUEyisvhKQquZbAtfg==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-linux-x64.tgz}
+  '@openai/codex@0.120.0-linux-x64':
+    resolution: {integrity: sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-x64.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.117.0-win32-arm64':
-    resolution: {integrity: sha512-oglr9IEh0P3cXF1LyGE4ROR6OFOJ7zmOZppoS+FJR6ovaPb08RhfXCDq/1yyzZhCYIaL6GHIdJ56ZEfpM4FuCQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-win32-arm64.tgz}
+  '@openai/codex@0.120.0-win32-arm64':
+    resolution: {integrity: sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-arm64.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.117.0-win32-x64':
-    resolution: {integrity: sha512-ByedNwSlHJ4aE2++fBaUcaqbQsmx2dZS6mhrnv2SqbTY0saRFE2BT1R64fClt8TwXwMsQQn1uvkxjzU4aEhRcg==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-win32-x64.tgz}
+  '@openai/codex@0.120.0-win32-x64':
+    resolution: {integrity: sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-x64.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5679,7 +5679,7 @@ snapshots:
       package-manager-detector: 1.5.0
       tinyexec: 1.0.1
 
-  '@anthropic-ai/claude-code@2.1.87':
+  '@anthropic-ai/claude-code@2.1.109':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -6510,31 +6510,31 @@ snapshots:
 
   '@nolyfill/function-bind@1.0.21': {}
 
-  '@openai/codex@0.117.0':
+  '@openai/codex@0.120.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.117.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.117.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.117.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.117.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.117.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.117.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.120.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.120.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.120.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.120.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.120.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.120.0-win32-x64'
 
-  '@openai/codex@0.117.0-darwin-arm64':
+  '@openai/codex@0.120.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.117.0-darwin-x64':
+  '@openai/codex@0.120.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.117.0-linux-arm64':
+  '@openai/codex@0.120.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.117.0-linux-x64':
+  '@openai/codex@0.120.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.117.0-win32-arm64':
+  '@openai/codex@0.120.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.117.0-win32-x64':
+  '@openai/codex@0.120.0-win32-x64':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.4':

--- a/scripts/adapter-e2e/runners.ts
+++ b/scripts/adapter-e2e/runners.ts
@@ -67,9 +67,18 @@ const walkJsonlFiles = async (dir: string): Promise<string[]> => {
   return nested.flat()
 }
 
+const resolveCodexTranscriptWaitMs = () => {
+  const configured = Number(process.env.HOOK_SMOKE_CODEX_TRANSCRIPT_WAIT_MS ?? 30_000)
+  const fallback = Number(process.env.HOOK_SMOKE_TIMEOUT_MS ?? 180_000)
+  if (Number.isFinite(configured) && configured > 0) {
+    return Math.min(configured, fallback)
+  }
+  return fallback
+}
+
 const waitForCodexTranscriptFile = async () => {
   const sessionsRoot = path.resolve(mockHome, '.codex', 'sessions')
-  const deadline = Date.now() + 10_000
+  const deadline = Date.now() + resolveCodexTranscriptWaitMs()
 
   while (Date.now() < deadline) {
     const files = await walkJsonlFiles(sessionsRoot)


### PR DESCRIPTION
## Summary
- bump `@openai/codex` to `0.120.0` and `@anthropic-ai/claude-code` to `2.1.109`
- merge CLI-injected plugins with workspace plugins so codex native hooks still install after the upgrade
- fix codex mock-home and spawn-home handling, and extend transcript injection wait time for slower startup paths

## Testing
- `pnpm install --lockfile-only --ignore-scripts --reporter append-only`
- `git diff --check`
- `NODE_PATH="$NP" node ./scripts/run-tools.mjs adapter-e2e run claude-code`
- `NODE_PATH="$NP" node ./scripts/run-tools.mjs adapter-e2e run codex`

## Notes
- I did not run Vitest directly because the local root install in this worktree still has a `vitest/config` resolution issue.`