### PR TITLE
docs: add kimi adapter handoff guide

### DIFF
--- a/packages/adapters/kimi/.ai/rules/KIMI-ADAPTER.md
+++ b/packages/adapters/kimi/.ai/rules/KIMI-ADAPTER.md
@@ -1,0 +1,35 @@
+---
+alwaysApply: false
+description: 当任务涉及 Kimi adapter runtime、Kimi CLI 安装、modelServices 转换、native hooks、client 图标或真实 Kimi CLI 验证时加载。
+---
+
+# Kimi Adapter
+
+本文件是 Kimi adapter 维护入口页；运行时、模型服务、hooks/assets 和验证细节拆到同目录下的细分文件。
+
+## 先读这些
+
+- [运行时与安装](./runtime.md)
+- [modelServices 转换](./model-services.md)
+- [hooks 与 assets](./hooks-and-assets.md)
+- [验证与官方资料](./verification.md)
+
+## 关联规则
+
+- 根规则：[.ai/rules/ADAPTERS.md](../../../../../.ai/rules/ADAPTERS.md)
+- 根规则：[.ai/rules/HOOKS.md](../../../../../.ai/rules/HOOKS.md)
+- 根规则：[.ai/rules/HOOKS-REFERENCE.md](../../../../../.ai/rules/HOOKS-REFERENCE.md)
+- [packages/workspace-assets/AGENTS.md](../../../../../packages/workspace-assets/AGENTS.md)
+- [packages/task/AGENTS.md](../../../../../packages/task/AGENTS.md)
+- [apps/cli/src/AGENTS.md](../../../../../apps/cli/src/AGENTS.md)
+
+## 核心边界
+
+1. Kimi `--print` 会隐式启用 yolo，权限安全必须依赖 native hooks。
+2. adapter 自动安装只用 `uv tool install` 写入 `.ai/caches/adapter-kimi/cli`，不在 init 中执行官方 `install.sh`。
+3. `showThinkingStream` 已在配置类型中声明，但 runtime 尚未映射到 Kimi config 的 `show_thinking_stream`。
+4. client 展示图标必须来自官方 KIMI Brand Guidelines。
+
+## 相关记录
+
+- [PR #102](https://github.com/vibe-forge-ai/vibe-forge.ai/pull/102) 是 Kimi adapter 的实现与评审记录。

--- a/packages/adapters/kimi/.ai/rules/hooks-and-assets.md
+++ b/packages/adapters/kimi/.ai/rules/hooks-and-assets.md
@@ -1,0 +1,58 @@
+# Kimi Hooks And Assets
+
+## Native Hooks
+
+Kimi 官方 hooks 仍是 Beta。当前 adapter 只托管这些事件：
+
+- `SessionStart`
+- `UserPromptSubmit`
+- `PreToolUse`
+- `PostToolUse`
+- `Stop`
+
+`PreToolUse` 和 `PostToolUse` matcher 当前写 `.*`，由 Vibe Forge hook runtime 继续做权限、插件和内置 permission 逻辑。
+
+托管配置会写入 generated JSON config，或在复制到的 TOML config 中插入：
+
+```text
+# Vibe Forge managed Kimi hooks start
+...
+# Vibe Forge managed Kimi hooks end
+```
+
+## Hook Bridge
+
+[kimi-hook.js](../../kimi-hook.js) 的行为边界：
+
+- stdin 读取 Kimi hook payload，转换成 Vibe Forge hook input。
+- `permissionDecision: "deny"` 走 Kimi 官方结构化输出，由 Kimi 自己阻断。
+- `continue === false` 且事件可阻断时，stderr 写 reason 并 `exit 2`。
+- hook runtime 崩溃、超时或 wrapper 异常时 fail-open，避免 Kimi session 被 bridge 故障卡死。
+- `Stop` 当前标记为不可阻断；需要阻断 Stop 时先确认官方语义和 Vibe Forge hook contract。
+
+新增 Kimi native 事件时，同时更新：
+
+- [src/runtime/native-hooks.ts](../../src/runtime/native-hooks.ts)
+- [kimi-hook.js](../../kimi-hook.js)
+- [packages/task/src/run.ts](../../../../../packages/task/src/run.ts)
+- [packages/hooks/src/builtin-permissions.ts](../../../../../packages/hooks/src/builtin-permissions.ts)
+- [apps/server/src/services/session/permission.ts](../../../../../apps/server/src/services/session/permission.ts)
+- [tests/native-hooks.spec.ts](../../__tests__/native-hooks.spec.ts)
+
+## 去重边界
+
+native hooks 开启后，[packages/task/src/run.ts](../../../../../packages/task/src/run.ts) 必须继续禁用重复的 framework bridge 事件。adapter 层只负责写 Kimi-native config 和 payload 翻译，hooks runtime 负责插件执行，task runtime 负责 native/bridge 去重。
+
+## Skills 与 Workspace Assets
+
+Kimi 支持 `--skills-dir`，所以 workspace skill overlay 走 native skills 目录。当前 session 会把 asset plan 中的 skill overlay 软链到：
+
+```text
+.ai/caches/<ctxId>/<sessionId>/adapter-kimi/skills
+```
+
+维护点：
+
+- [packages/workspace-assets](../../../../../packages/workspace-assets/AGENTS.md) 把 Kimi 标记为 native skill adapter。
+- hook plugins 对 Kimi 是 native hooks，不要额外生成 OpenCode plugin overlay。
+- Kimi 的 `--skills-dir` 可以重复追加；当前 adapter 只传 session overlay 目录。

--- a/packages/adapters/kimi/.ai/rules/model-services.md
+++ b/packages/adapters/kimi/.ai/rules/model-services.md
@@ -1,0 +1,61 @@
+# Kimi Model Services
+
+## 转换入口
+
+[src/runtime/config.ts](../../src/runtime/config.ts) 会把 Vibe Forge `modelServices` 生成 Kimi config。命令里的：
+
+```bash
+--model serviceKey,modelName
+```
+
+会被解析为 Kimi 的：
+
+- `default_model`
+- `providers`
+- `models`
+- `services`，仅 `providerType: "kimi"` 时额外生成 search/fetch
+
+## Provider Types
+
+支持的 provider type：
+
+- `kimi`
+- `openai_legacy`
+- `openai_responses`
+- `anthropic`
+- `gemini`
+- `vertexai`
+
+推断规则在 `inferProviderType`。新配置优先写 `modelServices.<key>.extra.kimi`，同名字段也兼容既有 `extra.codex` 和 `extra.opencode`。
+
+常用扩展字段：
+
+- `providerType`
+- `providerId`
+- `modelKey`
+- `headers`
+- `env`
+- `queryParams`
+- `maxContextSize`
+- `capabilities`
+
+## URL 归一化
+
+外部 API 接入的关键是 provider base URL 归一化：
+
+- `kimi` 和 `openai_legacy` 要剥掉结尾 `/chat/completions`
+- `openai_responses` 要剥掉结尾 `/responses`
+- `kimi` provider 要基于剥离后的 base URL 生成 `/search` 与 `/fetch`
+
+维护结论：很多用户会直接把 `apiBaseUrl` 配成 `/v1/chat/completions`。如果不剥掉，Kimi CLI 会请求重复路径，search/fetch 也会拼错。
+
+## Fallback
+
+如果没有匹配到 `modelServices` 且没有复制到真实 Kimi config，fallback 会按裸 model 生成默认 provider，并从这些 env 取 key：
+
+- `KIMI_API_KEY`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GEMINI_API_KEY`
+
+维护时优先走 `modelServices`，不要把外部服务接入散落到 env 特判里。

--- a/packages/adapters/kimi/.ai/rules/runtime.md
+++ b/packages/adapters/kimi/.ai/rules/runtime.md
@@ -1,0 +1,73 @@
+# Kimi Runtime
+
+## Session 布局
+
+Kimi adapter 不直接写真实 `~/.kimi`。每个 session 使用独立 share dir：
+
+```text
+.ai/caches/<ctxId>/<sessionId>/adapter-kimi/share
+```
+
+运行时会设置：
+
+- `KIMI_SHARE_DIR` 指向 session share dir
+- `KIMI_CLI_NO_AUTO_UPDATE=1`
+- `__VF_KIMI_TASK_SESSION_ID__`
+- `__VF_KIMI_HOOK_RUNTIME__`
+- `__VF_KIMI_HOOK_MODEL__`
+
+如果真实 Kimi home 有 `credentials`，会软链到 session share dir；如果存在 `config.toml` 或 `config.json`，且本次没有生成新的 model config，会复制一份到 session share dir 再合并托管 hooks。
+
+## Print 模式
+
+稳定命令形态：
+
+```bash
+kimi \
+  --work-dir "$PWD" \
+  --config-file ".ai/caches/.../adapter-kimi/share/config.json" \
+  --mcp-config-file ".ai/caches/.../adapter-kimi/share/mcp.json" \
+  --skills-dir ".ai/caches/.../adapter-kimi/skills" \
+  --print \
+  --output-format stream-json \
+  --prompt "..."
+```
+
+维护要点：
+
+- `--print` 会隐式启用 yolo，不要依赖 Kimi 自带交互审批。
+- stdout 是 JSONL，由 [src/runtime/messages.ts](../../src/runtime/messages.ts) 转成 Vibe Forge `ChatMessage`。
+- resume 只在 session share dir 下存在 `sessions` 时加 `--continue`。
+- `--continue` 与 `--session`/`--resume` 互斥，当前 adapter 没有主动指定 Kimi session id。
+
+## Direct 模式
+
+[src/runtime/direct.ts](../../src/runtime/direct.ts) 只负责把交互式 Kimi 交给终端：
+
+- `stdio: inherit`
+- 支持 `--yolo`、`--plan`、`--continue`
+- 不解析 stdout 事件
+
+## 安装策略
+
+Kimi CLI 定位优先级：
+
+1. `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__`
+2. workspace 托管 binary：`.ai/caches/adapter-kimi/cli/bin/kimi`
+3. 系统 `PATH` 里的 `kimi`
+4. `autoInstall !== false` 且 `uv` 可用时，执行 `uv tool install --python 3.13 kimi-cli`
+
+官方安装脚本适合提示用户手动执行：
+
+```bash
+curl -LsSf https://code.kimi.com/install.sh | bash
+```
+
+adapter 内部不直接执行官方脚本，因为它会修改用户级环境和 PATH。自动安装必须保持在 `.ai/caches/adapter-kimi/cli`，避免污染真实 home。
+
+没有 `kimi` 或 `uv` 时，错误信息要继续包含：
+
+- 官方 Kimi installer，macOS/Linux 与 Windows PowerShell 两种命令
+- uv installer、Homebrew `brew install uv`
+- 手动 `uv tool install --python <version> kimi-cli`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH=/absolute/path/to/kimi`

--- a/packages/adapters/kimi/.ai/rules/verification.md
+++ b/packages/adapters/kimi/.ai/rules/verification.md
@@ -1,0 +1,54 @@
+# Kimi Verification
+
+## 真实 CLI Smoke
+
+不要只跑单测。至少覆盖一次本地真实 CLI：
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+npx vf --adapter kimi --print hi
+```
+
+如果要走真实 model service，使用仓库已有私有 [.ai.dev.config.json](../../../../../.ai.dev.config.json)，不要把 key 写进文档或提交：
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER=/path/to/real/workspace \
+npx vf \
+  --adapter kimi \
+  --model kimi,kimi-k2.5 \
+  --exclude-mcp-server ChromeDevtools \
+  --print hi
+```
+
+当前已验证的真实环境：
+
+- `uv 0.11.6`
+- Kimi CLI `1.35.0`
+- `npx vf --adapter kimi --model kimi,kimi-k2.5 --print hi` 能通过真实 API 返回 Kimi 响应
+
+## 本地检查
+
+```bash
+pnpm exec dprint check
+pnpm exec eslint .
+pnpm typecheck
+pnpm exec vitest run \
+  packages/adapters/kimi/__tests__/runtime-config.spec.ts \
+  packages/adapters/kimi/__tests__/native-hooks.spec.ts \
+  packages/workspace-assets/__tests__/adapter-asset-plan.spec.ts \
+  packages/task/__tests__/run.spec.ts \
+  packages/hooks/__tests__/runtime.spec.ts \
+  apps/server/__tests__/services/session-permission.spec.ts
+```
+
+## 官方资料
+
+- [Kimi Code CLI Docs](https://moonshotai.github.io/kimi-cli/en/)
+- [kimi Command](https://moonshotai.github.io/kimi-cli/en/reference/kimi-command.html)
+- [Print 模式](https://moonshotai.github.io/kimi-cli/zh/customization/print-mode.html)
+- [Config Files](https://moonshotai.github.io/kimi-cli/en/configuration/config-files.html)
+- [Providers and Models](https://moonshotai.github.io/kimi-cli/en/configuration/providers.html)
+- [Hooks Beta](https://moonshotai.github.io/kimi-cli/zh/customization/hooks.html)
+- [KIMI Brand Guidelines](https://moonshotai.github.io/Branding-Guide/)
+- [MoonshotAI/kimi-cli issues](https://github.com/MoonshotAI/kimi-cli/issues)

--- a/packages/adapters/kimi/AGENTS.md
+++ b/packages/adapters/kimi/AGENTS.md
@@ -1,0 +1,21 @@
+# Kimi Adapter
+
+本目录只保留本地入口。Kimi adapter 的设计、维护经验和验证规范统一维护在本 package 内的 [`.ai/rules/`](./.ai/rules/)：
+
+- [KIMI-ADAPTER.md](./.ai/rules/KIMI-ADAPTER.md)
+- [runtime.md](./.ai/rules/runtime.md)
+- [model-services.md](./.ai/rules/model-services.md)
+- [hooks-and-assets.md](./.ai/rules/hooks-and-assets.md)
+- [verification.md](./.ai/rules/verification.md)
+
+Kimi adapter 的实现与评审记录见 [PR #102](https://github.com/vibe-forge-ai/vibe-forge.ai/pull/102)。
+
+## 目录职责
+
+- [src/runtime/init.ts](./src/runtime/init.ts)：Kimi CLI 定位、workspace cache 自动安装、native hook bridge 初始化。
+- [src/runtime/config.ts](./src/runtime/config.ts)：session share dir、modelServices 转 Kimi config、MCP、agent file、skills overlay、spawn env。
+- [src/runtime/session.ts](./src/runtime/session.ts)：`kimi --print --output-format stream-json --prompt` 会话。
+- [src/runtime/direct.ts](./src/runtime/direct.ts)：交互式直连模式，`stdio: inherit`。
+- [src/runtime/native-hooks.ts](./src/runtime/native-hooks.ts) 与 [kimi-hook.js](./kimi-hook.js)：Kimi native hooks 到 Vibe Forge hook runtime 的 bridge。
+- [src/icon.ts](./src/icon.ts)：client 展示图标，必须来自官方 KIMI Brand Guidelines。
+- [tests/runtime-config.spec.ts](./__tests__/runtime-config.spec.ts) 与 [tests/native-hooks.spec.ts](./__tests__/native-hooks.spec.ts)：主要回归测试入口。


### PR DESCRIPTION
## Summary
- add Kimi adapter handoff docs under `packages/adapters/kimi/.ai/rules/`
- keep `packages/adapters/kimi/AGENTS.md` as a short local entrypoint
- document runtime, model service mapping, hooks/assets, and verification guidance

## Verification
- pnpm exec dprint check packages/adapters/kimi/AGENTS.md packages/adapters/kimi/.ai/rules/KIMI-ADAPTER.md packages/adapters/kimi/.ai/rules/runtime.md packages/adapters/kimi/.ai/rules/model-services.md packages/adapters/kimi/.ai/rules/hooks-and-assets.md packages/adapters/kimi/.ai/rules/verification.md