### PR TITLE
Adjust chat composer stack padding

### DIFF
--- a/apps/client/src/routes/ChatRoute.scss
+++ b/apps/client/src/routes/ChatRoute.scss
@@ -241,7 +241,7 @@
 
 .chat-composer-stack {
   flex: 0;
-  padding: 0 24px 24px;
+  padding: 0 12px 8px;
 }
 
 .chat-composer-stack__inner {
@@ -323,6 +323,6 @@
 
 @media (max-width: 768px) {
   .chat-composer-stack {
-    padding: 0 16px 16px;
+    padding: 0 12px 8px;
   }
 }


### PR DESCRIPTION
## Summary
- restore the chat composer stack padding to the original tighter spacing
- align desktop and mobile composer stack padding values

## Verification
- pnpm typecheck web