### PR TITLE
Fix session worktree path naming

### DIFF
--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -11,6 +11,7 @@
 - 聊天页 sender 下方会固定显示一个 status bar：左侧承载当前 session 的 workspace / git 操作；新建会话时这里会继续展示，并允许先决定是否创建 worktree 以及要切到哪个分支。
 - 分支面板支持 `树状 / 平铺` 两种展示模式；两种视图共用同一套搜索和切换逻辑。
 - 如果新建会话启用了 worktree，但没有显式指定分支，server 会默认从源 worktree 当前分支派生一个新的 session worktree 分支；只有源目录本身是 detached HEAD 时，才会退回 detached 模式。
+- session managed worktree 会落在 `.ai/worktrees/sessions/<sessionId>/<repo-name>`；最后一级目录始终跟随当前 git 根目录名，方便和真实仓库目录保持一致。
 - 如果当前 session 分支还没有对应的远端分支，`同步` 会优先尝试同名远端分支；如果远端还没有这条分支，则会回退到 worktree 记录的基线分支继续同步。
 - 如果你想给项目设默认值，可以在 `.ai.config.json` / `.ai.config.yaml` 的 `conversation.createSessionWorktree` 里配置；Web UI 新建会话时会按这个项目配置初始化。
 

--- a/apps/server/__tests__/services/session-workspace.spec.ts
+++ b/apps/server/__tests__/services/session-workspace.spec.ts
@@ -26,6 +26,17 @@ const runGit = (cwd: string, args: string[]) => {
   })
 }
 
+const resolveExpectedManagedWorktreePath = (primaryWorkspaceRoot: string, workspaceRoot: string, sessionId: string) => (
+  path.join(
+    primaryWorkspaceRoot,
+    '.ai',
+    'worktrees',
+    'sessions',
+    sessionId,
+    path.basename(workspaceRoot)
+  )
+)
+
 describe('session workspace service', () => {
   let db: SqliteDb
   let workspaceRoot: string
@@ -68,6 +79,7 @@ describe('session workspace service', () => {
     db.createSession('Demo', 'sess-1')
 
     const workspace = await provisionSessionWorkspace('sess-1')
+    const expectedWorktreePath = resolveExpectedManagedWorktreePath(primaryWorkspaceRoot, workspaceRoot, 'sess-1')
     const currentBranch = execFileSync('git', ['branch', '--show-current'], {
       cwd: workspace.workspaceFolder,
       encoding: 'utf8'
@@ -76,9 +88,9 @@ describe('session workspace service', () => {
     expect(workspace).toMatchObject({
       sessionId: 'sess-1',
       kind: 'managed_worktree',
-      workspaceFolder: path.join(primaryWorkspaceRoot, '.ai', 'worktrees', 'sessions', 'sess-1'),
-      repositoryRoot: path.join(primaryWorkspaceRoot, '.ai', 'worktrees', 'sessions', 'sess-1'),
-      worktreePath: path.join(primaryWorkspaceRoot, '.ai', 'worktrees', 'sessions', 'sess-1'),
+      workspaceFolder: expectedWorktreePath,
+      repositoryRoot: expectedWorktreePath,
+      worktreePath: expectedWorktreePath,
       baseRef: 'main',
       cleanupPolicy: 'delete_on_session_delete',
       state: 'ready'
@@ -133,15 +145,33 @@ describe('session workspace service', () => {
     expect(sharedWorkspace.kind).toBe('shared_workspace')
 
     const managedWorkspace = await createSessionManagedWorktree('sess-shared')
+    const expectedWorktreePath = resolveExpectedManagedWorktreePath(primaryWorkspaceRoot, workspaceRoot, 'sess-shared')
 
     expect(managedWorkspace).toMatchObject({
       sessionId: 'sess-shared',
       kind: 'managed_worktree',
-      workspaceFolder: path.join(primaryWorkspaceRoot, '.ai', 'worktrees', 'sessions', 'sess-shared'),
-      worktreePath: path.join(primaryWorkspaceRoot, '.ai', 'worktrees', 'sessions', 'sess-shared'),
+      workspaceFolder: expectedWorktreePath,
+      worktreePath: expectedWorktreePath,
       cleanupPolicy: 'delete_on_session_delete',
       state: 'ready'
     })
+  })
+
+  it('keeps the repo root directory name as the final segment when forking from an existing managed worktree', async () => {
+    const { provisionSessionWorkspace } = await import('#~/services/session/workspace.js')
+    db.createSession('Parent', 'sess-parent')
+    db.createSession('Child', 'sess-child')
+
+    const parentWorkspace = await provisionSessionWorkspace('sess-parent')
+    const childWorkspace = await provisionSessionWorkspace('sess-child', {
+      sourceSessionId: 'sess-parent'
+    })
+
+    expect(path.basename(parentWorkspace.workspaceFolder)).toBe(path.basename(workspaceRoot))
+    expect(path.basename(childWorkspace.workspaceFolder)).toBe(path.basename(workspaceRoot))
+    expect(childWorkspace.workspaceFolder).toBe(
+      resolveExpectedManagedWorktreePath(primaryWorkspaceRoot, workspaceRoot, 'sess-child')
+    )
   })
 
   it('transfers a managed worktree to a retained local workspace without deleting files', async () => {

--- a/apps/server/src/services/session/workspace.ts
+++ b/apps/server/src/services/session/workspace.ts
@@ -47,9 +47,29 @@ const getSessionOrThrow = (sessionId: string) => {
   return session
 }
 
-const resolveManagedWorktreePath = (workspaceFolder: string, sessionId: string) => {
+const resolveRepositoryDirectoryName = (repositoryRoot: string, fallback: string) => {
+  const segments = repositoryRoot
+    .split(/[\\/]+/)
+    .map(segment => segment.trim())
+    .filter(Boolean)
+
+  return segments.at(-1) ?? fallback
+}
+
+const resolveManagedWorktreePath = (
+  workspaceFolder: string,
+  sessionId: string,
+  repositoryRoot: string
+) => {
   const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder) ?? workspaceFolder
-  return resolveProjectAiPath(primaryWorkspaceFolder, processEnv, 'worktrees', 'sessions', sessionId)
+  return resolveProjectAiPath(
+    primaryWorkspaceFolder,
+    processEnv,
+    'worktrees',
+    'sessions',
+    sessionId,
+    resolveRepositoryDirectoryName(repositoryRoot, sessionId)
+  )
 }
 
 const buildManagedWorktreeBranchName = (baseBranch: string, sessionId: string) => {
@@ -119,7 +139,7 @@ const buildManagedWorkspace = async (
   const currentBranch = await resolveGitCurrentBranch(workspaceFolder).catch(() => '')
   const normalizedBranch = currentBranch.trim() !== '' ? currentBranch.trim() : undefined
   const baseRef = normalizedBranch ?? await resolveGitHeadRef(workspaceFolder).catch(() => 'HEAD')
-  const worktreePath = resolveManagedWorktreePath(workspaceFolder, sessionId)
+  const worktreePath = resolveManagedWorktreePath(workspaceFolder, sessionId, repositoryRoot)
   const branchName = normalizedBranch == null
     ? undefined
     : buildManagedWorktreeBranchName(normalizedBranch, sessionId)


### PR DESCRIPTION
## Summary
- change managed session worktree paths to end with the current git root directory name
- keep the repo-name suffix when provisioning from an existing managed worktree
- update session workspace tests and web usage docs

## Verification
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/server/__tests__/services/session-workspace.spec.ts
- pnpm typecheck node node:test