### PR TITLE
feat(client): polish mobile app surfaces

### DIFF
--- a/apps/client/src/components/ArchiveView.scss
+++ b/apps/client/src/components/ArchiveView.scss
@@ -139,9 +139,18 @@
   flex: 1;
   min-width: 0;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.archive-view__item-meta {
+  display: flex;
   align-items: center;
   gap: 6px;
+  width: 100%;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .archive-view__item-title {
@@ -166,6 +175,12 @@
   padding-inline: 3px;
   border-radius: 2px;
   margin: 0;
+}
+
+.archive-view__item-tag-count {
+  font-size: 10px;
+  line-height: 1;
+  color: var(--sub-text-color);
 }
 
 .archive-view__item-time {
@@ -210,4 +225,33 @@
   align-items: center;
   justify-content: center;
   padding: 0;
+}
+
+@media (max-width: 960px) {
+  .archive-view__toolbar {
+    gap: 6px;
+  }
+
+  .archive-view__toolbar-actions {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .archive-view__item-actions {
+    max-width: 48px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .archive-view__item-row:hover .archive-view__item-time {
+    opacity: 1;
+    max-width: none;
+    margin-left: 0;
+  }
+
+  .archive-view__item-action-button {
+    width: 24px;
+    min-width: 24px;
+    height: 24px;
+  }
 }

--- a/apps/client/src/components/ArchiveView.tsx
+++ b/apps/client/src/components/ArchiveView.tsx
@@ -8,17 +8,20 @@ import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
 
 import { PageShell } from '#~/components/layout/PageShell'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 import { deleteSession, getApiErrorMessage, listSessions, updateSession } from '../api'
 
 export function ArchiveView() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const { data: sessionsRes, mutate } = useSWR<{ sessions: Session[] }>(
     '/api/sessions/archived',
     async () => listSessions('archived')
   )
   const sessions: Session[] = sessionsRes?.sessions ?? []
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -103,7 +106,7 @@ export function ArchiveView() {
 
   return (
     <PageShell
-      className='archive-view'
+      className={`archive-view ${isCompactView ? 'archive-view--compact' : ''}`}
       header={
         <div className='archive-view__toolbar'>
           {isBatchMode && (
@@ -213,83 +216,95 @@ export function ArchiveView() {
             <List
               itemLayout='horizontal'
               dataSource={filteredSessions}
-              renderItem={(session) => (
-                <List.Item
-                  className={[
-                    'archive-view__item',
-                    selectedIds.has(session.id) ? 'archive-view__item--selected' : '',
-                    isBatchMode ? 'archive-view__item--batch' : ''
-                  ].filter(Boolean).join(' ')}
-                  onClick={() => isBatchMode && handleToggleSelect(session.id)}
-                >
-                  <div className='archive-view__item-row'>
-                    {isBatchMode && (
-                      <div className='archive-view__item-select'>
-                        <Checkbox
-                          checked={selectedIds.has(session.id)}
-                          onChange={() => handleToggleSelect(session.id)}
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                      </div>
-                    )}
-                    <span className='material-symbols-rounded archive-view__item-icon'>
-                      chat_bubble
-                    </span>
-                    <div className='archive-view__item-main'>
-                      <span className='archive-view__item-title'>
-                        {(session.title != null && session.title !== '')
-                          ? session.title
-                          : (session.lastMessage != null && session.lastMessage !== '')
-                          ? session.lastMessage
-                          : t('common.newChat')}
-                      </span>
-                      {session.tags && session.tags.length > 0 && (
-                        <div className='archive-view__item-tags'>
-                          {session.tags.map((tag: string) => (
-                            <Tag key={tag} className='archive-view__item-tag'>{tag}</Tag>
-                          ))}
-                        </div>
-                      )}
-                      <span className='archive-view__item-time'>
-                        {dayjs(session.createdAt).format('YYYY-MM-DD HH:mm')}
-                      </span>
-                    </div>
+              renderItem={(session) => {
+                const displayTitle = (session.title != null && session.title !== '')
+                  ? session.title
+                  : (session.lastMessage != null && session.lastMessage !== '')
+                  ? session.lastMessage
+                  : t('common.newChat')
+                const sessionTags = session.tags ?? []
+                const visibleTags = isCompactView ? sessionTags.slice(0, 1) : sessionTags
+                const hiddenTagCount = Math.max(sessionTags.length - visibleTags.length, 0)
 
-                    {!isBatchMode && (
-                      <div className='archive-view__item-actions'>
-                        <Tooltip title={t('common.restore')}>
-                          <Button
-                            type='text'
-                            size='small'
-                            className='archive-view__item-action-button'
-                            icon={<span className='material-symbols-rounded archive-view__action-icon'>unarchive</span>}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              void handleRestore(session.id)
-                            }}
-                          />
-                        </Tooltip>
-                        <Popconfirm
-                          title={t('common.deleteSessionConfirm')}
-                          onConfirm={(e) => {
-                            e?.stopPropagation()
-                            void handleDelete(session.id)
-                          }}
-                        >
-                          <Button
-                            type='text'
-                            size='small'
-                            danger
-                            className='archive-view__item-action-button'
-                            icon={<span className='material-symbols-rounded archive-view__action-icon'>delete</span>}
+                return (
+                  <List.Item
+                    className={[
+                      'archive-view__item',
+                      selectedIds.has(session.id) ? 'archive-view__item--selected' : '',
+                      isBatchMode ? 'archive-view__item--batch' : ''
+                    ].filter(Boolean).join(' ')}
+                    onClick={() => isBatchMode && handleToggleSelect(session.id)}
+                  >
+                    <div className='archive-view__item-row'>
+                      {isBatchMode && (
+                        <div className='archive-view__item-select'>
+                          <Checkbox
+                            checked={selectedIds.has(session.id)}
+                            onChange={() => handleToggleSelect(session.id)}
                             onClick={(e) => e.stopPropagation()}
                           />
-                        </Popconfirm>
+                        </div>
+                      )}
+                      <span className='material-symbols-rounded archive-view__item-icon'>
+                        chat_bubble
+                      </span>
+                      <div className='archive-view__item-main'>
+                        <span className='archive-view__item-title'>{displayTitle}</span>
+                        <div className='archive-view__item-meta'>
+                          {visibleTags.length > 0 && (
+                            <div className='archive-view__item-tags'>
+                              {visibleTags.map((tag: string) => (
+                                <Tag key={tag} className='archive-view__item-tag'>{tag}</Tag>
+                              ))}
+                              {hiddenTagCount > 0 && (
+                                <span className='archive-view__item-tag-count'>+{hiddenTagCount}</span>
+                              )}
+                            </div>
+                          )}
+                          <span className='archive-view__item-time'>
+                            {dayjs(session.createdAt).format('YYYY-MM-DD HH:mm')}
+                          </span>
+                        </div>
                       </div>
-                    )}
-                  </div>
-                </List.Item>
-              )}
+
+                      {!isBatchMode && (
+                        <div className='archive-view__item-actions'>
+                          <Tooltip title={t('common.restore')}>
+                            <Button
+                              type='text'
+                              size='small'
+                              className='archive-view__item-action-button'
+                              icon={
+                                <span className='material-symbols-rounded archive-view__action-icon'>unarchive</span>
+                              }
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                void handleRestore(session.id)
+                              }}
+                            />
+                          </Tooltip>
+                          <Popconfirm
+                            title={t('common.deleteSessionConfirm')}
+                            onConfirm={(e) => {
+                              e?.stopPropagation()
+                              void handleDelete(session.id)
+                            }}
+                          >
+                            <Button
+                              type='text'
+                              size='small'
+                              danger
+                              className='archive-view__item-action-button'
+                              icon={<span className='material-symbols-rounded archive-view__action-icon'>delete</span>}
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          </Popconfirm>
+                        </div>
+                      )}
+                    </div>
+                  </List.Item>
+                )
+              }}
             />
           )}
       </div>

--- a/apps/client/src/components/CodeBlock.scss
+++ b/apps/client/src/components/CodeBlock.scss
@@ -44,6 +44,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      width: 24px;
+      min-width: 24px;
+      height: 24px;
       padding: 4px;
       border: none;
       background: transparent;
@@ -59,6 +62,8 @@
 
       .material-symbols-rounded {
         font-size: 16px;
+        font-family: 'Material Symbols Rounded';
+        line-height: 1;
       }
     }
   }

--- a/apps/client/src/components/ConfigView.scss
+++ b/apps/client/src/components/ConfigView.scss
@@ -6,6 +6,44 @@
     min-height: 0;
   }
 
+  &__compact-shell {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  &__compact-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    padding-bottom: 0;
+  }
+
+  &__compact-select {
+    width: 100%;
+
+    .ant-select-selector {
+      min-height: 36px !important;
+      border-radius: 8px !important;
+      padding-inline: 10px !important;
+      background: var(--subpage-content-card-bg) !important;
+    }
+  }
+
+  &__compact-panel {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    margin: var(--subpage-content-card-gap);
+    margin-top: 12px;
+    border-radius: var(--subpage-content-card-radius);
+    background: var(--subpage-content-card-bg);
+    overflow: hidden;
+  }
+
   &__state {
     display: grid;
     place-items: center;
@@ -121,6 +159,12 @@
   line-height: 1;
 }
 
+.config-view__compact-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .config-view__tab-icon {
   font-size: 16px;
   color: var(--sub-text-color);
@@ -230,5 +274,23 @@
   .config-view__tabs > .ant-tabs-content-holder {
     margin-top: 0;
     margin-left: var(--subpage-content-card-gap);
+  }
+}
+
+@media (max-width: 960px) {
+  .config-view--compact {
+    .config-view__body {
+      padding: 0;
+    }
+
+    .config-view__content {
+      padding: 12px;
+      gap: 10px;
+      overflow: auto;
+    }
+
+    .config-view__card {
+      overflow: visible;
+    }
   }
 }

--- a/apps/client/src/components/ConfigView.tsx
+++ b/apps/client/src/components/ConfigView.tsx
@@ -1,6 +1,6 @@
 import './ConfigView.scss'
 
-import { App, Empty, Space, Spin, Tabs } from 'antd'
+import { App, Empty, Select, Space, Spin, Tabs } from 'antd'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
@@ -9,6 +9,7 @@ import type { ConfigSource } from '@vibe-forge/core'
 import type { AboutInfo, ConfigResponse } from '@vibe-forge/types'
 
 import { PageShell } from '#~/components/layout/PageShell'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 import { getApiErrorMessage, getConfig, updateConfig } from '../api'
 import { useQueryParams } from '../hooks/useQueryParams'
@@ -19,6 +20,7 @@ import { cloneValue, getValueByPath, isEmptyValue } from './config/configUtils'
 export function ConfigView() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const { data, isLoading, error, mutate } = useSWR<ConfigResponse>('/api/config', getConfig)
   const { values: queryValues, update: updateQuery, searchParams } = useQueryParams<{ tab: string; source: string }>({
     keys: ['tab', 'source'],
@@ -107,8 +109,33 @@ export function ConfigView() {
 
   const activeTabKey = tabKeys.has(queryValues.tab) ? queryValues.tab : 'general'
   const setActiveTabKey = (key: string) => updateQuery({ tab: key })
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   const activeTab = useMemo(() => tabs.find(tab => tab.key === activeTabKey), [tabs, activeTabKey])
+  const compactTabOptions = useMemo(() => {
+    const groups: Array<{ label: string; options: Array<{ label: string; value: string }> }> = []
+    let currentGroup: { label: string; options: Array<{ label: string; value: string }> } | null = null
+
+    tabs.forEach((tab) => {
+      if (tab.type === 'group') {
+        currentGroup = { label: String(tab.label), options: [] }
+        groups.push(currentGroup)
+        return
+      }
+
+      if (currentGroup == null) {
+        currentGroup = { label: t('config.groups.config'), options: [] }
+        groups.push(currentGroup)
+      }
+
+      currentGroup.options.push({
+        value: tab.key,
+        label: String(tab.label)
+      })
+    })
+
+    return groups
+  }, [tabs, t])
 
   useEffect(() => {
     if (activeTab == null) return
@@ -182,9 +209,60 @@ export function ConfigView() {
     scheduleSave(sectionKey, sourceKey, nextValue)
   }
 
+  const renderTabContent = (tab: typeof tabs[number]) => (
+    <div className='config-view__content'>
+      {tab.key === 'about' && (
+        <AboutSection value={tab.value as AboutInfo | undefined} />
+      )}
+      {tab.key === 'appearance' && (
+        <AppSettingsPanel t={t} />
+      )}
+      {tab.key !== 'about' && tab.key !== 'appearance' && !configTabKeys.has(tab.key) && (
+        <DisplayValue value={tab.value} sectionKey={tab.key} t={t} />
+      )}
+      {configTabKeys.has(tab.key) && (
+        <ConfigSectionPanel
+          sectionKey={tab.key}
+          value={drafts[getDraftKey(tab.key)] ?? cloneValue(tab.value ?? {}) ?? {}}
+          onChange={(next) => handleDraftChange(tab.key, next)}
+          mergedModelServices={mergedModelServices as Record<string, unknown>}
+          mergedAdapters={mergedAdapters as Record<string, unknown>}
+          selectedModelService={selectedModelService}
+          t={t}
+          headerExtra={isCompactView
+            ? undefined
+            : (
+              <Space size={12}>
+                <ConfigSourceSwitch
+                  value={sourceKey}
+                  onChange={setSourceKey}
+                  options={[
+                    {
+                      value: 'project',
+                      icon: 'folder',
+                      label: configPresent?.project === true
+                        ? t('config.sources.project')
+                        : t('config.sources.projectMissing')
+                    },
+                    {
+                      value: 'user',
+                      icon: 'person',
+                      label: configPresent?.user === true
+                        ? t('config.sources.user')
+                        : t('config.sources.userMissing')
+                    }
+                  ]}
+                />
+              </Space>
+            )}
+        />
+      )}
+    </div>
+  )
+
   return (
     <PageShell
-      className='config-view'
+      className={`config-view ${isCompactView ? 'config-view--compact' : ''}`}
       bodyClassName='config-view__body'
     >
       {isLoading && (
@@ -198,87 +276,81 @@ export function ConfigView() {
         </div>
       )}
       {!isLoading && error == null && (
-        <div className='config-view__tabs-wrap'>
-          <Tabs
-            tabPosition='left'
-            tabBarGutter={4}
-            indicator={{ size: 0 }}
-            className='config-view__tabs'
-            activeKey={activeTabKey}
-            onChange={(key) => {
-              if (key !== 'group-config' && key !== 'group-app') {
-                setActiveTabKey(key)
-              }
-            }}
-            items={tabs.map((tab) => {
-              if (tab.type === 'group') {
-                return {
-                  key: tab.key,
-                  label: <span className='config-view__group-label'>{tab.label}</span>,
-                  disabled: true,
-                  children: <div />
-                }
-              }
-              return {
-                key: tab.key,
-                label: (
-                  <span className='config-view__tab-label'>
-                    <span className='material-symbols-rounded config-view__tab-icon'>{tab.icon}</span>
-                    <span className='config-view__tab-text'>{tab.label}</span>
-                  </span>
-                ),
-                children: (
-                  <div className='config-view__content'>
-                    {tab.key === 'about' && (
-                      <AboutSection value={tab.value as AboutInfo | undefined} />
-                    )}
-                    {tab.key === 'appearance' && (
-                      <AppSettingsPanel t={t} />
-                    )}
-                    {tab.key !== 'about' && tab.key !== 'appearance' && !configTabKeys.has(tab.key) && (
-                      <DisplayValue value={tab.value} sectionKey={tab.key} t={t} />
-                    )}
-                    {configTabKeys.has(tab.key) && (
-                      <ConfigSectionPanel
-                        sectionKey={tab.key}
-                        value={drafts[getDraftKey(tab.key)] ?? cloneValue(tab.value ?? {}) ?? {}}
-                        onChange={(next) => handleDraftChange(tab.key, next)}
-                        mergedModelServices={mergedModelServices as Record<string, unknown>}
-                        mergedAdapters={mergedAdapters as Record<string, unknown>}
-                        selectedModelService={selectedModelService}
-                        t={t}
-                        headerExtra={
-                          <Space size={12}>
-                            <ConfigSourceSwitch
-                              value={sourceKey}
-                              onChange={setSourceKey}
-                              options={[
-                                {
-                                  value: 'project',
-                                  icon: 'folder',
-                                  label: configPresent?.project === true
-                                    ? t('config.sources.project')
-                                    : t('config.sources.projectMissing')
-                                },
-                                {
-                                  value: 'user',
-                                  icon: 'person',
-                                  label: configPresent?.user === true
-                                    ? t('config.sources.user')
-                                    : t('config.sources.userMissing')
-                                }
-                              ]}
-                            />
-                          </Space>
-                        }
-                      />
-                    )}
-                  </div>
-                )
-              }
-            })}
-          />
-        </div>
+        isCompactView
+          ? (
+            <div className='config-view__compact-shell'>
+              <div className='config-view__compact-controls'>
+                <Select
+                  value={activeTabKey}
+                  onChange={setActiveTabKey}
+                  options={compactTabOptions}
+                  className='config-view__compact-select'
+                  popupMatchSelectWidth={false}
+                />
+                {activeTab != null && configTabKeys.has(activeTab.key) && (
+                  <ConfigSourceSwitch
+                    value={sourceKey}
+                    onChange={setSourceKey}
+                    options={[
+                      {
+                        value: 'project',
+                        icon: 'folder',
+                        label: configPresent?.project === true
+                          ? t('config.sources.project')
+                          : t('config.sources.projectMissing')
+                      },
+                      {
+                        value: 'user',
+                        icon: 'person',
+                        label: configPresent?.user === true
+                          ? t('config.sources.user')
+                          : t('config.sources.userMissing')
+                      }
+                    ]}
+                  />
+                )}
+              </div>
+              <div className='config-view__compact-panel'>
+                {activeTab != null ? renderTabContent(activeTab) : null}
+              </div>
+            </div>
+          )
+          : (
+            <div className='config-view__tabs-wrap'>
+              <Tabs
+                tabPosition='left'
+                tabBarGutter={4}
+                indicator={{ size: 0 }}
+                className='config-view__tabs'
+                activeKey={activeTabKey}
+                onChange={(key) => {
+                  if (key !== 'group-config' && key !== 'group-app') {
+                    setActiveTabKey(key)
+                  }
+                }}
+                items={tabs.map((tab) => {
+                  if (tab.type === 'group') {
+                    return {
+                      key: tab.key,
+                      label: <span className='config-view__group-label'>{tab.label}</span>,
+                      disabled: true,
+                      children: <div />
+                    }
+                  }
+                  return {
+                    key: tab.key,
+                    label: (
+                      <span className='config-view__tab-label'>
+                        <span className='material-symbols-rounded config-view__tab-icon'>{tab.icon}</span>
+                        <span className='config-view__tab-text'>{tab.label}</span>
+                      </span>
+                    ),
+                    children: renderTabContent(tab)
+                  }
+                })}
+              />
+            </div>
+          )
       )}
     </PageShell>
   )

--- a/apps/client/src/components/MarkdownContent.tsx
+++ b/apps/client/src/components/MarkdownContent.tsx
@@ -16,6 +16,13 @@ export function MarkdownContent({
           pre({ children }) {
             return <>{children}</>
           },
+          table({ children, ...props }: any) {
+            return (
+              <div className='markdown-table-wrapper'>
+                <table {...props}>{children}</table>
+              </div>
+            )
+          },
           code({ inline, className, children, ...props }: any) {
             const langClass = typeof className === 'string' ? className : ''
             const match = /language-(\w+)/.exec(langClass)

--- a/apps/client/src/components/NavRail.scss
+++ b/apps/client/src/components/NavRail.scss
@@ -47,6 +47,254 @@
   }
 }
 
+.nav-rail--compact {
+  width: 100%;
+  height: auto;
+  padding: 8px max(8px, env(safe-area-inset-right))
+    calc(16px + env(safe-area-inset-bottom))
+    max(8px, env(safe-area-inset-left));
+  border-top: 1px solid var(--border-color);
+  background: color-mix(
+    in srgb,
+    var(--sub-sub-bg-color) 96%,
+    var(--bg-color) 4%
+  );
+  z-index: 20;
+
+  .nav-rail-compact-list {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+  }
+
+  .nav-item--compact {
+    width: 100%;
+    min-width: 0;
+    height: 44px;
+    border-radius: 8px;
+
+    .material-symbols-rounded {
+      font-size: 20px;
+    }
+  }
+}
+
+.nav-rail-compact-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: rgba(15, 23, 42, .28);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity .2s ease, visibility 0s linear .2s;
+  z-index: 68;
+}
+
+.nav-rail-compact-sheet-backdrop.is-open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+
+.nav-rail-compact-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 10px 12px calc(16px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--border-color);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  background: var(--bg-color);
+  box-shadow: none;
+  transform: translateY(100%);
+  visibility: hidden;
+  transition:
+    transform .24s cubic-bezier(.4, 0, .2, 1),
+    visibility 0s linear .24s;
+  z-index: 69;
+}
+
+.nav-rail-compact-sheet.is-open {
+  transform: translateY(0);
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.nav-rail-compact-sheet__handle {
+  width: 40px;
+  height: 4px;
+  margin: 0 auto;
+  border-radius: 999px;
+  background: var(--border-color);
+}
+
+.nav-rail-compact-sheet__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-rail-compact-sheet__section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--sub-text-color);
+}
+
+.nav-rail-compact-sheet__section-title-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.nav-rail-compact-sheet__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.nav-rail-compact-sheet__action,
+.nav-rail-compact-sheet__chip {
+  min-width: 0;
+  min-height: 40px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--sub-bg-color);
+  color: var(--text-color);
+  transition: background-color .2s ease, border-color .2s ease, color .2s ease;
+}
+
+.nav-rail-compact-sheet__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 10px;
+
+  .material-symbols-rounded {
+    font-size: 18px;
+    line-height: 1;
+  }
+
+  > span:last-child {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+  }
+}
+
+.nav-rail-compact-sheet__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nav-rail-compact-sheet__segmented {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--sub-bg-color);
+}
+
+.nav-rail-compact-sheet__chip {
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+.nav-rail-compact-sheet__segment {
+  min-width: 0;
+  min-height: 44px;
+  padding: 8px 6px;
+  border: 0;
+  border-right: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  transition: background-color .2s ease, color .2s ease;
+
+  &:last-child {
+    border-right: 0;
+  }
+
+  > span:last-child {
+    min-width: 0;
+    font-size: 11px;
+    line-height: 1.2;
+    text-align: center;
+  }
+}
+
+.nav-rail-compact-sheet__segment-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.nav-rail-compact-sheet__select-shell {
+  min-width: 0;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--sub-bg-color);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav-rail-compact-sheet__select-icon,
+.nav-rail-compact-sheet__select-chevron {
+  font-size: 18px;
+  line-height: 1;
+  color: var(--sub-text-color);
+  flex-shrink: 0;
+}
+
+.nav-rail-compact-sheet__select {
+  flex: 1;
+  min-width: 0;
+  height: 44px;
+  border: 0;
+  background: transparent;
+  color: var(--text-color);
+  display: block;
+  font-size: 14px;
+  line-height: 44px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.nav-rail-compact-sheet__select-chevron {
+  pointer-events: none;
+}
+
+.nav-rail-compact-sheet__action.is-active,
+.nav-rail-compact-sheet__chip.is-active,
+.nav-rail-compact-sheet__segment.is-active {
+  border-color: var(--nav-active-text, #2563eb);
+  background: var(--nav-active-bg, #eff6ff);
+  color: var(--nav-active-text, #2563eb);
+}
+
 .nav-menu-icon {
   font-size: 16px;
   display: inline-flex;

--- a/apps/client/src/components/NavRail.tsx
+++ b/apps/client/src/components/NavRail.tsx
@@ -7,133 +7,106 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { themeAtom } from '../store'
+import { NavRailCompact } from './NavRailCompact'
+import {
+  buildCompactLanguageActions,
+  buildCompactMoreActions,
+  buildCompactThemeActions
+} from './nav-rail-compact-config'
+import { buildLanguageItems, buildNavItems, buildThemeItems } from './nav-rail-items'
 
 export function NavRail({
-  collapsed,
-  onToggleCollapse
+  ariaHidden = false,
+  isCompactLayout = false,
+  onOpenSidebar,
+  showSidebar = false
 }: {
-  collapsed?: boolean
-  onToggleCollapse?: () => void
+  ariaHidden?: boolean
+  isCompactLayout?: boolean
+  onOpenSidebar?: () => void
+  showSidebar?: boolean
 }) {
   const { t, i18n } = useTranslation()
   const [themeMode, setThemeMode] = useAtom(themeAtom)
   const navigate = useNavigate()
   const location = useLocation()
+  const { isTouchInteraction } = useResponsiveLayout()
 
   const currentPath = location.pathname
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
-  const langItems: MenuProps['items'] = React.useMemo(() => [
-    {
-      key: 'zh',
-      label: '简体中文',
-      icon: i18n.language.startsWith('zh')
-        ? (
-          <span className='material-symbols-rounded nav-menu-icon active'>check</span>
-        )
-        : <div className='nav-menu-icon-placeholder' />,
-      onClick: () => {
-        void i18n.changeLanguage('zh')
-      }
-    },
-    {
-      key: 'en',
-      label: 'English',
-      icon: i18n.language.startsWith('en')
-        ? (
-          <span className='material-symbols-rounded nav-menu-icon active'>check</span>
-        )
-        : <div className='nav-menu-icon-placeholder' />,
-      onClick: () => {
-        void i18n.changeLanguage('en')
-      }
-    }
-  ], [i18n.language])
+  const langItems: MenuProps['items'] = React.useMemo(() =>
+    buildLanguageItems({
+      currentLanguage: i18n.language,
+      onChangeLanguage: (language) => i18n.changeLanguage(language)
+    }), [i18n.language])
 
-  const themeItems: MenuProps['items'] = React.useMemo(() => [
-    {
-      key: 'light',
-      label: t('common.themeLight'),
-      icon: themeMode === 'light'
-        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
-        : <span className='material-symbols-rounded nav-menu-icon'>light_mode</span>,
-      onClick: () => {
-        setThemeMode('light')
-        localStorage.setItem('theme', 'light')
-      }
-    },
-    {
-      key: 'dark',
-      label: t('common.themeDark'),
-      icon: themeMode === 'dark'
-        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
-        : <span className='material-symbols-rounded nav-menu-icon'>dark_mode</span>,
-      onClick: () => {
-        setThemeMode('dark')
-        localStorage.setItem('theme', 'dark')
-      }
-    },
-    {
-      key: 'system',
-      label: t('common.themeSystem'),
-      icon: themeMode === 'system'
-        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
-        : <span className='material-symbols-rounded nav-menu-icon'>desktop_windows</span>,
-      onClick: () => {
-        setThemeMode('system')
-        localStorage.setItem('theme', 'system')
-      }
-    }
-  ], [themeMode, t, setThemeMode])
+  const themeItems: MenuProps['items'] = React.useMemo(() =>
+    buildThemeItems({
+      setThemeMode,
+      t,
+      themeMode
+    }), [setThemeMode, t, themeMode])
 
-  const navItems = React.useMemo(() => [
-    {
-      key: 'sessions',
-      icon: 'chat_bubble',
-      label: t('common.sessions'),
-      path: '/',
-      active: currentPath === '/' || currentPath.startsWith('/session/')
-    },
-    {
-      key: 'knowledge',
-      icon: 'library_books',
-      label: t('common.knowledgeBase'),
-      path: '/knowledge',
-      active: currentPath === '/knowledge'
-    },
-    {
-      key: 'automation',
-      icon: 'schedule',
-      label: t('common.automation'),
-      path: '/automation',
-      active: currentPath === '/automation'
-    },
-    {
-      key: 'benchmark',
-      icon: 'speed',
-      label: t('common.benchmark'),
-      path: '/benchmark',
-      active: currentPath === '/benchmark'
-    },
-    {
-      key: 'archive',
-      icon: 'archive',
-      label: t('common.archivedSessions'),
-      path: '/archive',
-      active: currentPath === '/archive'
-    }
-  ], [currentPath, t])
+  const navItems = React.useMemo(() => buildNavItems({ currentPath, t }), [currentPath, t])
+
+  const compactMoreActions = React.useMemo(() =>
+    buildCompactMoreActions({
+      currentPath,
+      navigate,
+      onOpenSidebar,
+      showSidebar,
+      t
+    }), [currentPath, navigate, onOpenSidebar, showSidebar, t])
+
+  const compactThemeActions = React.useMemo(() =>
+    buildCompactThemeActions({
+      setThemeMode,
+      t,
+      themeMode
+    }), [setThemeMode, t, themeMode])
+
+  const compactLanguageActions = React.useMemo(() =>
+    buildCompactLanguageActions({
+      currentLanguage: i18n.language,
+      onChangeLanguage: (language) => {
+        void i18n.changeLanguage(language)
+      }
+    }), [i18n.language])
+
+  const handleNavClick = (_key: string, path: string) => {
+    void navigate(path)
+  }
+
+  if (isCompactLayout) {
+    return (
+      <NavRailCompact
+        ariaHidden={ariaHidden}
+        currentPath={currentPath}
+        languageActions={compactLanguageActions}
+        languageLabel={t('common.language')}
+        moreLabel={t('common.moreActions')}
+        moreSheetActions={compactMoreActions}
+        navItems={navItems}
+        themeActions={compactThemeActions}
+        themeLabel={t('common.theme')}
+        onNavClick={handleNavClick}
+      />
+    )
+  }
 
   return (
-    <div className='nav-rail'>
+    <div className='nav-rail' aria-hidden={ariaHidden || undefined}>
       <div className='nav-rail-top'>
         {navItems.map(item => (
-          <Tooltip key={item.key} title={item.label} placement='right'>
+          <Tooltip key={item.key} title={resolveTooltipTitle(item.label)} placement='right'>
             <span>
               <Button
                 type='text'
                 className={`nav-item ${item.active ? 'active' : ''}`}
-                onClick={() => void navigate(item.path)}
+                onClick={() => handleNavClick(item.key, item.path)}
                 icon={<span className='material-symbols-rounded'>{item.icon}</span>}
               />
             </span>
@@ -141,7 +114,7 @@ export function NavRail({
         ))}
       </div>
       <div className='nav-rail-bottom'>
-        <Tooltip title={t('common.theme')} placement='right'>
+        <Tooltip title={resolveTooltipTitle(t('common.theme'))} placement='right'>
           <span>
             <Dropdown
               menu={{
@@ -162,7 +135,7 @@ export function NavRail({
             </Dropdown>
           </span>
         </Tooltip>
-        <Tooltip title={t('common.language')} placement='right'>
+        <Tooltip title={resolveTooltipTitle(t('common.language'))} placement='right'>
           <span>
             <Dropdown
               menu={{
@@ -179,7 +152,7 @@ export function NavRail({
             </Dropdown>
           </span>
         </Tooltip>
-        <Tooltip title={t('common.settings')} placement='right'>
+        <Tooltip title={resolveTooltipTitle(t('common.settings'))} placement='right'>
           <span>
             <Button
               type='text'

--- a/apps/client/src/components/NavRailCompact.tsx
+++ b/apps/client/src/components/NavRailCompact.tsx
@@ -1,0 +1,107 @@
+import { Button } from 'antd'
+import { useEffect, useState } from 'react'
+
+import { NavRailCompactMoreSheet } from './NavRailCompactMoreSheet'
+
+export interface NavRailCompactItem {
+  active: boolean
+  icon: string
+  key: string
+  label: string
+  path: string
+}
+
+export interface NavRailCompactMoreAction {
+  active?: boolean
+  icon: string
+  key: string
+  label: string
+  onSelect: () => void
+}
+
+export interface NavRailCompactChoiceAction {
+  active: boolean
+  icon?: string
+  key: string
+  label: string
+  onSelect: () => void
+}
+
+export function NavRailCompact({
+  ariaHidden = false,
+  currentPath,
+  languageActions,
+  languageLabel,
+  moreLabel,
+  moreSheetActions,
+  navItems,
+  themeActions,
+  themeLabel,
+  onNavClick
+}: {
+  ariaHidden?: boolean
+  currentPath: string
+  languageActions: NavRailCompactChoiceAction[]
+  languageLabel: string
+  moreLabel: string
+  moreSheetActions: NavRailCompactMoreAction[]
+  navItems: NavRailCompactItem[]
+  themeActions: NavRailCompactChoiceAction[]
+  themeLabel: string
+  onNavClick: (key: string, path: string) => void
+}) {
+  const [isMoreSheetOpen, setIsMoreSheetOpen] = useState(false)
+
+  useEffect(() => {
+    setIsMoreSheetOpen(false)
+  }, [currentPath])
+
+  useEffect(() => {
+    if (ariaHidden) {
+      setIsMoreSheetOpen(false)
+    }
+  }, [ariaHidden])
+
+  return (
+    <div className='nav-rail nav-rail--compact' aria-hidden={ariaHidden || undefined}>
+      <div className='nav-rail-compact-list'>
+        {navItems.map((item) => (
+          <Button
+            key={item.key}
+            type='text'
+            className={`nav-item nav-item--compact ${item.active ? 'active' : ''}`}
+            title={item.label}
+            aria-label={item.label}
+            onClick={() => {
+              setIsMoreSheetOpen(false)
+              onNavClick(item.key, item.path)
+            }}
+            icon={<span className='material-symbols-rounded'>{item.icon}</span>}
+          />
+        ))}
+
+        <Button
+          type='text'
+          className={`nav-item nav-item--compact ${isMoreSheetOpen || currentPath === '/config' ? 'active' : ''}`}
+          title={moreLabel}
+          aria-expanded={isMoreSheetOpen}
+          aria-haspopup='dialog'
+          aria-label={moreLabel}
+          onClick={() => setIsMoreSheetOpen((prev) => !prev)}
+          icon={<span className='material-symbols-rounded'>more_horiz</span>}
+        />
+      </div>
+
+      <NavRailCompactMoreSheet
+        actions={moreSheetActions}
+        isOpen={isMoreSheetOpen}
+        languageActions={languageActions}
+        languageLabel={languageLabel}
+        moreLabel={moreLabel}
+        onClose={() => setIsMoreSheetOpen(false)}
+        themeActions={themeActions}
+        themeLabel={themeLabel}
+      />
+    </div>
+  )
+}

--- a/apps/client/src/components/NavRailCompactMoreSheet.tsx
+++ b/apps/client/src/components/NavRailCompactMoreSheet.tsx
@@ -1,0 +1,141 @@
+interface NavRailCompactMoreAction {
+  active?: boolean
+  icon: string
+  key: string
+  label: string
+  onSelect: () => void
+}
+
+interface NavRailCompactChoiceAction {
+  active: boolean
+  icon?: string
+  key: string
+  label: string
+  onSelect: () => void
+}
+
+export function NavRailCompactMoreSheet({
+  actions,
+  isOpen,
+  languageActions,
+  languageLabel,
+  moreLabel,
+  onClose,
+  themeActions,
+  themeLabel
+}: {
+  actions: NavRailCompactMoreAction[]
+  isOpen: boolean
+  languageActions: NavRailCompactChoiceAction[]
+  languageLabel: string
+  moreLabel: string
+  onClose: () => void
+  themeActions: NavRailCompactChoiceAction[]
+  themeLabel: string
+}) {
+  const activeLanguageKey = languageActions.find((action) => action.active)?.key ?? languageActions[0]?.key ?? ''
+
+  const handleActionSelect = (action: { onSelect: () => void }) => {
+    action.onSelect()
+    onClose()
+  }
+
+  const handleChoiceSelect = (action: NavRailCompactChoiceAction) => {
+    action.onSelect()
+  }
+
+  return (
+    <>
+      <button
+        type='button'
+        className={`nav-rail-compact-sheet-backdrop ${isOpen ? 'is-open' : ''}`}
+        aria-hidden={!isOpen}
+        tabIndex={-1}
+        onClick={onClose}
+      />
+      <div
+        className={`nav-rail-compact-sheet ${isOpen ? 'is-open' : ''}`}
+        role='dialog'
+        aria-modal={isOpen ? 'true' : undefined}
+        aria-hidden={!isOpen}
+        aria-label={moreLabel}
+      >
+        <div className='nav-rail-compact-sheet__handle' />
+
+        {actions.length > 0 && (
+          <div className='nav-rail-compact-sheet__section'>
+            <div className='nav-rail-compact-sheet__section-title'>
+              <span className='material-symbols-rounded nav-rail-compact-sheet__section-title-icon'>tune</span>
+              <span>{moreLabel}</span>
+            </div>
+            <div className='nav-rail-compact-sheet__actions'>
+              {actions.map((action) => (
+                <button
+                  key={action.key}
+                  type='button'
+                  className={`nav-rail-compact-sheet__action ${action.active ? 'is-active' : ''}`}
+                  onClick={() => handleActionSelect(action)}
+                >
+                  <span className='material-symbols-rounded'>{action.icon}</span>
+                  <span>{action.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className='nav-rail-compact-sheet__section'>
+          <div className='nav-rail-compact-sheet__section-title'>
+            <span className='material-symbols-rounded nav-rail-compact-sheet__section-title-icon'>palette</span>
+            <span>{themeLabel}</span>
+          </div>
+          <div className='nav-rail-compact-sheet__segmented'>
+            {themeActions.map((action) => (
+              <button
+                key={action.key}
+                type='button'
+                className={`nav-rail-compact-sheet__segment ${action.active ? 'is-active' : ''}`}
+                onClick={() => handleChoiceSelect(action)}
+              >
+                {action.icon != null && (
+                  <span className='material-symbols-rounded nav-rail-compact-sheet__segment-icon'>
+                    {action.icon}
+                  </span>
+                )}
+                <span>{action.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className='nav-rail-compact-sheet__section'>
+          <div className='nav-rail-compact-sheet__section-title'>
+            <span className='material-symbols-rounded nav-rail-compact-sheet__section-title-icon'>language</span>
+            <span>{languageLabel}</span>
+          </div>
+          <label className='nav-rail-compact-sheet__select-shell'>
+            <span className='material-symbols-rounded nav-rail-compact-sheet__select-icon'>translate</span>
+            <select
+              className='nav-rail-compact-sheet__select'
+              value={activeLanguageKey}
+              aria-label={languageLabel}
+              onChange={(event) => {
+                const selectedAction = languageActions.find((action) => action.key === event.target.value)
+                if (selectedAction != null) {
+                  handleChoiceSelect(selectedAction)
+                }
+              }}
+            >
+              {languageActions.map((action) => (
+                <option key={action.key} value={action.key}>
+                  {action.label}
+                </option>
+              ))}
+            </select>
+            <span className='material-symbols-rounded nav-rail-compact-sheet__select-chevron'>expand_more</span>
+          </label>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/client/src/components/ShortcutTooltip.tsx
+++ b/apps/client/src/components/ShortcutTooltip.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from 'antd'
 import type { TooltipPlacement } from 'antd/es/tooltip'
 import React, { forwardRef, useMemo } from 'react'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { formatShortcutLabel } from '#~/utils/shortcutUtils'
 import { ShortcutDisplay } from './ShortcutDisplay'
 
@@ -38,14 +39,15 @@ export const ShortcutTooltip = forwardRef<HTMLDivElement, ShortcutTooltipProps>(
   className,
   ...divProps
 }, ref) => {
+  const { isTouchInteraction } = useResponsiveLayout()
   const shortcutLabel = useMemo(() => formatShortcutLabel(shortcut, isMac), [isMac, shortcut])
   const resolvedTitle = useMemo(() => {
-    if (!enabled || shortcutLabel === '') {
+    if (!enabled || isTouchInteraction || shortcutLabel === '') {
       return null
     }
 
     return resolveShortcutTooltipTitle(title, shortcutLabel)
-  }, [enabled, shortcutLabel, title])
+  }, [enabled, isTouchInteraction, shortcutLabel, title])
 
   const trigger = (
     <div

--- a/apps/client/src/components/Sidebar.scss
+++ b/apps/client/src/components/Sidebar.scss
@@ -89,6 +89,20 @@
   }
 }
 
+.sidebar-container--compact {
+  width: 100%;
+  height: 100%;
+  border-right: 1px solid var(--border-color);
+
+  .sidebar-content {
+    width: 100%;
+  }
+
+  .sidebar-footer {
+    padding-bottom: max(8px, env(safe-area-inset-bottom));
+  }
+}
+
 .sidebar-collapsed-header {
   position: absolute;
   top: 12px;
@@ -140,6 +154,43 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+}
+
+.sidebar-utility-footer {
+  margin-top: auto;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--border-color);
+  background: var(--sub-bg-color);
+}
+
+.sidebar-utility-footer__action.ant-btn.ant-btn-text {
+  min-width: 0;
+  height: 40px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+
+  .material-symbols-rounded {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  > span:last-child {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 11px;
+  }
 }
 
 html.dark .sidebar-container {

--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import React, { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useSidebarQueryState } from '#~/hooks/use-sidebar-query-state'
 import type { SidebarSessionSortOrder } from '#~/hooks/use-sidebar-query-state'
 import { getAdapterDisplay } from '#~/resources/adapters.js'
@@ -30,11 +31,17 @@ const sortSessionsByOrder = (sessions: Session[], sortOrder: SidebarSessionSortO
 
 export function Sidebar({
   activeId,
+  isCompactLayout = false,
+  isMobileOpen = false,
+  onRequestClose,
   onSelectSession,
   onDeletedSession,
   width
 }: {
   activeId?: string
+  isCompactLayout?: boolean
+  isMobileOpen?: boolean
+  onRequestClose?: () => void
   onSelectSession: (session: Session, isNew?: boolean) => void
   onDeletedSession?: (id: string, nextId?: string) => void
   width: number
@@ -58,6 +65,7 @@ export function Sidebar({
   const [isBatchMode, setIsBatchMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState(new Set<string>())
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
   const isMac = navigator.platform.includes('Mac')
 
   const { data: sessionsRes, mutate: mutateSessions } = useSWR<{ sessions: Session[] }>(
@@ -124,6 +132,7 @@ export function Sidebar({
   }, [adapterFilters, searchQuery, sessions, sortOrder, tagFilters])
 
   async function handleCreateSession() {
+    onRequestClose?.()
     onSelectSession({ id: '' } as Session, true)
   }
 
@@ -259,6 +268,8 @@ export function Sidebar({
   }
 
   const isCreatingSession = activeId === undefined || activeId === ''
+  const effectiveSidebarCollapsed = isCompactLayout ? false : isSidebarCollapsed
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
   const createBtnRef = useRef<HTMLButtonElement>(null)
 
@@ -280,27 +291,37 @@ export function Sidebar({
 
   return (
     <div
-      className={`sidebar-container ${isSidebarCollapsed ? 'collapsed' : ''}`}
-      style={{
-        width: isSidebarCollapsed ? 0 : width,
-        minWidth: isSidebarCollapsed ? 0 : undefined,
-        transition: isResizing ? 'none' : 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        borderRight: isSidebarCollapsed ? 'none' : undefined
-      }}
+      className={[
+        'sidebar-container',
+        effectiveSidebarCollapsed ? 'collapsed' : '',
+        isCompactLayout ? 'sidebar-container--compact' : '',
+        isMobileOpen ? 'is-mobile-open' : ''
+      ].filter(Boolean).join(' ')}
+      style={isCompactLayout
+        ? undefined
+        : {
+          width: effectiveSidebarCollapsed ? 0 : width,
+          minWidth: effectiveSidebarCollapsed ? 0 : undefined,
+          transition: isResizing ? 'none' : 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          borderRight: effectiveSidebarCollapsed ? 'none' : undefined
+        }}
     >
       <div
         className='sidebar-content'
-        style={{
-          width,
-          transition: isResizing ? 'none' : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-          transform: isSidebarCollapsed ? `translateX(-${width}px)` : 'translateX(0)'
-        }}
+        style={isCompactLayout
+          ? undefined
+          : {
+            width,
+            transition: isResizing ? 'none' : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+            transform: effectiveSidebarCollapsed ? `translateX(-${width}px)` : 'translateX(0)'
+          }}
       >
         <SidebarHeader
           adapterFilters={adapterFilters}
           availableAdapters={availableAdapters}
           hasActiveSearchControls={hasActiveSearchControls}
-          isSidebarCollapsed={isSidebarCollapsed}
+          isCompactLayout={isCompactLayout}
+          isSidebarCollapsed={effectiveSidebarCollapsed}
           searchQuery={searchQuery}
           sortOrder={sortOrder}
           sortSelection={sortSelection}
@@ -313,6 +334,7 @@ export function Sidebar({
           isBatchMode={isBatchMode}
           onToggleBatchMode={toggleBatchMode}
           onToggleSidebarCollapsed={() => setSidebarCollapsed(!isSidebarCollapsed)}
+          onCloseSidebar={onRequestClose}
           selectedCount={selectedIds.size}
           totalCount={filteredSessions.length}
           onSelectAll={handleSelectAll}
@@ -337,7 +359,9 @@ export function Sidebar({
           sessions={filteredSessions}
           activeId={activeId}
           isBatchMode={isBatchMode}
+          isCompactLayout={isCompactLayout}
           selectedIds={selectedIds}
+          isTouchInteraction={isTouchInteraction}
           searchQuery={searchQuery}
           onSelectSession={onSelectSession}
           onArchiveSession={handleArchiveSession}
@@ -347,9 +371,12 @@ export function Sidebar({
           onToggleSelect={handleToggleSelect}
         />
       </div>
-      {isSidebarCollapsed && (
+      {!isCompactLayout && isSidebarCollapsed && (
         <div className='sidebar-collapsed-header'>
-          <Tooltip title={isCreatingSession ? t('common.alreadyInNewChat') : t('common.newChat')} placement='bottom'>
+          <Tooltip
+            title={resolveTooltipTitle(isCreatingSession ? t('common.alreadyInNewChat') : t('common.newChat'))}
+            placement='bottom'
+          >
             <Button
               ref={createBtnRef}
               className={`sidebar-collapsed-control ${isCreatingSession ? 'active' : ''}`}
@@ -364,7 +391,7 @@ export function Sidebar({
               </span>
             </Button>
           </Tooltip>
-          <Tooltip title={t('common.expand')} placement='bottom'>
+          <Tooltip title={resolveTooltipTitle(t('common.expand'))} placement='bottom'>
             <Button
               className='sidebar-collapsed-control'
               type='text'

--- a/apps/client/src/components/automation-view/RunHistoryPanel.scss
+++ b/apps/client/src/components/automation-view/RunHistoryPanel.scss
@@ -232,6 +232,50 @@
     }
   }
 
+  &__run-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__run-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    border: var(--subpage-tertiary-border);
+    border-radius: var(--subpage-tertiary-radius);
+    background: var(--subpage-tertiary-bg);
+    color: inherit;
+  }
+
+  &__run-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  &__run-card-title {
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-color);
+  }
+
+  &__run-card-time,
+  &__run-card-summary {
+    font-size: 12px;
+    color: var(--sub-text-color);
+  }
+
+  &__run-card-summary {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
   &__run-summary {
     display: inline-block;
     max-width: 320px;
@@ -338,6 +382,31 @@
 
 @media (max-width: 960px) {
   .automation-view {
+    &__content {
+      gap: 14px;
+    }
+
+    &__detail-header,
+    &__content-header {
+      align-items: flex-start;
+      gap: 10px;
+    }
+
+    &__detail-description {
+      align-items: flex-start;
+    }
+
+    &__run-filters {
+      display: grid;
+      grid-template-columns: 1fr;
+    }
+
+    &__run-search,
+    &__run-select {
+      min-width: 0;
+      width: 100%;
+    }
+
     &__detail-body {
       grid-template-columns: 1fr;
     }

--- a/apps/client/src/components/automation-view/RunHistoryPanel.tsx
+++ b/apps/client/src/components/automation-view/RunHistoryPanel.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import type { AutomationRule, AutomationRun } from '#~/api.js'
 
 interface RunHistoryPanelProps {
+  compact?: boolean
   rule: AutomationRule | null
   runs: AutomationRun[]
   runQuery: string
@@ -23,6 +24,7 @@ interface RunHistoryPanelProps {
 }
 
 export function RunHistoryPanel({
+  compact = false,
   rule,
   runs,
   runQuery,
@@ -309,6 +311,40 @@ export function RunHistoryPanel({
           ? (
             <div className='automation-view__empty'>
               <Empty description={t('automation.noRuns')} />
+            </div>
+          )
+          : compact
+          ? (
+            <div className='automation-view__run-card-list'>
+              {filteredRuns.map((run) => (
+                <a
+                  key={run.id}
+                  className='automation-view__run-card'
+                  href={`/session/${run.sessionId}`}
+                >
+                  <div className='automation-view__run-card-header'>
+                    <span className='automation-view__run-card-title'>
+                      {run.taskTitle ?? t('automation.taskUnknown')}
+                    </span>
+                    {run.status
+                      ? (
+                        <span className='automation-view__status' data-status={run.status}>
+                          <span className='material-symbols-rounded automation-view__status-icon'>
+                            fiber_manual_record
+                          </span>
+                          {t(`common.status.${run.status}`, run.status)}
+                        </span>
+                      )
+                      : null}
+                  </div>
+                  <div className='automation-view__run-card-time'>
+                    {dayjs(run.runAt).format('YYYY-MM-DD HH:mm')}
+                  </div>
+                  <div className='automation-view__run-card-summary'>
+                    {run.title ?? run.lastMessage ?? run.lastUserMessage ?? '-'}
+                  </div>
+                </a>
+              ))}
             </div>
           )
           : (

--- a/apps/client/src/components/automation-view/index.scss
+++ b/apps/client/src/components/automation-view/index.scss
@@ -5,6 +5,10 @@
     padding: 0;
   }
 
+  &__mobile-switcher-shell {
+    display: none;
+  }
+
   display: flex;
   height: 100%;
   overflow: hidden;
@@ -50,6 +54,49 @@
     &__right {
       margin-top: 0;
       margin-left: var(--subpage-content-card-gap);
+    }
+  }
+}
+
+@media (max-width: 960px) {
+  .automation-view--compact {
+    .automation-view__body {
+      gap: 0;
+    }
+
+    .automation-view__mobile-switcher-shell {
+      display: block;
+      padding: 12px;
+      padding-bottom: 0;
+    }
+
+    .automation-view__mobile-switcher {
+      width: 100%;
+
+      .ant-segmented-group {
+        gap: 4px;
+      }
+
+      .ant-segmented-item {
+        min-height: 32px;
+      }
+    }
+
+    .automation-view__left,
+    .automation-view__right {
+      width: auto;
+      min-width: 0;
+      max-width: none;
+      max-height: none;
+      margin: 12px;
+      margin-top: 12px;
+      border-radius: var(--subpage-content-card-radius);
+      background: var(--subpage-content-card-bg);
+      overflow: hidden;
+    }
+
+    .automation-view__right {
+      padding: 12px;
     }
   }
 }

--- a/apps/client/src/components/automation-view/index.tsx
+++ b/apps/client/src/components/automation-view/index.tsx
@@ -1,6 +1,6 @@
 import './index.scss'
 
-import { App } from 'antd'
+import { App, Segmented } from 'antd'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -17,6 +17,7 @@ import {
   updateAutomationRule
 } from '#~/api.js'
 import { PageShell } from '#~/components/layout/PageShell'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useQueryParams } from '#~/hooks/useQueryParams.js'
 
 import { RuleFormPanel } from './RuleFormPanel.js'
@@ -37,6 +38,7 @@ interface AutomationQueryParams extends Record<string, string> {
 export function AutomationView() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const navigate = useNavigate()
   const { data, mutate } = useSWR<{ rules: AutomationRule[] }>(
     '/api/automation/rules',
@@ -45,6 +47,8 @@ export function AutomationView() {
   const rules = data?.rules ?? []
   const [panelMode, setPanelMode] = useState<PanelMode>('view')
   const [submitting, setSubmitting] = useState(false)
+  const [mobilePanel, setMobilePanel] = useState<'rules' | 'details'>('rules')
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   const { values, update } = useQueryParams<AutomationQueryParams>({
     keys: ['rule', 'q', 'runQ', 'status', 'time', 'sort'],
@@ -90,23 +94,50 @@ export function AutomationView() {
     }
   }, [rules, update, values.rule])
 
+  useEffect(() => {
+    if (!isCompactView) return
+    if (panelMode !== 'view') {
+      setMobilePanel('details')
+      return
+    }
+    if (selectedRuleId == null) {
+      setMobilePanel('rules')
+    }
+  }, [isCompactView, panelMode, selectedRuleId])
+
   const handleSelectRule = useCallback((ruleId: string) => {
     setPanelMode('view')
     update({ rule: ruleId })
-  }, [update])
+    if (isCompactView) {
+      setMobilePanel('details')
+    }
+  }, [isCompactView, update])
 
   const handleCreateRule = useCallback(() => {
     setPanelMode('create')
-  }, [])
+    if (isCompactView) {
+      setMobilePanel('details')
+    }
+  }, [isCompactView])
 
   const handleEditRule = useCallback((rule: AutomationRule) => {
     setPanelMode('edit')
     update({ rule: rule.id })
-  }, [update])
+    if (isCompactView) {
+      setMobilePanel('details')
+    }
+  }, [isCompactView, update])
 
   const handleCancelForm = useCallback(() => {
     setPanelMode('view')
-  }, [])
+    if (isCompactView) {
+      setMobilePanel(selectedRuleId != null ? 'details' : 'rules')
+    }
+  }, [isCompactView, selectedRuleId])
+
+  const showRuleList = !isCompactView || mobilePanel === 'rules'
+  const showDetails = !isCompactView || mobilePanel === 'details'
+  const detailDisabled = panelMode === 'view' && selectedRule == null
 
   const handleSubmit = useCallback(async (
     payload: Partial<AutomationRule>,
@@ -174,56 +205,78 @@ export function AutomationView() {
   }, [message, mutate, t])
 
   return (
-    <PageShell className='automation-view' bodyClassName='automation-view__body'>
-      <div className='automation-view__left'>
-        <RuleSidebar
-          rules={rules}
-          selectedRuleId={selectedRuleId}
-          query={values.q}
-          isCreating={panelMode === 'create'}
-          onCreate={handleCreateRule}
-          onSelect={handleSelectRule}
-          onRun={handleRun}
-          onDelete={handleDelete}
-          onToggle={handleToggle}
-          onQueryChange={(value: string) => update({ q: value })}
-        />
-      </div>
-      <div className='automation-view__right'>
-        {panelMode === 'create' && (
-          <RuleFormPanel
-            mode='create'
-            rule={null}
-            submitting={submitting}
-            onSubmit={handleSubmit}
-            onCancel={handleCancelForm}
+    <PageShell
+      className={`automation-view ${isCompactView ? 'automation-view--compact' : ''}`}
+      bodyClassName='automation-view__body'
+    >
+      {isCompactView && (
+        <div className='automation-view__mobile-switcher-shell'>
+          <Segmented
+            block
+            className='automation-view__mobile-switcher'
+            value={mobilePanel}
+            onChange={(value) => setMobilePanel(value as 'rules' | 'details')}
+            options={[
+              { label: t('automation.mobileRules'), value: 'rules' },
+              { label: t('automation.mobileDetails'), value: 'details', disabled: detailDisabled }
+            ]}
           />
-        )}
-        {panelMode === 'edit' && (
-          <RuleFormPanel
-            mode='edit'
-            rule={selectedRule}
-            submitting={submitting}
-            onSubmit={handleSubmit}
-            onCancel={handleCancelForm}
+        </div>
+      )}
+      {showRuleList && (
+        <div className='automation-view__left'>
+          <RuleSidebar
+            rules={rules}
+            selectedRuleId={selectedRuleId}
+            query={values.q}
+            isCreating={panelMode === 'create'}
+            onCreate={handleCreateRule}
+            onSelect={handleSelectRule}
+            onRun={handleRun}
+            onDelete={handleDelete}
+            onToggle={handleToggle}
+            onQueryChange={(value: string) => update({ q: value })}
           />
-        )}
-        {panelMode === 'view' && (
-          <RunHistoryPanel
-            rule={selectedRule}
-            runs={runs}
-            runQuery={values.runQ}
-            statusFilter={values.status}
-            timeFilter={values.time}
-            sortOrder={values.sort}
-            onEditRule={handleEditRule}
-            onRunQueryChange={(value: string) => update({ runQ: value })}
-            onStatusFilterChange={(value: string) => update({ status: value })}
-            onTimeFilterChange={(value: string) => update({ time: value })}
-            onSortOrderChange={(value: string) => update({ sort: value })}
-          />
-        )}
-      </div>
+        </div>
+      )}
+      {showDetails && (
+        <div className='automation-view__right'>
+          {panelMode === 'create' && (
+            <RuleFormPanel
+              mode='create'
+              rule={null}
+              submitting={submitting}
+              onSubmit={handleSubmit}
+              onCancel={handleCancelForm}
+            />
+          )}
+          {panelMode === 'edit' && (
+            <RuleFormPanel
+              mode='edit'
+              rule={selectedRule}
+              submitting={submitting}
+              onSubmit={handleSubmit}
+              onCancel={handleCancelForm}
+            />
+          )}
+          {panelMode === 'view' && (
+            <RunHistoryPanel
+              compact={isCompactView}
+              rule={selectedRule}
+              runs={runs}
+              runQuery={values.runQ}
+              statusFilter={values.status}
+              timeFilter={values.time}
+              sortOrder={values.sort}
+              onEditRule={handleEditRule}
+              onRunQueryChange={(value: string) => update({ runQ: value })}
+              onStatusFilterChange={(value: string) => update({ status: value })}
+              onTimeFilterChange={(value: string) => update({ time: value })}
+              onSortOrderChange={(value: string) => update({ sort: value })}
+            />
+          )}
+        </div>
+      )}
     </PageShell>
   )
 }

--- a/apps/client/src/components/benchmark-view/BenchmarkCasePanel.scss
+++ b/apps/client/src/components/benchmark-view/BenchmarkCasePanel.scss
@@ -119,8 +119,8 @@
       align-items: flex-start;
     }
 
-    code,
-    span:last-child {
+    > code,
+    > span:last-child {
       max-width: 70%;
       text-align: right;
       white-space: pre-wrap;

--- a/apps/client/src/components/benchmark-view/BenchmarkView.scss
+++ b/apps/client/src/components/benchmark-view/BenchmarkView.scss
@@ -5,6 +5,10 @@
     padding: 0;
   }
 
+  &__mobile-switcher-shell {
+    display: none;
+  }
+
   display: flex;
   height: 100%;
   overflow: hidden;
@@ -73,6 +77,45 @@
   .benchmark-view {
     &__right {
       padding: 10px 12px;
+    }
+  }
+}
+
+@media (max-width: 960px) {
+  .benchmark-view--compact {
+    .benchmark-view__mobile-switcher-shell {
+      display: block;
+      padding: 12px;
+      padding-bottom: 0;
+    }
+
+    .benchmark-view__mobile-switcher {
+      width: 100%;
+
+      .ant-segmented-group {
+        gap: 4px;
+      }
+
+      .ant-segmented-item {
+        min-height: 32px;
+      }
+    }
+
+    .benchmark-view__left,
+    .benchmark-view__right {
+      width: auto;
+      min-width: 0;
+      max-width: none;
+      max-height: none;
+      margin: 12px;
+      margin-top: 12px;
+      border-radius: var(--subpage-content-card-radius);
+      background: var(--subpage-content-card-bg);
+      overflow: hidden;
+    }
+
+    .benchmark-view__right {
+      padding: 12px;
     }
   }
 }

--- a/apps/client/src/components/benchmark-view/index.tsx
+++ b/apps/client/src/components/benchmark-view/index.tsx
@@ -1,6 +1,6 @@
 import './BenchmarkView.scss'
 
-import { App } from 'antd'
+import { App, Segmented } from 'antd'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
@@ -14,6 +14,7 @@ import {
   startBenchmarkRun
 } from '#~/api.js'
 import { PageShell } from '#~/components/layout/PageShell'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useQueryParams } from '#~/hooks/useQueryParams.js'
 import type { BenchmarkCase } from '@vibe-forge/types'
 
@@ -25,12 +26,15 @@ import { isTerminalRun } from './utils.js'
 export function BenchmarkView() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
 
   // State
   const [activeRunId, setActiveRunId] = useState('')
   const [treeQuery, setTreeQuery] = useState('')
   const [expandedKeys, setExpandedKeys] = useState<string[]>([])
   const [checkedKeys, setCheckedKeys] = useState<string[]>([])
+  const [mobilePanel, setMobilePanel] = useState<'cases' | 'details'>('cases')
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   const { values, update } = useQueryParams<BenchmarkQueryParams>({
     keys: ['category', 'title'],
@@ -149,6 +153,13 @@ export function BenchmarkView() {
   }, [selectedCase, update, values.category, values.title])
 
   useEffect(() => {
+    if (!isCompactView) return
+    if (selectedCase == null) {
+      setMobilePanel('cases')
+    }
+  }, [isCompactView, selectedCase])
+
+  useEffect(() => {
     if (!isTerminalRun(activeRun)) return
     void mutateCases()
     void mutateCategories()
@@ -162,37 +173,65 @@ export function BenchmarkView() {
   }, [activeRun, activeRunId, message, mutateCases, mutateCategories, mutateResult, mutateRun, t])
 
   const checkedCaseCount = checkedKeys.filter(k => k.startsWith('case:')).length
+  const showCases = !isCompactView || mobilePanel === 'cases'
+  const showDetails = !isCompactView || mobilePanel === 'details'
 
   return (
-    <PageShell className='benchmark-view' bodyClassName='benchmark-view__body'>
-      <div className='benchmark-view__left'>
-        <BenchmarkSidebar
-          cases={cases}
-          categories={categories}
-          selectedCase={selectedCase}
-          query={treeQuery}
-          expandedKeys={expandedKeys}
-          checkedKeys={checkedKeys}
-          checkedCaseCount={checkedCaseCount}
-          onQueryChange={setTreeQuery}
-          onExpandedKeysChange={setExpandedKeys}
-          onCheckedKeysChange={setCheckedKeys}
-          onSelectCase={(category, title) => update({ category, title })}
-          onRunCase={(item) => void handleRunSpecificCase(item)}
-          onRunCategory={(category) => void handleRunCategory(category)}
-          onBatchRun={() => void handleBatchRun()}
-        />
-      </div>
-      <div className='benchmark-view__right'>
-        <BenchmarkCasePanel
-          selectedCase={selectedCase}
-          latestResult={latestResult}
-          activeRun={activeRun}
-          activeRunId={activeRunId}
-          progressPercent={progressPercent}
-          onRunCase={() => void (selectedCase && handleRunSpecificCase(selectedCase))}
-        />
-      </div>
+    <PageShell
+      className={`benchmark-view ${isCompactView ? 'benchmark-view--compact' : ''}`}
+      bodyClassName='benchmark-view__body'
+    >
+      {isCompactView && (
+        <div className='benchmark-view__mobile-switcher-shell'>
+          <Segmented
+            block
+            className='benchmark-view__mobile-switcher'
+            value={mobilePanel}
+            onChange={(value) => setMobilePanel(value as 'cases' | 'details')}
+            options={[
+              { label: t('benchmark.mobileCases'), value: 'cases' },
+              { label: t('benchmark.mobileDetails'), value: 'details', disabled: selectedCase == null }
+            ]}
+          />
+        </div>
+      )}
+      {showCases && (
+        <div className='benchmark-view__left'>
+          <BenchmarkSidebar
+            cases={cases}
+            categories={categories}
+            selectedCase={selectedCase}
+            query={treeQuery}
+            expandedKeys={expandedKeys}
+            checkedKeys={checkedKeys}
+            checkedCaseCount={checkedCaseCount}
+            onQueryChange={setTreeQuery}
+            onExpandedKeysChange={setExpandedKeys}
+            onCheckedKeysChange={setCheckedKeys}
+            onSelectCase={(category, title) => {
+              update({ category, title })
+              if (isCompactView) {
+                setMobilePanel('details')
+              }
+            }}
+            onRunCase={(item) => void handleRunSpecificCase(item)}
+            onRunCategory={(category) => void handleRunCategory(category)}
+            onBatchRun={() => void handleBatchRun()}
+          />
+        </div>
+      )}
+      {showDetails && (
+        <div className='benchmark-view__right'>
+          <BenchmarkCasePanel
+            selectedCase={selectedCase}
+            latestResult={latestResult}
+            activeRun={activeRun}
+            activeRunId={activeRunId}
+            progressPercent={progressPercent}
+            onRunCase={() => void (selectedCase && handleRunSpecificCase(selectedCase))}
+          />
+        </div>
+      )}
     </PageShell>
   )
 }

--- a/apps/client/src/components/chat/ChatComposerCard.scss
+++ b/apps/client/src/components/chat/ChatComposerCard.scss
@@ -3,6 +3,7 @@
   --chat-composer-card-border: var(--border-color);
 
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -30,6 +31,7 @@
 
   &__summary {
     width: 100%;
+    min-width: 0;
     margin: 0;
     border: none;
     min-height: 36px;
@@ -50,6 +52,7 @@
 
   &__content {
     display: grid;
+    min-width: 0;
     grid-template-rows: 0fr;
     opacity: 0;
     transition: grid-template-rows .24s ease, opacity .18s ease;
@@ -57,6 +60,7 @@
 
   &__body {
     min-height: 0;
+    min-width: 0;
     overflow: hidden;
     padding: 0 4px 4px;
   }

--- a/apps/client/src/components/chat/ChatHeader.scss
+++ b/apps/client/src/components/chat/ChatHeader.scss
@@ -30,6 +30,13 @@
     min-width: 0;
   }
 
+  &-leading-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
   &-title {
     font-weight: 600;
     color: var(--text-color);
@@ -41,6 +48,45 @@
   }
 }
 
+.chat-header.is-compact {
+  padding: 10px 12px 8px;
+  align-items: center;
+  gap: 8px;
+
+  .chat-header-main {
+    align-items: center;
+    gap: 8px;
+  }
+
+  .chat-header-leading-actions {
+    gap: 4px;
+  }
+
+  .chat-header-title {
+    line-height: 1.3;
+    white-space: nowrap;
+    display: block;
+  }
+
+  .chat-header-actions {
+    flex-shrink: 0;
+    margin-left: auto;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+
+  .chat-header-action-button.ant-btn.ant-btn-text {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+    border-radius: 8px;
+
+    .chat-header-view-option.material-symbols-rounded {
+      font-size: 18px;
+    }
+  }
+}
+
 .chat-header-icon.material-symbols-rounded {
   font-size: 18px;
 }
@@ -49,6 +95,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
 }
 
 .chat-header-action-button.ant-btn.ant-btn-text {
@@ -584,6 +631,146 @@ html.dark .chat-header-action-button.ant-btn.ant-btn-text {
 
 .session-debug-row__value.is-mono {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+@media (max-width: 768px) {
+  .session-settings-drawer {
+    gap: 10px;
+
+    .settings-section {
+      gap: 10px;
+
+      .section-header {
+        font-size: 11px;
+        letter-spacing: .08em;
+      }
+    }
+
+    &__form {
+      .config-view__field-row {
+        gap: 10px;
+        padding: 10px 12px;
+      }
+
+      .config-view__field-meta {
+        gap: 8px;
+      }
+
+      .config-view__field-title,
+      .config-view__field-desc {
+        white-space: normal;
+      }
+
+      .config-view__field-control {
+        min-width: 0;
+        width: 100%;
+      }
+
+      .config-view__array-list {
+        gap: 6px;
+      }
+
+      .config-view__array-item {
+        align-items: flex-start;
+      }
+
+      .config-view__icon-button--compact {
+        width: 30px;
+        min-width: 30px;
+        height: 30px;
+      }
+
+      .config-view__icon-button--full {
+        width: 100%;
+        min-width: 100%;
+        height: 36px;
+        justify-content: flex-start;
+        gap: 6px;
+        padding: 0 12px;
+        border-radius: 8px;
+        border: 1px dashed var(--border-color) !important;
+        background: var(--sub-bg-color) !important;
+        color: var(--sub-text-color) !important;
+        align-self: stretch;
+
+        &::after {
+          content: attr(aria-label);
+          font-size: 12px;
+          font-weight: 500;
+        }
+      }
+    }
+  }
+
+  .session-tool-groups {
+    gap: 10px;
+  }
+
+  .session-tool-group-card {
+    padding: 12px 12px 0;
+    border-radius: 12px;
+  }
+
+  .session-tool-group-card__header {
+    align-items: flex-start;
+    padding-bottom: 10px;
+  }
+
+  .session-tool-group-card__title {
+    gap: 8px;
+    font-size: 12px;
+
+    .material-symbols-rounded {
+      width: 24px;
+      height: 24px;
+      border-radius: 8px;
+      font-size: 14px;
+    }
+  }
+
+  .session-tool-group-card__meta {
+    gap: 6px;
+  }
+
+  .session-tool-group-card__count {
+    padding: 1px 6px;
+    font-size: 11px;
+  }
+
+  .session-tool-group-card__list {
+    max-height: none;
+    margin: 0 -12px;
+    padding: 0 12px;
+  }
+
+  .session-tool-row {
+    height: 34px;
+  }
+
+  .session-debug-panel {
+    padding: 0 10px;
+  }
+
+  .session-debug-row {
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 8px;
+    height: auto;
+    min-height: 34px;
+    padding: 6px 0;
+  }
+
+  .settings-footer {
+    gap: 16px;
+    padding-top: 16px;
+
+    .danger-zone {
+      .delete-session-row {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 12px;
+      }
+    }
+  }
 }
 
 html.dark {

--- a/apps/client/src/components/chat/ChatHeader.tsx
+++ b/apps/client/src/components/chat/ChatHeader.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ApiError, deleteSession, getApiErrorMessage, updateSession } from '../../api'
+import { useResponsiveLayout } from '../../hooks/use-responsive-layout'
 import { useQueryParams } from '../../hooks/useQueryParams'
 import { isSidebarCollapsedAtom, isSidebarResizingAtom } from '../../store/index'
 import { ConfigSectionPanel } from '../config'
@@ -51,6 +52,8 @@ export function ChatHeader({
   lastUserMessage,
   activeView,
   isTerminalOpen,
+  onCreateSession,
+  onOpenSidebar,
   onViewChange,
   onToggleTerminal
 }: {
@@ -65,11 +68,14 @@ export function ChatHeader({
   lastUserMessage?: string
   activeView: ChatHeaderView
   isTerminalOpen: boolean
+  onCreateSession?: () => void
+  onOpenSidebar?: () => void
   onViewChange: (view: ChatHeaderView) => void
   onToggleTerminal: () => void
 }) {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const isSidebarCollapsed = useAtomValue(isSidebarCollapsedAtom)
   const isResizing = useAtomValue(isSidebarResizingAtom)
   const { searchParams, update: updateQuery } = useQueryParams<{ debug: string }>({
@@ -83,6 +89,8 @@ export function ChatHeader({
   const hasDebugQuery = searchParams.has('debug')
   const isDebugMode = searchParams.get('debug') === 'true'
   const shouldShowDebugButton = hasDebugQuery
+  const hasSession = sessionId != null && sessionId !== ''
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
   const summary = sessionInfo?.type === 'summary' ? sessionInfo.summary : null
   const title = (sessionInfo?.type === 'init' ? sessionInfo.title : null) ?? sessionTitle
@@ -104,6 +112,7 @@ export function ChatHeader({
     { value: 'timeline' as const, icon: 'timeline', title: t('chat.viewTimeline') },
     { value: 'settings' as const, icon: 'tune', title: t('chat.viewSettings') }
   ]
+  const activeViewItem = viewItems.find((item) => item.value === activeView) ?? viewItems[0]!
 
   const handleToggleStar = async () => {
     if (sessionId == null || sessionId === '') return
@@ -147,6 +156,37 @@ export function ChatHeader({
       }
     }
   ]
+  const compactViewItems: MenuProps['items'] = viewItems.map((item) => ({
+    key: `view:${item.value}`,
+    label: item.title,
+    icon: <span className={`material-symbols-rounded chat-header-icon ${activeView === item.value ? 'is-filled' : ''}`}>
+      {item.icon}
+    </span>,
+    onClick: () => {
+      onViewChange(item.value)
+    }
+  }))
+  const compactMoreItems: MenuProps['items'] = [
+    {
+      key: 'terminal',
+      label: t('chat.viewTerminal'),
+      icon: <span className={`material-symbols-rounded chat-header-icon ${isTerminalOpen ? 'is-filled' : ''}`}>
+        terminal
+      </span>,
+      onClick: onToggleTerminal
+    },
+    ...moreItems,
+    ...(shouldShowDebugButton
+      ? [{
+        key: 'debug',
+        label: isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable'),
+        icon: <span className={`material-symbols-rounded chat-header-icon ${isDebugMode ? 'is-filled' : ''}`}>
+          bug_report
+        </span>,
+        onClick: toggleDebugMode
+      }]
+      : [])
+  ]
 
   useEffect(() => {
     return () => {
@@ -188,8 +228,40 @@ export function ChatHeader({
   }
 
   return (
-    <div className={`chat-header ${isSidebarCollapsed ? 'is-collapsed' : ''} ${isResizing ? 'is-resizing' : ''}`}>
+    <div
+      className={`chat-header ${isSidebarCollapsed ? 'is-collapsed' : ''} ${isResizing ? 'is-resizing' : ''} ${
+        isCompactLayout ? 'is-compact' : ''
+      }`}
+    >
       <div className='chat-header-main'>
+        {isCompactLayout && (
+          <div className='chat-header-leading-actions'>
+            {onOpenSidebar != null && (
+              <Tooltip title={resolveTooltipTitle(t('common.sessions'))}>
+                <Button
+                  type='text'
+                  className='chat-header-action-button'
+                  title={t('common.sessions')}
+                  aria-label={t('common.sessions')}
+                  onClick={onOpenSidebar}
+                  icon={<span className='chat-header-view-option material-symbols-rounded'>menu</span>}
+                />
+              </Tooltip>
+            )}
+            {onCreateSession != null && (
+              <Tooltip title={resolveTooltipTitle(t('common.newChat'))}>
+                <Button
+                  type='text'
+                  className={`chat-header-action-button ${!hasSession ? 'is-active' : ''}`}
+                  title={t('common.newChat')}
+                  aria-label={t('common.newChat')}
+                  onClick={onCreateSession}
+                  icon={<span className='chat-header-view-option material-symbols-rounded'>edit_square</span>}
+                />
+              </Tooltip>
+            )}
+          </div>
+        )}
         <div className='chat-header-info'>
           <div
             className='chat-header-title'
@@ -201,53 +273,92 @@ export function ChatHeader({
       </div>
 
       <div className='chat-header-actions'>
-        {viewItems.map(item => (
-          <Tooltip key={item.value} title={item.title}>
-            <Button
-              type='text'
-              className={`chat-header-action-button ${activeView === item.value ? 'is-active' : ''}`}
-              title={item.title}
-              aria-label={item.title}
-              onClick={() => {
-                onViewChange(item.value)
-              }}
-              icon={<span className='chat-header-view-option material-symbols-rounded'>{item.icon}</span>}
-            />
-          </Tooltip>
-        ))}
-        <Tooltip title={t('chat.viewTerminal')}>
-          <Button
-            type='text'
-            className={`chat-header-action-button ${isTerminalOpen ? 'is-active' : ''}`}
-            title={t('chat.viewTerminal')}
-            aria-label={t('chat.viewTerminal')}
-            onClick={onToggleTerminal}
-            icon={<span className='chat-header-view-option material-symbols-rounded'>terminal</span>}
-          />
-        </Tooltip>
-        {shouldShowDebugButton && (
-          <Tooltip title={isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable')}>
-            <Button
-              type='text'
-              className={`chat-header-action-button ${isDebugMode ? 'is-debug-active' : ''}`}
-              title={isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable')}
-              aria-label={isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable')}
-              onClick={toggleDebugMode}
-              icon={<span className='chat-header-view-option material-symbols-rounded'>bug_report</span>}
-            />
-          </Tooltip>
-        )}
-        <Tooltip title={t('common.moreActions')}>
-          <Dropdown menu={{ items: moreItems }} placement='bottomRight' trigger={['click']}>
-            <Button
-              type='text'
-              className='chat-header-action-button'
-              title={t('common.moreActions')}
-              aria-label={t('common.moreActions')}
-              icon={<span className='chat-header-view-option material-symbols-rounded'>more_vert</span>}
-            />
-          </Dropdown>
-        </Tooltip>
+        {isCompactLayout
+          ? (
+            <>
+              {hasSession && (
+                <Tooltip title={resolveTooltipTitle(activeViewItem.title)}>
+                  <Dropdown menu={{ items: compactViewItems }} placement='bottomRight' trigger={['click']}>
+                    <Button
+                      type='text'
+                      className='chat-header-action-button'
+                      title={activeViewItem.title}
+                      aria-label={activeViewItem.title}
+                      icon={
+                        <span className='chat-header-view-option material-symbols-rounded'>
+                          {activeViewItem.icon}
+                        </span>
+                      }
+                    />
+                  </Dropdown>
+                </Tooltip>
+              )}
+              {hasSession && (
+                <Tooltip title={resolveTooltipTitle(t('common.moreActions'))}>
+                  <Dropdown menu={{ items: compactMoreItems }} placement='bottomRight' trigger={['click']}>
+                    <Button
+                      type='text'
+                      className='chat-header-action-button'
+                      title={t('common.moreActions')}
+                      aria-label={t('common.moreActions')}
+                      icon={<span className='chat-header-view-option material-symbols-rounded'>more_vert</span>}
+                    />
+                  </Dropdown>
+                </Tooltip>
+              )}
+            </>
+          )
+          : (
+            <>
+              {viewItems.map(item => (
+                <Tooltip key={item.value} title={resolveTooltipTitle(item.title)}>
+                  <Button
+                    type='text'
+                    className={`chat-header-action-button ${activeView === item.value ? 'is-active' : ''}`}
+                    title={item.title}
+                    aria-label={item.title}
+                    onClick={() => {
+                      onViewChange(item.value)
+                    }}
+                    icon={<span className='chat-header-view-option material-symbols-rounded'>{item.icon}</span>}
+                  />
+                </Tooltip>
+              ))}
+              <Tooltip title={resolveTooltipTitle(t('chat.viewTerminal'))}>
+                <Button
+                  type='text'
+                  className={`chat-header-action-button ${isTerminalOpen ? 'is-active' : ''}`}
+                  title={t('chat.viewTerminal')}
+                  aria-label={t('chat.viewTerminal')}
+                  onClick={onToggleTerminal}
+                  icon={<span className='chat-header-view-option material-symbols-rounded'>terminal</span>}
+                />
+              </Tooltip>
+              {shouldShowDebugButton && (
+                <Tooltip title={resolveTooltipTitle(isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable'))}>
+                  <Button
+                    type='text'
+                    className={`chat-header-action-button ${isDebugMode ? 'is-debug-active' : ''}`}
+                    title={isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable')}
+                    aria-label={isDebugMode ? t('chat.debugDisable') : t('chat.debugEnable')}
+                    onClick={toggleDebugMode}
+                    icon={<span className='chat-header-view-option material-symbols-rounded'>bug_report</span>}
+                  />
+                </Tooltip>
+              )}
+              <Tooltip title={resolveTooltipTitle(t('common.moreActions'))}>
+                <Dropdown menu={{ items: moreItems }} placement='bottomRight' trigger={['click']}>
+                  <Button
+                    type='text'
+                    className='chat-header-action-button'
+                    title={t('common.moreActions')}
+                    aria-label={t('common.moreActions')}
+                    icon={<span className='chat-header-view-option material-symbols-rounded'>more_vert</span>}
+                  />
+                </Dropdown>
+              </Tooltip>
+            </>
+          )}
       </div>
     </div>
   )
@@ -263,6 +374,7 @@ export function SessionSettingsPanel({
   onClose: () => void
 }) {
   const { t } = useTranslation()
+  const { isCompactLayout } = useResponsiveLayout()
   const { message, modal } = App.useApp()
   const { searchParams } = useQueryParams<{ debug: string }>({ keys: ['debug'] })
   const isDebugMode = searchParams.get('debug') === 'true'
@@ -314,6 +426,27 @@ export function SessionSettingsPanel({
   const toolGroups = useMemo(() => getSessionToolGroups(sessionInfo), [sessionInfo])
   const assetWarnings = useMemo(() => getSessionAssetWarnings(sessionInfo), [sessionInfo])
   const selectionWarnings = useMemo(() => getSessionSelectionWarnings(sessionInfo), [sessionInfo])
+
+  useEffect(() => {
+    if (!isCompactLayout || toolGroups.length === 0) {
+      return
+    }
+
+    setCollapsedToolGroupKeys((prev) => {
+      const next = { ...prev }
+      let changed = false
+
+      for (const group of toolGroups) {
+        if (!(group.key in next)) {
+          next[group.key] = true
+          changed = true
+        }
+      }
+
+      return changed ? next : prev
+    })
+  }, [isCompactLayout, toolGroups])
+
   const debugItems = useMemo<SessionDebugItem[]>(() => {
     const emptyValue = t('chat.timelineEmptyValue')
     const booleanValue = (value: boolean | undefined) =>

--- a/apps/client/src/components/chat/ChatHistoryView.tsx
+++ b/apps/client/src/components/chat/ChatHistoryView.tsx
@@ -25,6 +25,7 @@ import type { ModelSelectMenuGroup, ModelSelectOption } from '#~/hooks/chat/use-
 import type { PermissionMode } from '#~/hooks/chat/use-chat-permission-mode'
 import { useChatScroll } from '#~/hooks/chat/use-chat-scroll'
 import { useChatSessionActions } from '#~/hooks/chat/use-chat-session-actions'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { getLoopedIndex } from '#~/hooks/use-roving-focus-list'
 import { CurrentTodoList } from './CurrentTodoList'
 import { NewSessionGuide } from './NewSessionGuide'
@@ -113,6 +114,7 @@ export function ChatHistoryView({
   const { t } = useTranslation()
   const { message } = App.useApp()
   const location = useLocation()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const { data: configRes } = useSWR<ConfigResponse>('/api/config', getConfig)
   const configWorkspaceDraft = useMemo(
     () => getChatSessionWorkspaceDraftFromConfig(configRes),
@@ -336,6 +338,7 @@ export function ChatHistoryView({
     }
   }
   const isInlineEditing = editingMessageId != null
+  const shouldShowNewSessionGuide = !session?.id && messages.length === 0 && historyStatusNotices.length === 0
   const renderItems = useMemo(() => processMessages(messages), [messages])
   const hashAnchorId = useMemo(() => decodeURIComponent(location.hash.replace(/^#/, '')), [location.hash])
   const targetAnchorId = useMemo(() => {
@@ -571,6 +574,8 @@ export function ChatHistoryView({
           originalMessage={item.originalMessage}
           sessionInfo={sessionInfo}
           isEditing={editingMessageId === item.originalMessage.id}
+          isCompactLayout={isCompactLayout}
+          isTouchInteraction={isTouchInteraction}
           isSessionBusy={isCreating || session?.status === 'running' ||
             session?.status === 'waiting_input'}
           showAssistantActions={item.anchorId === lastAssistantActionAnchorId}
@@ -651,8 +656,14 @@ export function ChatHistoryView({
         )}
       </div>
 
-      {!session?.id && messages.length === 0 && historyStatusNotices.length === 0 && (
+      {shouldShowNewSessionGuide && !isCompactLayout && (
         <div className='new-session-guide-wrapper'>
+          <NewSessionGuide />
+        </div>
+      )}
+
+      {shouldShowNewSessionGuide && isCompactLayout && (
+        <div className='new-session-guide-wrapper is-compact-layout'>
           <NewSessionGuide />
         </div>
       )}

--- a/apps/client/src/components/chat/ChatTimelineView.scss
+++ b/apps/client/src/components/chat/ChatTimelineView.scss
@@ -5,13 +5,26 @@
   min-height: 0;
   padding: 6px 12px 12px;
   overflow: auto;
+  min-width: 0;
+  overscroll-behavior: contain;
+}
+
+.chat-timeline-view__tabs {
+  display: none;
+}
+
+.chat-timeline-view__panel {
+  min-width: 0;
+  min-height: 0;
 }
 
 .session-timeline-section {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow: scroll;
+  min-width: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
 }
 
 .session-timeline-section--fixed {
@@ -31,11 +44,13 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   overflow: hidden;
 }
 
 .session-timeline-column--graph {
   overflow: auto;
+  overscroll-behavior: contain;
 }
 
 .session-timeline-column--events {
@@ -51,4 +66,82 @@
 .session-timeline-column > .session-timeline-panel,
 .session-timeline-column > .session-timeline-event-table {
   flex: 1 1 auto;
+}
+
+@media (max-width: 960px) {
+  .chat-timeline-view {
+    padding: 6px 8px 8px;
+    gap: 12px;
+  }
+
+  .chat-timeline-view--compact {
+    gap: 8px;
+  }
+
+  .chat-timeline-view__tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--bg-color);
+  }
+
+  .chat-timeline-view__tab {
+    min-width: 0;
+    min-height: 34px;
+    padding: 7px 6px;
+    border: 0;
+    border-right: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--sub-text-color);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.2;
+    text-align: center;
+
+    &:last-child {
+      border-right: 0;
+    }
+
+    &.is-active {
+      background: var(--nav-active-bg, #eff6ff);
+      color: var(--nav-active-text, #2563eb);
+    }
+  }
+
+  .chat-timeline-view__panel {
+    display: flex;
+    flex: 1 1 auto;
+  }
+
+  .chat-timeline-view__panel--diagram {
+    min-height: 320px;
+  }
+
+  .chat-timeline-view__panel > .session-timeline-panel,
+  .chat-timeline-view__panel > .session-timeline-event-table {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .session-timeline-section {
+    overflow: visible;
+  }
+
+  .session-timeline-section--fixed {
+    flex-basis: auto;
+  }
+
+  .session-timeline-section--row {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .session-timeline-column--graph,
+  .session-timeline-column--events {
+    flex: 1 1 auto;
+  }
 }

--- a/apps/client/src/components/chat/ChatTimelineView.tsx
+++ b/apps/client/src/components/chat/ChatTimelineView.tsx
@@ -1,9 +1,11 @@
 import './ChatTimelineView.scss'
 
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import type { ChatMessage } from '@vibe-forge/core'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { SessionTimelinePanel } from './session-timeline-panel'
 import { SessionTimelineEventList } from './session-timeline-panel/EventList'
 import type { Task } from './session-timeline-panel/types'
@@ -134,6 +136,46 @@ export function ChatTimelineView({
 }: {
   messages: ChatMessage[]
 }) {
+  const { t } = useTranslation()
+  const { isCompactLayout } = useResponsiveLayout()
+  const [compactView, setCompactView] = React.useState<'events' | 'gantt' | 'git'>('events')
+
+  if (isCompactLayout) {
+    const compactViews = [
+      { key: 'events' as const, label: t('chat.timeline.eventListTitle') },
+      { key: 'gantt' as const, label: t('chat.timeline.viewGantt') },
+      { key: 'git' as const, label: t('chat.timeline.viewGit') }
+    ]
+    return (
+      <div className='chat-timeline-view chat-timeline-view--compact'>
+        <div className='chat-timeline-view__tabs' role='tablist' aria-label={t('chat.timelineTiming')}>
+          {compactViews.map((item) => (
+            <button
+              key={item.key}
+              type='button'
+              role='tab'
+              aria-selected={compactView === item.key}
+              className={`chat-timeline-view__tab ${compactView === item.key ? 'is-active' : ''}`}
+              onClick={() => setCompactView(item.key)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <section
+          className={`chat-timeline-view__panel ${
+            compactView === 'events' ? 'chat-timeline-view__panel--events' : 'chat-timeline-view__panel--diagram'
+          }`}
+        >
+          {compactView === 'events' && <SessionTimelineEventList task={mockTimelineTask} />}
+          {compactView === 'gantt' && <SessionTimelinePanel task={mockTimelineTask} viewMode='gantt' />}
+          {compactView === 'git' && <SessionTimelinePanel task={mockTimelineTask} viewMode='git' />}
+        </section>
+      </div>
+    )
+  }
+
   return (
     <div className='chat-timeline-view'>
       <section className='session-timeline-section session-timeline-section--fixed'>

--- a/apps/client/src/components/chat/NewSessionGuide.scss
+++ b/apps/client/src/components/chat/NewSessionGuide.scss
@@ -1,6 +1,7 @@
 .new-session-guide {
   width: 100%;
   max-width: 1100px;
+  min-width: 0;
 }
 
 .new-session-guide__announcements {
@@ -117,7 +118,10 @@
   flex-direction: column;
   gap: 12px;
   height: 160px;
-  overflow: scroll;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 .new-session-guide__list {
@@ -201,8 +205,142 @@
   color: var(--sub-text-color);
 }
 
+.new-session-guide__more {
+  font-size: 11px;
+  color: var(--sub-text-color);
+  line-height: 1.4;
+}
+
+.new-session-guide__compact-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--tag-bg);
+  overflow: hidden;
+}
+
+.new-session-guide__compact-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  padding: 12px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--border-color);
+  }
+}
+
+.new-session-guide__compact-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.new-session-guide__compact-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.new-session-guide__compact-primary-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.new-session-guide__compact-primary-desc {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--sub-text-color);
+  overflow-wrap: anywhere;
+}
+
+.new-session-guide__compact-help-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--sub-text-color);
+
+  > span:last-child {
+    overflow-wrap: anywhere;
+  }
+}
+
+.new-session-guide__compact-inline-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+
+  .new-session-guide__empty-desc {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
 @media (max-width: 1100px) {
   .new-session-guide__grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 960px) {
+  .new-session-guide--compact {
+    max-width: none;
+  }
+
+  .new-session-guide--compact .new-session-guide__announcements {
+    margin-bottom: 12px;
+    padding: 10px 12px;
+    border-radius: 8px;
+  }
+
+  .new-session-guide--compact .new-session-guide__grid {
+    gap: 12px;
+  }
+
+  .new-session-guide--compact .new-session-guide__compact-inline-actions {
+    align-items: flex-start;
+  }
+
+  .new-session-guide--compact
+    .new-session-guide__compact-inline-actions
+    .ant-btn {
+    flex-shrink: 0;
+  }
+
+  .new-session-guide--compact .new-session-guide__compact-row {
+    gap: 6px;
+    padding: 10px 12px;
+  }
+
+  .new-session-guide--compact .new-session-guide__compact-primary-desc {
+    display: none;
+  }
+
+  .new-session-guide--compact .new-session-guide__compact-help-item {
+    line-height: 1.35;
+  }
+
+  .new-session-guide--compact .new-session-guide__compact-primary-desc,
+  .new-session-guide--compact
+    .new-session-guide__compact-help-item
+    > span:last-child,
+  .new-session-guide--compact .new-session-guide__announcements-item > span {
+    overflow-wrap: anywhere;
   }
 }

--- a/apps/client/src/components/chat/NewSessionGuide.tsx
+++ b/apps/client/src/components/chat/NewSessionGuide.tsx
@@ -1,16 +1,20 @@
 import './NewSessionGuide.scss'
 
-import { App, Button } from 'antd'
+import { App } from 'antd'
 import { useAtom } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
 
 import type { EntitySummary, SpecSummary } from '#~/api.js'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { showAnnouncementsAtom } from '#~/store/index.js'
+import { NewSessionGuideCompactPanel } from './NewSessionGuideCompactPanel'
+import { NewSessionGuideGrid } from './NewSessionGuideGrid'
 
 export function NewSessionGuide() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout } = useResponsiveLayout()
   const [showAnnouncements, setShowAnnouncements] = useAtom(showAnnouncementsAtom)
 
   const { data: specsRes } = useSWR<{ specs: SpecSummary[] }>('/api/ai/specs')
@@ -39,6 +43,19 @@ export function NewSessionGuide() {
     t('chat.newSessionGuide.help.item2'),
     t('chat.newSessionGuide.help.item3')
   ]
+  const visibleAnnouncements = isCompactLayout ? announcements.slice(0, 1) : announcements
+  const visibleSpecs = isCompactLayout ? alwaysSpecs.slice(0, 1) : alwaysSpecs
+  const visibleEntities = isCompactLayout ? entities.slice(0, 1) : entities
+  const visibleHelpItems = isCompactLayout ? helpItems.slice(0, 1) : helpItems
+  const hiddenAnnouncementCount = Math.max(announcements.length - visibleAnnouncements.length, 0)
+  const hiddenSpecCount = Math.max(alwaysSpecs.length - visibleSpecs.length, 0)
+  const hiddenEntityCount = Math.max(entities.length - visibleEntities.length, 0)
+  const hiddenHelpCount = Math.max(helpItems.length - visibleHelpItems.length, 0)
+
+  const renderMoreCount = (count: number) =>
+    count > 0
+      ? <div className='new-session-guide__more'>{t('chat.newSessionGuide.moreCount', { count })}</div>
+      : null
 
   const handleCreateSpec = () => {
     message.info(t('chat.newSessionGuide.specs.createToast'))
@@ -49,7 +66,7 @@ export function NewSessionGuide() {
   }
 
   return (
-    <div className='new-session-guide'>
+    <div className={`new-session-guide ${isCompactLayout ? 'new-session-guide--compact' : ''}`}>
       {showAnnouncements && announcements.length > 0 && (
         <div className='new-session-guide__announcements'>
           <div className='new-session-guide__announcements-header'>
@@ -66,112 +83,52 @@ export function NewSessionGuide() {
             </button>
           </div>
           <div className='new-session-guide__announcements-list'>
-            {announcements.map((item, index) => (
+            {visibleAnnouncements.map((item, index) => (
               <div key={`${item}-${index}`} className='new-session-guide__announcements-item'>
                 <span>{item}</span>
               </div>
             ))}
+            {renderMoreCount(hiddenAnnouncementCount)}
           </div>
         </div>
       )}
-      <div className='new-session-guide__grid'>
-        <div className='new-session-guide__card'>
-          <div className='new-session-guide__header'>
-            <div className='new-session-guide__title'>
-              <span className='material-symbols-rounded new-session-guide__title-icon'>account_tree</span>
-              <span>{t('chat.newSessionGuide.specs.title')}</span>
-            </div>
-            <div className='new-session-guide__count'>{alwaysSpecs.length}</div>
-          </div>
-          <div className='new-session-guide__body'>
-            {!isSpecsReady && (
-              <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
-            )}
-            {isSpecsReady && alwaysSpecs.length > 0 && (
-              <div className='new-session-guide__list'>
-                {alwaysSpecs.map((spec) => (
-                  <div key={spec.id} className='new-session-guide__item'>
-                    <div className='new-session-guide__item-title'>
-                      <span>{spec.name}</span>
-                    </div>
-                    <div className='new-session-guide__item-desc'>{spec.description}</div>
-                    {spec.params.length > 0 && (
-                      <div className='new-session-guide__meta'>
-                        {t('chat.newSessionGuide.specs.params', { count: spec.params.length })}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-            {isSpecsReady && alwaysSpecs.length === 0 && (
-              <div className='new-session-guide__empty'>
-                <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.specs.empty')}</div>
-                <Button type='primary' size='small' onClick={handleCreateSpec}>
-                  {t('chat.newSessionGuide.specs.create')}
-                </Button>
-              </div>
-            )}
-          </div>
-        </div>
 
-        <div className='new-session-guide__card'>
-          <div className='new-session-guide__header'>
-            <div className='new-session-guide__title'>
-              <span className='material-symbols-rounded new-session-guide__title-icon'>group_work</span>
-              <span>{t('chat.newSessionGuide.entities.title')}</span>
-            </div>
-            <div className='new-session-guide__count'>{entities.length}</div>
-          </div>
-          <div className='new-session-guide__body'>
-            {!isEntitiesReady && (
-              <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
-            )}
-            {isEntitiesReady && entities.length > 0 && (
-              <div className='new-session-guide__list'>
-                {entities.map((entity) => (
-                  <div key={entity.id} className='new-session-guide__item'>
-                    <div className='new-session-guide__item-title'>
-                      <span>{entity.name}</span>
-                    </div>
-                    <div className='new-session-guide__item-desc'>{entity.description}</div>
-                  </div>
-                ))}
-              </div>
-            )}
-            {isEntitiesReady && entities.length === 0 && (
-              <div className='new-session-guide__empty'>
-                <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.entities.empty')}</div>
-                <Button type='primary' size='small' onClick={handleCreateEntity}>
-                  {t('chat.newSessionGuide.entities.create')}
-                </Button>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className='new-session-guide__card'>
-          <div className='new-session-guide__header'>
-            <div className='new-session-guide__title'>
-              <span className='material-symbols-rounded new-session-guide__title-icon'>tips_and_updates</span>
-              <span>{t('chat.newSessionGuide.help.title')}</span>
-            </div>
-          </div>
-          <div className='new-session-guide__body'>
-            <div className='new-session-guide__help'>
-              {helpItems.map(item => (
-                <div key={item} className='new-session-guide__help-item'>
-                  <span className='material-symbols-rounded new-session-guide__help-icon'>check_circle</span>
-                  <span>{item}</span>
-                </div>
-              ))}
-            </div>
-            <div className='new-session-guide__help-footer'>
-              {t('chat.newSessionGuide.help.footer')}
-            </div>
-          </div>
-        </div>
-      </div>
+      {isCompactLayout
+        ? (
+          <NewSessionGuideCompactPanel
+            alwaysSpecs={alwaysSpecs}
+            entities={entities}
+            helpItems={helpItems}
+            hiddenEntityCount={hiddenEntityCount}
+            hiddenHelpCount={hiddenHelpCount}
+            hiddenSpecCount={hiddenSpecCount}
+            isEntitiesReady={isEntitiesReady}
+            isSpecsReady={isSpecsReady}
+            onCreateEntity={handleCreateEntity}
+            onCreateSpec={handleCreateSpec}
+            renderMoreCount={renderMoreCount}
+            visibleEntities={visibleEntities}
+            visibleHelpItems={visibleHelpItems}
+            visibleSpecs={visibleSpecs}
+          />
+        )
+        : (
+          <NewSessionGuideGrid
+            alwaysSpecs={alwaysSpecs}
+            entities={entities}
+            hiddenEntityCount={hiddenEntityCount}
+            hiddenHelpCount={hiddenHelpCount}
+            hiddenSpecCount={hiddenSpecCount}
+            isEntitiesReady={isEntitiesReady}
+            isSpecsReady={isSpecsReady}
+            onCreateEntity={handleCreateEntity}
+            onCreateSpec={handleCreateSpec}
+            renderMoreCount={renderMoreCount}
+            visibleEntities={visibleEntities}
+            visibleHelpItems={visibleHelpItems}
+            visibleSpecs={visibleSpecs}
+          />
+        )}
     </div>
   )
 }

--- a/apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx
+++ b/apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx
@@ -1,0 +1,130 @@
+import { Button } from 'antd'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { EntitySummary, SpecSummary } from '#~/api.js'
+
+export function NewSessionGuideCompactPanel({
+  alwaysSpecs,
+  entities,
+  helpItems,
+  hiddenEntityCount,
+  hiddenHelpCount,
+  hiddenSpecCount,
+  isEntitiesReady,
+  isSpecsReady,
+  onCreateEntity,
+  onCreateSpec,
+  renderMoreCount,
+  visibleEntities,
+  visibleHelpItems,
+  visibleSpecs
+}: {
+  alwaysSpecs: SpecSummary[]
+  entities: EntitySummary[]
+  helpItems: string[]
+  hiddenEntityCount: number
+  hiddenHelpCount: number
+  hiddenSpecCount: number
+  isEntitiesReady: boolean
+  isSpecsReady: boolean
+  onCreateEntity: () => void
+  onCreateSpec: () => void
+  renderMoreCount: (count: number) => ReactNode
+  visibleEntities: EntitySummary[]
+  visibleHelpItems: string[]
+  visibleSpecs: SpecSummary[]
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <div className='new-session-guide__compact-panel'>
+      <div className='new-session-guide__compact-row'>
+        <div className='new-session-guide__compact-row-header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>account_tree</span>
+            <span>{t('chat.newSessionGuide.specs.title')}</span>
+          </div>
+          <div className='new-session-guide__count'>{alwaysSpecs.length}</div>
+        </div>
+
+        {!isSpecsReady && (
+          <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
+        )}
+
+        {isSpecsReady && alwaysSpecs.length > 0 && visibleSpecs[0] != null && (
+          <div className='new-session-guide__compact-row-main'>
+            <div className='new-session-guide__compact-primary-title'>{visibleSpecs[0].name}</div>
+            <div className='new-session-guide__compact-primary-desc'>{visibleSpecs[0].description}</div>
+            {visibleSpecs[0].params.length > 0 && (
+              <div className='new-session-guide__meta'>
+                {t('chat.newSessionGuide.specs.params', { count: visibleSpecs[0].params.length })}
+              </div>
+            )}
+            {renderMoreCount(hiddenSpecCount)}
+          </div>
+        )}
+
+        {isSpecsReady && alwaysSpecs.length === 0 && (
+          <div className='new-session-guide__compact-inline-actions'>
+            <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.specs.empty')}</div>
+            <Button type='primary' size='small' onClick={onCreateSpec}>
+              {t('chat.newSessionGuide.specs.create')}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className='new-session-guide__compact-row'>
+        <div className='new-session-guide__compact-row-header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>group_work</span>
+            <span>{t('chat.newSessionGuide.entities.title')}</span>
+          </div>
+          <div className='new-session-guide__count'>{entities.length}</div>
+        </div>
+
+        {!isEntitiesReady && (
+          <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
+        )}
+
+        {isEntitiesReady && entities.length > 0 && visibleEntities[0] != null && (
+          <div className='new-session-guide__compact-row-main'>
+            <div className='new-session-guide__compact-primary-title'>{visibleEntities[0].name}</div>
+            <div className='new-session-guide__compact-primary-desc'>{visibleEntities[0].description}</div>
+            {renderMoreCount(hiddenEntityCount)}
+          </div>
+        )}
+
+        {isEntitiesReady && entities.length === 0 && (
+          <div className='new-session-guide__compact-inline-actions'>
+            <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.entities.empty')}</div>
+            <Button type='primary' size='small' onClick={onCreateEntity}>
+              {t('chat.newSessionGuide.entities.create')}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className='new-session-guide__compact-row'>
+        <div className='new-session-guide__compact-row-header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>tips_and_updates</span>
+            <span>{t('chat.newSessionGuide.help.title')}</span>
+          </div>
+          <div className='new-session-guide__count'>{helpItems.length}</div>
+        </div>
+
+        <div className='new-session-guide__compact-row-main'>
+          {visibleHelpItems[0] != null && (
+            <div className='new-session-guide__compact-help-item'>
+              <span className='material-symbols-rounded new-session-guide__help-icon'>check_circle</span>
+              <span>{visibleHelpItems[0]}</span>
+            </div>
+          )}
+          {renderMoreCount(hiddenHelpCount)}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/client/src/components/chat/NewSessionGuideGrid.tsx
+++ b/apps/client/src/components/chat/NewSessionGuideGrid.tsx
@@ -1,0 +1,141 @@
+import { Button } from 'antd'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { EntitySummary, SpecSummary } from '#~/api.js'
+
+export function NewSessionGuideGrid({
+  alwaysSpecs,
+  entities,
+  hiddenEntityCount,
+  hiddenHelpCount,
+  hiddenSpecCount,
+  isEntitiesReady,
+  isSpecsReady,
+  onCreateEntity,
+  onCreateSpec,
+  renderMoreCount,
+  visibleEntities,
+  visibleHelpItems,
+  visibleSpecs
+}: {
+  alwaysSpecs: SpecSummary[]
+  entities: EntitySummary[]
+  hiddenEntityCount: number
+  hiddenHelpCount: number
+  hiddenSpecCount: number
+  isEntitiesReady: boolean
+  isSpecsReady: boolean
+  onCreateEntity: () => void
+  onCreateSpec: () => void
+  renderMoreCount: (count: number) => ReactNode
+  visibleEntities: EntitySummary[]
+  visibleHelpItems: string[]
+  visibleSpecs: SpecSummary[]
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <div className='new-session-guide__grid'>
+      <div className='new-session-guide__card'>
+        <div className='new-session-guide__header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>account_tree</span>
+            <span>{t('chat.newSessionGuide.specs.title')}</span>
+          </div>
+          <div className='new-session-guide__count'>{alwaysSpecs.length}</div>
+        </div>
+        <div className='new-session-guide__body'>
+          {!isSpecsReady && (
+            <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
+          )}
+          {isSpecsReady && alwaysSpecs.length > 0 && (
+            <div className='new-session-guide__list'>
+              {visibleSpecs.map((spec) => (
+                <div key={spec.id} className='new-session-guide__item'>
+                  <div className='new-session-guide__item-title'>
+                    <span>{spec.name}</span>
+                  </div>
+                  <div className='new-session-guide__item-desc'>{spec.description}</div>
+                  {spec.params.length > 0 && (
+                    <div className='new-session-guide__meta'>
+                      {t('chat.newSessionGuide.specs.params', { count: spec.params.length })}
+                    </div>
+                  )}
+                </div>
+              ))}
+              {renderMoreCount(hiddenSpecCount)}
+            </div>
+          )}
+          {isSpecsReady && alwaysSpecs.length === 0 && (
+            <div className='new-session-guide__empty'>
+              <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.specs.empty')}</div>
+              <Button type='primary' size='small' onClick={onCreateSpec}>
+                {t('chat.newSessionGuide.specs.create')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className='new-session-guide__card'>
+        <div className='new-session-guide__header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>group_work</span>
+            <span>{t('chat.newSessionGuide.entities.title')}</span>
+          </div>
+          <div className='new-session-guide__count'>{entities.length}</div>
+        </div>
+        <div className='new-session-guide__body'>
+          {!isEntitiesReady && (
+            <div className='new-session-guide__loading'>{t('chat.newSessionGuide.loading')}</div>
+          )}
+          {isEntitiesReady && entities.length > 0 && (
+            <div className='new-session-guide__list'>
+              {visibleEntities.map((entity) => (
+                <div key={entity.id} className='new-session-guide__item'>
+                  <div className='new-session-guide__item-title'>
+                    <span>{entity.name}</span>
+                  </div>
+                  <div className='new-session-guide__item-desc'>{entity.description}</div>
+                </div>
+              ))}
+              {renderMoreCount(hiddenEntityCount)}
+            </div>
+          )}
+          {isEntitiesReady && entities.length === 0 && (
+            <div className='new-session-guide__empty'>
+              <div className='new-session-guide__empty-desc'>{t('chat.newSessionGuide.entities.empty')}</div>
+              <Button type='primary' size='small' onClick={onCreateEntity}>
+                {t('chat.newSessionGuide.entities.create')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className='new-session-guide__card'>
+        <div className='new-session-guide__header'>
+          <div className='new-session-guide__title'>
+            <span className='material-symbols-rounded new-session-guide__title-icon'>tips_and_updates</span>
+            <span>{t('chat.newSessionGuide.help.title')}</span>
+          </div>
+        </div>
+        <div className='new-session-guide__body'>
+          <div className='new-session-guide__help'>
+            {visibleHelpItems.map(item => (
+              <div key={item} className='new-session-guide__help-item'>
+                <span className='material-symbols-rounded new-session-guide__help-icon'>check_circle</span>
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+          {renderMoreCount(hiddenHelpCount)}
+          <div className='new-session-guide__help-footer'>
+            {t('chat.newSessionGuide.help.footer')}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/client/src/components/chat/git-controls/BranchSwitcherDropdown.tsx
+++ b/apps/client/src/components/chat/git-controls/BranchSwitcherDropdown.tsx
@@ -9,6 +9,7 @@ import { BranchSwitcherResults } from './BranchSwitcherResults'
 export function BranchSwitcherDropdown({
   availableLocalBranches,
   currentBranchLabel,
+  compact = false,
   isBusy,
   isLoading,
   open,
@@ -24,6 +25,7 @@ export function BranchSwitcherDropdown({
   onSwitchBranch
 }: {
   availableLocalBranches: GitBranchSummary[]
+  compact?: boolean
   currentBranchLabel: string
   isBusy: boolean
   isLoading: boolean
@@ -142,7 +144,9 @@ export function BranchSwitcherDropdown({
     >
       <Button
         type='text'
-        className={`chat-header-git__trigger ${open ? 'is-open' : ''} ${isBusy ? 'is-disabled' : ''}`}
+        className={`chat-header-git__trigger chat-header-git__trigger--branch ${open ? 'is-open' : ''} ${
+          isBusy ? 'is-disabled' : ''
+        } ${compact ? 'is-compact' : ''}`.trim()}
         title={t('chat.gitBranchSwitcher')}
         aria-label={t('chat.gitBranchSwitcher')}
       >

--- a/apps/client/src/components/chat/git-controls/ChatGitControls.scss
+++ b/apps/client/src/components/chat/git-controls/ChatGitControls.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
 }
 
 .chat-draft-git {
@@ -10,6 +11,11 @@
   align-items: center;
   gap: 0;
   min-width: max-content;
+}
+
+.chat-header-git--compact,
+.chat-draft-git--compact .chat-header-git {
+  gap: 4px;
 }
 
 .chat-draft-git__controls {
@@ -146,6 +152,83 @@
   white-space: nowrap;
   font-size: 11px;
   font-weight: 500;
+}
+
+.chat-header-git__trigger--worktree.is-compact .chat-header-git__trigger-label {
+  display: none;
+}
+
+.chat-header-git__trigger.ant-btn.ant-btn-text.chat-header-git__trigger--worktree.is-compact {
+  width: 24px;
+  min-width: 24px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
+
+  .chat-header-git__trigger-main {
+    width: 100%;
+    justify-content: center;
+    gap: 0;
+  }
+
+  .chat-header-git__trigger-chevron {
+    display: none;
+  }
+}
+
+.chat-header-git__trigger.ant-btn.ant-btn-text.chat-header-git__trigger--branch.is-compact {
+  width: 24px;
+  min-width: 24px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
+
+  .chat-header-git__trigger-label,
+  .chat-header-git__dirty-dot {
+    display: none;
+  }
+
+  .chat-header-git__trigger-main {
+    width: 100%;
+    justify-content: center;
+    gap: 0;
+  }
+
+  .chat-header-git__trigger-chevron {
+    display: none;
+  }
+}
+
+.chat-header-git__split--operations.is-compact {
+  gap: 4px;
+
+  .chat-header-git__split-main.ant-btn.ant-btn-text {
+    width: 24px;
+    min-width: 24px;
+    padding: 0;
+    justify-content: center;
+    gap: 0;
+    border-radius: 6px;
+
+    .chat-header-git__trigger-label {
+      display: none;
+    }
+  }
+
+  .chat-header-git__split-divider {
+    display: none;
+  }
+
+  .chat-header-git__split-toggle.ant-btn.ant-btn-text {
+    width: 24px;
+    min-width: 24px;
+    padding: 0;
+    justify-content: center;
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 6px;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+  }
 }
 
 .chat-header-git__separator {

--- a/apps/client/src/components/chat/git-controls/ChatGitControls.tsx
+++ b/apps/client/src/components/chat/git-controls/ChatGitControls.tsx
@@ -12,9 +12,11 @@ import { GitWorktreeDropdown } from './GitWorktreeDropdown'
 import { useChatGitControls } from './use-chat-git-controls'
 
 export function ChatGitControls({
+  compact = false,
   placement = 'bottomLeft',
   sessionId
 }: {
+  compact?: boolean
   placement?: 'bottomLeft' | 'topLeft'
   sessionId: string
 }) {
@@ -27,8 +29,9 @@ export function ChatGitControls({
 
   return (
     <>
-      <div className='chat-header-git'>
+      <div className={`chat-header-git ${compact ? 'chat-header-git--compact' : ''}`.trim()}>
         <GitWorktreeDropdown
+          compact={compact}
           open={git.worktreeMenuOpen}
           placement={placement}
           workspace={git.workspace}
@@ -57,6 +60,7 @@ export function ChatGitControls({
         {git.repoState?.available === true && (
           <>
             <GitOperationsDropdown
+              compact={compact}
               isBusy={git.isBusy}
               open={git.operationsMenuOpen}
               placement={placement}
@@ -86,6 +90,7 @@ export function ChatGitControls({
 
             <BranchSwitcherDropdown
               availableLocalBranches={git.availableLocalBranches}
+              compact={compact}
               currentBranchLabel={git.currentBranchLabel}
               isBusy={git.isBusy}
               isLoading={git.isBranchListLoading}

--- a/apps/client/src/components/chat/git-controls/DraftGitControls.tsx
+++ b/apps/client/src/components/chat/git-controls/DraftGitControls.tsx
@@ -9,11 +9,13 @@ import { GitWorktreeDropdown } from './GitWorktreeDropdown'
 import { useChatDraftGitControls } from './use-chat-draft-git-controls'
 
 export function DraftGitControls({
+  compact = false,
   disabled = false,
   draft,
   placement = 'topLeft',
   onChange
 }: {
+  compact?: boolean
   disabled?: boolean
   draft: ChatSessionWorkspaceDraft
   placement?: 'bottomLeft' | 'topLeft'
@@ -26,11 +28,12 @@ export function DraftGitControls({
   })
 
   return (
-    <div className='chat-draft-git'>
+    <div className={`chat-draft-git ${compact ? 'chat-draft-git--compact' : ''}`.trim()}>
       {git.repoState.available
         ? (
           <div className='chat-header-git chat-draft-git__controls'>
             <GitWorktreeDropdown
+              compact={compact}
               currentBranch={git.repoState.currentBranch}
               open={git.worktreeMenuOpen}
               placement={placement}
@@ -52,6 +55,7 @@ export function DraftGitControls({
             <BranchSwitcherDropdown
               availableLocalBranches={git.availableLocalBranches}
               branchQuery={git.branchQuery}
+              compact={compact}
               canCreateBranch={git.canCreateBranch}
               currentBranchLabel={git.currentBranchLabel}
               hasBranchResults={git.hasBranchResults}

--- a/apps/client/src/components/chat/git-controls/GitOperationsDropdown.tsx
+++ b/apps/client/src/components/chat/git-controls/GitOperationsDropdown.tsx
@@ -7,6 +7,7 @@ import type { GitOperationKind } from './git-operation-utils'
 import { getPrimaryGitOperationKind, isGitOperationDisabled } from './git-operation-utils'
 
 export function GitOperationsDropdown({
+  compact = false,
   isBusy,
   open,
   placement = 'bottomLeft',
@@ -16,6 +17,7 @@ export function GitOperationsDropdown({
   onPush,
   onSync
 }: {
+  compact?: boolean
   isBusy: boolean
   open: boolean
   placement?: 'bottomLeft' | 'topLeft'
@@ -61,7 +63,11 @@ export function GitOperationsDropdown({
   const primaryAction = primaryActionKind != null ? actionMap[primaryActionKind] : null
 
   return (
-    <div className={`chat-header-git__split ${open ? 'is-open' : ''}`}>
+    <div
+      className={`chat-header-git__split chat-header-git__split--operations ${open ? 'is-open' : ''} ${
+        compact ? 'is-compact' : ''
+      }`.trim()}
+    >
       <Button
         type='text'
         className='chat-header-git__split-main'

--- a/apps/client/src/components/chat/git-controls/GitWorktreeDropdown.tsx
+++ b/apps/client/src/components/chat/git-controls/GitWorktreeDropdown.tsx
@@ -101,6 +101,7 @@ const filterGitWorktrees = (worktrees: GitWorktreeSummary[], query: string) => {
 }
 
 export function GitWorktreeDropdown({
+  compact = false,
   open,
   workspace,
   worktrees,
@@ -109,6 +110,7 @@ export function GitWorktreeDropdown({
   placement = 'bottomLeft',
   onOpenChange
 }: {
+  compact?: boolean
   open: boolean
   workspace?: SessionWorkspace
   worktrees: GitWorktreeSummary[]
@@ -322,9 +324,9 @@ export function GitWorktreeDropdown({
     >
       <Button
         type='text'
-        className={`chat-header-git__trigger ${open ? 'is-open' : ''} ${
+        className={`chat-header-git__trigger chat-header-git__trigger--worktree ${open ? 'is-open' : ''} ${
           mode.type === 'session' && mode.isBusy ? 'is-disabled' : ''
-        }`}
+        } ${compact ? 'is-compact' : ''}`.trim()}
         title={triggerTitle}
         aria-label={t('chat.sessionWorkspace')}
       >

--- a/apps/client/src/components/chat/messages/MessageContextMenu.tsx
+++ b/apps/client/src/components/chat/messages/MessageContextMenu.tsx
@@ -21,6 +21,7 @@ interface MessageContextMenuProps {
   isEditing: boolean
   message: ChatMessage
   sessionId?: string
+  trigger?: ('click' | 'contextMenu')[]
   onFork: () => void
   onRecall: () => void
   onStartEditing: () => void
@@ -39,6 +40,7 @@ export function MessageContextMenu({
   isEditing,
   message: sourceMessage,
   sessionId,
+  trigger = ['contextMenu'],
   onFork,
   onRecall,
   onStartEditing
@@ -86,7 +88,7 @@ export function MessageContextMenu({
 
   return (
     <Dropdown
-      trigger={['contextMenu']}
+      trigger={trigger}
       open={open}
       onOpenChange={(nextOpen) => {
         setOpen(nextOpen)

--- a/apps/client/src/components/chat/messages/MessageItem.scss
+++ b/apps/client/src/components/chat/messages/MessageItem.scss
@@ -34,9 +34,21 @@
     margin-top: 4px;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
+    min-width: 0;
     font-size: 11px;
     color: var(--sub-text-color, #9ca3af);
+
+    > * {
+      min-width: 0;
+    }
+
+    .msg-model,
+    .msg-usage,
+    .timestamp {
+      overflow-wrap: anywhere;
+    }
 
     .timestamp {
       user-select: none;
@@ -141,6 +153,13 @@
   }
 }
 
+.chat-message-user.has-compact-menu,
+.chat-message-assistant.has-compact-menu {
+  .msg-footer {
+    opacity: 1;
+  }
+}
+
 .msg-action-button__label {
   font-size: 11px;
   line-height: 1;
@@ -168,6 +187,12 @@
     background: rgba(8, 145, 178, .12);
     color: #0e7490;
   }
+}
+
+.msg-action-button--menu {
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
 }
 
 .chat-message-user {
@@ -246,8 +271,9 @@ html.dark {
 }
 
 .message-image {
-  display: inline-block;
-  max-width: 360px;
+  display: block;
+  width: min(100%, 360px);
+  max-width: 100%;
   border-radius: 10px;
   overflow: hidden;
   border: 1px solid var(--border-color);
@@ -255,6 +281,7 @@ html.dark {
 
 .message-image img {
   display: block;
+  width: 100%;
   max-width: 100%;
   height: auto;
 }
@@ -292,7 +319,9 @@ html.dark {
   font-size: 14px;
   line-height: 1.5;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
   width: 100%;
+  min-width: 0;
 
   p {
     margin: 0 0 4px 0;
@@ -355,14 +384,28 @@ html.dark {
     color: #6b7280;
   }
 
+  .markdown-table-wrapper {
+    max-width: 100%;
+    margin: 12px 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-gutter: stable both-edges;
+  }
+
   table {
     border-collapse: collapse;
-    width: 100%;
-    margin: 12px 0;
+    width: max-content;
+    min-width: 100%;
+    margin: 0;
 
     th, td {
       border: 1px solid #e5e7eb;
       padding: 6px 13px;
+      vertical-align: top;
+      overflow-wrap: anywhere;
     }
 
     tr:nth-child(2n) {
@@ -408,5 +451,36 @@ html.dark {
 
   &:hover {
     opacity: 1;
+  }
+}
+
+@media (max-width: 960px) {
+  .chat-message-user, .chat-message-assistant {
+    scroll-margin-top: 64px;
+
+    .msg-footer {
+      gap: 6px;
+      font-size: 10px;
+    }
+  }
+
+  .chat-message-user, .chat-message-assistant {
+    &.is-targeted {
+      scroll-margin-top: 76px;
+
+      .bubble {
+        outline-offset: 4px;
+      }
+    }
+  }
+
+  .message-context-file {
+    width: 100%;
+  }
+
+  .markdown-body {
+    .markdown-table-wrapper {
+      margin: 8px 0;
+    }
   }
 }

--- a/apps/client/src/components/chat/messages/MessageItem.tsx
+++ b/apps/client/src/components/chat/messages/MessageItem.tsx
@@ -30,6 +30,8 @@ interface MessageItemProps {
   sessionInfo?: SessionInfo | null
   isSessionBusy: boolean
   isEditing: boolean
+  isCompactLayout: boolean
+  isTouchInteraction: boolean
   showAssistantActions: boolean
   onEditMessage: (messageId: string, content: string | ChatMessageContent[]) => Promise<boolean>
   onRecallMessage: (messageId: string) => Promise<boolean>
@@ -53,6 +55,8 @@ function MessageItemComponent({
   sessionInfo,
   isSessionBusy,
   isEditing,
+  isCompactLayout,
+  isTouchInteraction,
   showAssistantActions,
   onEditMessage,
   onRecallMessage,
@@ -80,6 +84,7 @@ function MessageItemComponent({
   const canFork = isPersistedMessage && !isSessionBusy && isUser
   const canCopy = copyableText != null
   const shouldShowAssistantActions = !isUser && showAssistantActions
+  const showCompactActionMenu = isCompactLayout || isTouchInteraction
 
   useEffect(() => {
     setIsSubmitting(false)
@@ -384,6 +389,36 @@ function MessageItemComponent({
     </>
   )
 
+  const compactActionMenu = (
+    <MessageContextMenu
+      anchorId={anchorId}
+      canEdit={canEdit}
+      canFork={canFork}
+      canRecall={canRecall}
+      copyableText={copyableText}
+      isDebugMode={isDebugMode}
+      isEditing={isEditing}
+      message={originalMessage}
+      sessionId={sessionId}
+      trigger={['click']}
+      onFork={handleFork}
+      onRecall={handleRecall}
+      onStartEditing={handleStartEdit}
+    >
+      <button
+        type='button'
+        className='msg-action-button msg-action-button--menu'
+        title={t('common.moreActions')}
+        aria-label={t('common.moreActions')}
+        onClick={(event) => {
+          event.stopPropagation()
+        }}
+      >
+        <span className='material-symbols-rounded'>more_horiz</span>
+      </button>
+    </MessageContextMenu>
+  )
+
   return (
     <MessageContextMenu
       anchorId={anchorId}
@@ -404,13 +439,15 @@ function MessageItemComponent({
         id={anchorId}
         className={`${isUser ? 'chat-message-user' : 'chat-message-assistant'} ${isEditing ? 'is-editing' : ''} ${
           !isFirstInGroup ? 'consecutive' : ''
-        } ${isActionsVisible ? 'is-actions-visible' : ''} ${isTargeted ? 'is-targeted' : ''}`}
+        } ${isActionsVisible ? 'is-actions-visible' : ''} ${isTargeted ? 'is-targeted' : ''} ${
+          showCompactActionMenu ? 'has-compact-menu' : ''
+        }`}
         data-message-id={originalMessage.id}
         onPointerEnter={handleActionsPointerEnter}
         onPointerLeave={handleActionsPointerLeave}
       >
         <div className={`message-body-container ${isEditing ? 'is-editing' : ''}`}>
-          {isUser && !isEditing && (
+          {isUser && !isEditing && !showCompactActionMenu && (
             <div className='message-side-actions'>
               {actionButtons}
             </div>
@@ -440,7 +477,11 @@ function MessageItemComponent({
           </div>
           {!isEditing && (
             <MessageFooter msg={originalMessage} isUser={isUser}>
-              {shouldShowAssistantActions ? actionButtons : undefined}
+              {showCompactActionMenu
+                ? compactActionMenu
+                : shouldShowAssistantActions
+                ? actionButtons
+                : undefined}
             </MessageFooter>
           )}
         </div>
@@ -455,6 +496,8 @@ const areMessageItemPropsEqual = (prev: MessageItemProps, next: MessageItemProps
     prev.isTargeted === next.isTargeted &&
     prev.isSessionBusy === next.isSessionBusy &&
     prev.isEditing === next.isEditing &&
+    prev.isCompactLayout === next.isCompactLayout &&
+    prev.isTouchInteraction === next.isTouchInteraction &&
     prev.sessionId === next.sessionId &&
     prev.sessionInfo === next.sessionInfo &&
     prev.showAssistantActions === next.showAssistantActions &&

--- a/apps/client/src/components/chat/sender/@components/adapter-select/AdapterSelectControl.scss
+++ b/apps/client/src/components/chat/sender/@components/adapter-select/AdapterSelectControl.scss
@@ -92,3 +92,18 @@
   font-size: 15px;
   line-height: 1;
 }
+
+@media (max-width: 960px) {
+  .adapter-select,
+  .adapter-select--locked {
+    width: var(--sender-control-height);
+    min-width: var(--sender-control-height);
+  }
+
+  .adapter-option__icon,
+  .adapter-option__icon--fallback {
+    width: 14px;
+    height: 14px;
+    margin: 0 auto;
+  }
+}

--- a/apps/client/src/components/chat/sender/@components/reference-actions/ReferenceActionsControl.scss
+++ b/apps/client/src/components/chat/sender/@components/reference-actions/ReferenceActionsControl.scss
@@ -21,6 +21,23 @@
   }
 }
 
+@media (max-width: 960px) {
+  .toolbar-btn.toolbar-btn--reference {
+    width: var(--sender-control-height);
+    min-width: var(--sender-control-height);
+    height: var(--sender-control-height);
+    padding: 0 !important;
+    justify-content: center;
+
+    .toolbar-btn__icon-shell {
+      width: 100%;
+      min-width: 100%;
+      height: 100%;
+      border-radius: var(--sender-control-radius);
+    }
+  }
+}
+
 .reference-actions-popover,
 .reference-actions-submenu-popover {
   .ant-popover-inner {

--- a/apps/client/src/components/chat/sender/@components/reference-actions/ReferencePermissionActionsPopover.tsx
+++ b/apps/client/src/components/chat/sender/@components/reference-actions/ReferencePermissionActionsPopover.tsx
@@ -1,6 +1,8 @@
 import { Popover } from 'antd'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
+
 import type {
   SenderToolbarData,
   SenderToolbarHandlers,
@@ -27,6 +29,7 @@ export function ReferencePermissionActionsPopover({
   >
 }) {
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
   const { showReferenceActions, showPermissionActions, permissionMode } = state
   const { permissionModeOptions } = data
   const { referenceMenuNavigation, permissionMenuNavigation } = refs
@@ -81,7 +84,7 @@ export function ReferencePermissionActionsPopover({
         onShowPermissionActionsChange(nextOpen)
       }}
       placement='rightTop'
-      trigger={['hover', 'click']}
+      trigger={isTouchInteraction ? ['click'] : ['hover', 'click']}
       classNames={{ root: 'reference-actions-submenu-popover' }}
       destroyOnHidden
       arrow={false}

--- a/apps/client/src/components/chat/sender/@components/sender-attachments/SenderAttachments.scss
+++ b/apps/client/src/components/chat/sender/@components/sender-attachments/SenderAttachments.scss
@@ -4,6 +4,7 @@
   gap: 6px;
   padding: 2px 0 8px;
   align-items: flex-start;
+  min-width: 0;
 }
 
 .pending-attachments__files,
@@ -12,6 +13,7 @@
   display: flex;
   gap: 6px;
   align-items: flex-start;
+  min-width: 0;
 }
 
 .pending-attachments__files {
@@ -77,10 +79,11 @@
 }
 
 .pending-context-file {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   width: 100%;
+  min-width: 0;
   align-items: center;
-  justify-content: space-between;
   gap: 6px;
   padding: 5px 8px;
   border: 1px solid rgba(148, 163, 184, .2);
@@ -142,12 +145,15 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
+  min-width: 0;
+  justify-self: end;
 }
 
 .pending-context-file__size {
   font-size: 9px;
   font-weight: 600;
   color: var(--sub-text-color, #6b7280);
+  white-space: nowrap;
 }
 
 .pending-context-file__remove {
@@ -218,7 +224,14 @@ html.dark {
 
 @media (max-width: 640px) {
   .pending-context-file {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  .pending-context-file__actions {
     width: 100%;
+    justify-content: space-between;
+    justify-self: stretch;
   }
 
   .pending-attachments__images {

--- a/apps/client/src/components/chat/sender/@components/sender-submit-action/SenderSubmitAction.scss
+++ b/apps/client/src/components/chat/sender/@components/sender-submit-action/SenderSubmitAction.scss
@@ -149,3 +149,15 @@
     flex: 0 0 auto;
   }
 }
+
+@media (max-width: 960px) {
+  .chat-send-btn {
+    width: 24px;
+    min-width: 24px;
+    height: 24px;
+
+    .material-symbols-rounded {
+      font-size: 14px;
+    }
+  }
+}

--- a/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderSelectBase.scss
+++ b/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderSelectBase.scss
@@ -69,3 +69,24 @@
     opacity: .56;
   }
 }
+
+@media (max-width: 960px) {
+  .model-select,
+  .effort-select {
+    .ant-select-arrow {
+      width: 20px;
+      min-width: 20px;
+      flex: 0 0 20px;
+    }
+
+    &.ant-select-single .ant-select-selector {
+      padding-left: 6px !important;
+      padding-inline-start: 6px !important;
+    }
+
+    .ant-select-selection-item,
+    .ant-select-selection-placeholder {
+      font-size: 11px;
+    }
+  }
+}

--- a/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderSelectShared.scss
+++ b/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderSelectShared.scss
@@ -116,3 +116,24 @@
 .adapter-select-tooltip-target--locked {
   cursor: help;
 }
+
+@media (max-width: 960px) {
+  .sender-select-arrow {
+    font-size: 16px;
+  }
+
+  .model-select,
+  .effort-select,
+  .adapter-select {
+    font-size: 11px;
+
+    .ant-select-selector {
+      padding: 0 0 0 6px !important;
+    }
+
+    .ant-select-selection-item,
+    .ant-select-selection-placeholder {
+      font-size: 11px !important;
+    }
+  }
+}

--- a/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderToolbar.scss
+++ b/apps/client/src/components/chat/sender/@components/sender-toolbar/SenderToolbar.scss
@@ -15,6 +15,7 @@
   align-items: center;
   gap: 12px;
   margin: 4px -6px -6px;
+  min-width: 0;
 
   .toolbar-left {
     display: flex;
@@ -29,6 +30,7 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    min-width: 0;
   }
 
   .toolbar-right--inline-edit {
@@ -92,8 +94,69 @@
 
 @media (max-width: 960px) {
   .chat-input-toolbar {
+    --sender-control-height: 24px;
+
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    margin-top: 6px;
+    row-gap: 6px;
+
+    .toolbar-left {
+      gap: 6px;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+
+    .toolbar-right {
+      gap: 6px;
+      margin-left: auto;
+      max-width: 100%;
+    }
+
     .toolbar-btn__text {
       display: none;
     }
+
+    .toolbar-btn {
+      min-height: var(--sender-control-height);
+
+      .material-symbols-rounded {
+        font-size: 16px;
+      }
+    }
+
+    .toolbar-btn__icon-shell {
+      width: var(--sender-control-height);
+      height: var(--sender-control-height);
+    }
+
+    .toolbar-right--inline-edit {
+      width: 100%;
+      justify-content: flex-end;
+    }
+  }
+
+  .sender-select-shell,
+  .sender-control-tooltip-target,
+  .adapter-select-tooltip-target {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .model-select,
+  .effort-select {
+    max-width: min(100%, 196px);
+  }
+
+  .model-select .ant-select-selection-item,
+  .model-select .ant-select-selection-placeholder,
+  .effort-select .ant-select-selection-item,
+  .effort-select .ant-select-selection-placeholder {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/apps/client/src/components/chat/sender/@hooks/use-model-select-browser.tsx
+++ b/apps/client/src/components/chat/sender/@hooks/use-model-select-browser.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ModelSelectMenuGroup, ModelSelectOption } from '#~/hooks/chat/use-chat-model-adapter-selection'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 import { ModelSelectOptionLabel } from '../@components/model-select/ModelSelectOptionLabel'
 
@@ -27,6 +28,7 @@ export const useModelSelectBrowser = ({
   onSelectModel: (value: string) => void
 }) => {
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
 
   const renderCompactModelMenuLabel = useCallback((option: ModelSelectOption) => {
     return (
@@ -175,13 +177,13 @@ export const useModelSelectBrowser = ({
           mode='vertical'
           selectable
           selectedKeys={selectedModelMenuKeys}
-          triggerSubMenuAction='hover'
+          triggerSubMenuAction={isTouchInteraction ? 'click' : 'hover'}
           items={modelMenuItems}
           onClick={handleModelMenuClick}
         />
       </div>
     )
-  }, [hasModelSearchQuery, handleModelMenuClick, modelMenuItems, selectedModelMenuKeys])
+  }, [hasModelSearchQuery, handleModelMenuClick, isTouchInteraction, modelMenuItems, selectedModelMenuKeys])
 
   return {
     renderModelPopup

--- a/apps/client/src/components/chat/sender/Sender.scss
+++ b/apps/client/src/components/chat/sender/Sender.scss
@@ -24,7 +24,7 @@
   &:focus-within {
     border-color: #3b82f6;
     background-color: var(--input-focus-bg, #f9fafb);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, .1);
+    box-shadow: none;
   }
 
   .chat-input-monaco {

--- a/apps/client/src/components/chat/session-timeline-panel/EventList.scss
+++ b/apps/client/src/components/chat/session-timeline-panel/EventList.scss
@@ -12,12 +12,14 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  min-width: 0;
 }
 
 .session-timeline-event-table__title {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-color);
+  min-width: 0;
 }
 
 .session-timeline-event-table__search {
@@ -28,6 +30,7 @@
 .session-timeline-event-table__table {
   flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
 }
 
 .session-timeline-event-table__table .ant-table {
@@ -40,6 +43,12 @@
 
 .session-timeline-event-table__table .ant-table-body {
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+.session-timeline-event-table__table .ant-table-pagination {
+  margin: 8px 0 0;
 }
 
 .session-timeline-event-table__time {
@@ -55,4 +64,83 @@
 
 .session-timeline-event-table__value {
   color: var(--sub-text-color);
+  overflow-wrap: anywhere;
+}
+
+.session-timeline-event-table__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.session-timeline-event-table__detail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.session-timeline-event-table__detail-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+}
+
+.session-timeline-event-table__detail-key {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--sub-text-color);
+}
+
+.session-timeline-event-table__detail-text {
+  min-width: 0;
+  color: var(--sub-text-color);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.session-timeline-event-table__cell-timing {
+  display: inline-flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+@media (max-width: 960px) {
+  .session-timeline-event-table {
+    gap: 10px;
+    padding-top: 8px;
+  }
+
+  .session-timeline-event-table__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .session-timeline-event-table__search {
+    width: 100%;
+    max-width: none;
+  }
+
+  .session-timeline-event-table__table .ant-table-thead > tr > th,
+  .session-timeline-event-table__table .ant-table-tbody > tr > td {
+    padding: 8px;
+    font-size: 12px;
+  }
+
+  .session-timeline-event-table__table .ant-table-pagination {
+    row-gap: 6px;
+  }
+
+  .session-timeline-event-table__label {
+    line-height: 1.4;
+  }
+
+  .session-timeline-event-table__time {
+    font-size: 11px;
+    white-space: nowrap;
+  }
 }

--- a/apps/client/src/components/chat/session-timeline-panel/EventList.tsx
+++ b/apps/client/src/components/chat/session-timeline-panel/EventList.tsx
@@ -5,6 +5,8 @@ import type { ColumnsType } from 'antd/es/table'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
+
 import type { Task, TimelineEvent } from './types'
 import { normalizeTime, parseTime } from './utils'
 
@@ -83,6 +85,7 @@ const collectTimelineEntries = (task: Task, labels: TimelineLabels) => {
 
 export function SessionTimelineEventList({ task }: { task: Task }) {
   const { t } = useTranslation()
+  const { isCompactLayout } = useResponsiveLayout()
   const [query, setQuery] = React.useState('')
   const containerRef = React.useRef<HTMLDivElement | null>(null)
   const [scrollY, setScrollY] = React.useState(240)
@@ -105,55 +108,104 @@ export function SessionTimelineEventList({ task }: { task: Task }) {
     })
   }, [items, query])
   const emptyValue = t('chat.timelineEmptyValue')
-  const columns: ColumnsType<TimelineListItem> = React.useMemo(() => [
-    {
-      title: t('chat.timelineEventName'),
-      key: 'label',
-      width: 180,
-      render: (_value, item) => (
-        <span
-          className='session-timeline-event-table__label'
-          style={{ paddingLeft: `${item.depth * 16}px` }}
-        >
-          {item.label}
-        </span>
-      )
-    },
-    {
-      title: t('chat.timelineInput'),
-      key: 'input',
-      width: 180,
-      render: (_value, item) => (
-        <span className='session-timeline-event-table__value'>
-          {item.input ?? emptyValue}
-        </span>
-      )
-    },
-    {
-      title: t('chat.timelineOutput'),
-      key: 'output',
-      width: 180,
-      render: (_value, item) => (
-        <span className='session-timeline-event-table__value'>
-          {item.output ?? emptyValue}
-        </span>
-      )
-    },
-    {
-      title: t('chat.timelineTiming'),
-      key: 'time',
-      width: 160,
-      render: (_value, item) => {
-        const startTime = normalizeTime(item.startTime)
-        const endTime = normalizeTime(item.endTime)
-        return (
-          <span className='session-timeline-event-table__time'>
-            {startTime === endTime ? startTime : `${startTime} → ${endTime}`}
+  const renderTiming = React.useCallback((item: TimelineListItem) => {
+    const startTime = normalizeTime(item.startTime)
+    const endTime = normalizeTime(item.endTime)
+    return (
+      <span className='session-timeline-event-table__time'>
+        {startTime === endTime ? startTime : `${startTime} → ${endTime}`}
+      </span>
+    )
+  }, [])
+  const columns: ColumnsType<TimelineListItem> = React.useMemo(() => {
+    if (isCompactLayout) {
+      return [
+        {
+          title: t('chat.timelineEventName'),
+          key: 'summary',
+          render: (_value, item) => {
+            const detailItems = [
+              { key: t('chat.timelineInput'), value: item.input },
+              { key: t('chat.timelineOutput'), value: item.output }
+            ].filter((detail) => detail.value != null && detail.value !== '')
+
+            return (
+              <div className='session-timeline-event-table__summary'>
+                <span
+                  className='session-timeline-event-table__label'
+                  style={{ paddingLeft: `${item.depth * 12}px` }}
+                >
+                  {item.label}
+                </span>
+                {detailItems.length > 0 && (
+                  <div className='session-timeline-event-table__detail-list'>
+                    {detailItems.map((detail) => (
+                      <span className='session-timeline-event-table__detail-item' key={detail.key}>
+                        <span className='session-timeline-event-table__detail-key'>{detail.key}</span>
+                        <span className='session-timeline-event-table__detail-text'>{detail.value}</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          }
+        },
+        {
+          title: t('chat.timelineTiming'),
+          key: 'time',
+          width: 120,
+          render: (_value, item) => (
+            <span className='session-timeline-event-table__cell-timing'>
+              {renderTiming(item)}
+            </span>
+          )
+        }
+      ]
+    }
+
+    return [
+      {
+        title: t('chat.timelineEventName'),
+        key: 'label',
+        width: 180,
+        render: (_value, item) => (
+          <span
+            className='session-timeline-event-table__label'
+            style={{ paddingLeft: `${item.depth * 16}px` }}
+          >
+            {item.label}
           </span>
         )
+      },
+      {
+        title: t('chat.timelineInput'),
+        key: 'input',
+        width: 180,
+        render: (_value, item) => (
+          <span className='session-timeline-event-table__value'>
+            {item.input ?? emptyValue}
+          </span>
+        )
+      },
+      {
+        title: t('chat.timelineOutput'),
+        key: 'output',
+        width: 180,
+        render: (_value, item) => (
+          <span className='session-timeline-event-table__value'>
+            {item.output ?? emptyValue}
+          </span>
+        )
+      },
+      {
+        title: t('chat.timelineTiming'),
+        key: 'time',
+        width: 160,
+        render: (_value, item) => renderTiming(item)
       }
-    }
-  ], [emptyValue, t])
+    ]
+  }, [emptyValue, isCompactLayout, renderTiming, t])
 
   React.useEffect(() => {
     const element = containerRef.current
@@ -201,7 +253,7 @@ export function SessionTimelineEventList({ task }: { task: Task }) {
         })}
         pagination={{
           pageSize: 20,
-          showSizeChanger: true,
+          showSizeChanger: !isCompactLayout,
           pageSizeOptions: ['10', '20', '50']
         }}
         scroll={{ y: scrollY }}

--- a/apps/client/src/components/chat/session-timeline-panel/gantt.ts
+++ b/apps/client/src/components/chat/session-timeline-panel/gantt.ts
@@ -1,4 +1,4 @@
-import type { Task, TimelineDiagram, TimelineEvent, TimelineInteraction } from './types'
+import type { Task, TimelineDiagram, TimelineDiagramBuildOptions, TimelineEvent, TimelineInteraction } from './types'
 import { normalizeTime, parseTime } from './utils'
 
 interface GanttItem {
@@ -25,7 +25,18 @@ function createGanttItemIdFactory() {
   return (prefix: string) => `${prefix}_${seq++}`
 }
 
-function collectGanttItems(task: Task, labels: GanttLabels) {
+const COMPACT_GANTT_LABEL_MAX_LENGTH = 18
+
+const truncateTaskLabel = (value: string, maxLength: number, suffix = '') => {
+  if (value.length + suffix.length <= maxLength) {
+    return `${value}${suffix}`
+  }
+
+  const availableLength = Math.max(4, maxLength - suffix.length - 1)
+  return `${value.slice(0, availableLength).trimEnd()}…${suffix}`
+}
+
+function collectGanttItems(task: Task, labels: GanttLabels, options?: TimelineDiagramBuildOptions) {
   const nextId = createGanttItemIdFactory()
   const nextSectionId = createGanttItemIdFactory()
   const interactions: TimelineInteraction[] = []
@@ -80,9 +91,10 @@ function collectGanttItems(task: Task, labels: GanttLabels) {
             const segments = collectTaskSegments(task)
             segments.forEach((segment, segmentIndex) => {
               const itemId = nextId('task')
-              const label = segments.length > 1
-                ? `${taskName} - ${segmentIndex}`
-                : taskName
+              const segmentSuffix = segments.length > 1 ? ` ·${segmentIndex + 1}` : ''
+              const label = options?.compact
+                ? truncateTaskLabel(taskName, COMPACT_GANTT_LABEL_MAX_LENGTH, segmentSuffix)
+                : `${taskName}${segmentSuffix}`
               const interaction: TimelineInteraction = {
                 id: itemId,
                 label: taskName,
@@ -168,8 +180,12 @@ function buildGanttLines(items: GanttItem[]) {
   return lines.join('\n')
 }
 
-export function buildGantt(task: Task, labels: GanttLabels): TimelineDiagram {
-  const { items, interactions } = collectGanttItems(task, labels)
+export function buildGantt(
+  task: Task,
+  labels: GanttLabels,
+  options?: TimelineDiagramBuildOptions
+): TimelineDiagram {
+  const { items, interactions } = collectGanttItems(task, labels, options)
   return {
     code: buildGanttLines(items),
     interactions

--- a/apps/client/src/components/chat/session-timeline-panel/git-graph.ts
+++ b/apps/client/src/components/chat/session-timeline-panel/git-graph.ts
@@ -1,6 +1,7 @@
 import type {
   Task,
   TimelineDiagram,
+  TimelineDiagramBuildOptions,
   TimelineEvent,
   TimelineEventType,
   TimelineInteraction,
@@ -509,7 +510,11 @@ function applyTimelineOps(runtime: MermaidRuntime) {
   }
 }
 
-export function buildGitGraph(task: Task, labels: MermaidLabels): TimelineDiagram {
+export function buildGitGraph(
+  task: Task,
+  labels: MermaidLabels,
+  _options?: TimelineDiagramBuildOptions
+): TimelineDiagram {
   const runtime = createMermaidRuntime(labels)
   const mainBranch = 'main'
   runtime.checkout(mainBranch)

--- a/apps/client/src/components/chat/session-timeline-panel/index.scss
+++ b/apps/client/src/components/chat/session-timeline-panel/index.scss
@@ -1,12 +1,19 @@
 .session-timeline-panel {
   display: flex;
   align-content: center;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable both-edges;
 }
 
 .session-timeline-mermaid__svg {
+  display: block;
   height: 100%;
+  min-width: max-content;
   white-space: nowrap;
-  overflow-x: auto;
   user-select: none;
 }
 
@@ -25,4 +32,10 @@
 .session-timeline-mermaid__interactive:hover {
   filter: drop-shadow(0 0 6px var(--primary-color));
   opacity: .9;
+}
+
+@media (max-width: 960px) {
+  .session-timeline-panel {
+    padding-bottom: 4px;
+  }
 }

--- a/apps/client/src/components/chat/session-timeline-panel/index.tsx
+++ b/apps/client/src/components/chat/session-timeline-panel/index.tsx
@@ -3,6 +3,7 @@ import './index.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { buildGantt, buildGitGraph } from './mermaid'
 import type { Task } from './types'
 
@@ -13,6 +14,57 @@ export interface SessionTimelinePanelProps {
   style?: React.CSSProperties
 }
 
+const getCompactTimelineLabels = <
+  T extends {
+    allTasksDone: string
+    askUserQuestion: string
+    ganttMainSection: string
+    mainEnd: string
+    mainStart: string
+    receiveReply: string
+    resumeTask: string
+    startTasks: string
+    taskEnd: string
+    taskStart: string
+    userAnswer: string
+    userPrompt: string
+  },
+>(labels: T, isZh: boolean) => {
+  if (isZh) {
+    return {
+      ...labels,
+      mainStart: '启动',
+      mainEnd: '结束',
+      startTasks: '任务',
+      allTasksDone: '完成',
+      askUserQuestion: '提问',
+      resumeTask: '继续',
+      userPrompt: '提示',
+      userAnswer: '回答',
+      receiveReply: '回复',
+      taskStart: '开始',
+      taskEnd: '结束',
+      ganttMainSection: '主'
+    }
+  }
+
+  return {
+    ...labels,
+    mainStart: 'Start',
+    mainEnd: 'End',
+    startTasks: 'Tasks',
+    allTasksDone: 'Done',
+    askUserQuestion: 'Ask',
+    resumeTask: 'Resume',
+    userPrompt: 'Prompt',
+    userAnswer: 'Answer',
+    receiveReply: 'Reply',
+    taskStart: 'Start',
+    taskEnd: 'End',
+    ganttMainSection: 'Main'
+  }
+}
+
 export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
   const {
     task,
@@ -21,7 +73,8 @@ export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
     style
   } = props
   const containerRef = React.useRef<HTMLDivElement | null>(null)
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const { isCompactLayout } = useResponsiveLayout()
   const labels = React.useMemo(() => ({
     mainStart: t('chat.timeline.mainStart'),
     mainEnd: t('chat.timeline.mainEnd'),
@@ -39,12 +92,19 @@ export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
     ganttMainSection: t('chat.timeline.ganttMainSection'),
     ganttTasksSection: t('chat.timeline.ganttTasksSection')
   }), [t])
+  const diagramLabels = React.useMemo(
+    () =>
+      isCompactLayout
+        ? getCompactTimelineLabels(labels, i18n.resolvedLanguage?.startsWith('zh') === true)
+        : labels,
+    [i18n.resolvedLanguage, isCompactLayout, labels]
+  )
   const diagram = React.useMemo(() => {
     if (viewMode === 'gantt') {
-      return buildGantt(task, labels)
+      return buildGantt(task, diagramLabels, { compact: isCompactLayout })
     }
-    return buildGitGraph(task, labels)
-  }, [labels, task, viewMode])
+    return buildGitGraph(task, diagramLabels, { compact: isCompactLayout })
+  }, [diagramLabels, isCompactLayout, task, viewMode])
   const diagramId = React.useId()
   const safeDiagramId = React.useMemo(() => diagramId.replace(/\W/g, '_'), [diagramId])
   const interactionsRef = React.useRef(new Map<string, { label: string; payload: unknown }>())
@@ -60,15 +120,26 @@ export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
         startOnLoad: false,
         securityLevel: 'loose',
         themeVariables: {
-          fontFamily
+          fontFamily,
+          fontSize: isCompactLayout ? '12px' : '14px'
         },
-        gitGraph: {},
+        gitGraph: isCompactLayout
+          ? {
+            rotateCommitLabel: false,
+            showBranches: false
+          }
+          : {},
         gantt: {
           topAxis: true,
           displayMode: 'compact',
           gridLineStartPadding: 0,
-          leftPadding: 16,
-          rightPadding: 16
+          leftPadding: isCompactLayout ? 8 : 16,
+          rightPadding: isCompactLayout ? 8 : 16,
+          topPadding: isCompactLayout ? 28 : 36,
+          barHeight: isCompactLayout ? 16 : 20,
+          barGap: isCompactLayout ? 3 : 4,
+          fontSize: isCompactLayout ? 10 : 11,
+          sectionFontSize: isCompactLayout ? 10 : 11
         }
       })
       if (cancelled) return
@@ -100,7 +171,7 @@ export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
     return () => {
       cancelled = true
     }
-  }, [diagram.interactions, mermaidCode, safeDiagramId])
+  }, [diagram.interactions, isCompactLayout, mermaidCode, safeDiagramId])
 
   React.useEffect(() => {
     interactionsRef.current = new Map(
@@ -114,7 +185,12 @@ export function SessionTimelinePanel(props: SessionTimelinePanelProps) {
   return (
     <div
       ref={containerRef}
-      className={`session-timeline-panel session-timeline-panel--${viewMode}${className ? ` ${className}` : ''}`}
+      className={[
+        'session-timeline-panel',
+        `session-timeline-panel--${viewMode}`,
+        isCompactLayout ? 'session-timeline-panel--compact' : '',
+        className ?? ''
+      ].filter(Boolean).join(' ')}
       style={style}
     />
   )

--- a/apps/client/src/components/chat/session-timeline-panel/types.ts
+++ b/apps/client/src/components/chat/session-timeline-panel/types.ts
@@ -58,6 +58,10 @@ export interface TimelineInteraction {
   payload: TimelineInteractionPayload
 }
 
+export interface TimelineDiagramBuildOptions {
+  compact?: boolean
+}
+
 export interface TimelineDiagram {
   code: string
   interactions: TimelineInteraction[]

--- a/apps/client/src/components/chat/status-bar/ChatStatusBar.scss
+++ b/apps/client/src/components/chat/status-bar/ChatStatusBar.scss
@@ -1,5 +1,6 @@
 .chat-status-bar {
   min-width: 0;
+  width: 100%;
   display: flex;
   align-items: center;
   padding: 0;
@@ -11,9 +12,16 @@
   flex: 1;
   overflow-x: auto;
   overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-inline: 12px;
   scrollbar-width: none;
 
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+.chat-status-bar--compact .chat-status-bar__content {
+  scroll-padding-inline: 8px;
 }

--- a/apps/client/src/components/chat/status-bar/ChatStatusBar.tsx
+++ b/apps/client/src/components/chat/status-bar/ChatStatusBar.tsx
@@ -1,6 +1,7 @@
 import './ChatStatusBar.scss'
 
 import type { ChatSessionWorkspaceDraft } from '#~/hooks/chat/chat-session-workspace-draft'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 import { ChatGitControls } from '../git-controls/ChatGitControls'
 import { DraftGitControls } from '../git-controls/DraftGitControls'
@@ -16,13 +17,16 @@ export function ChatStatusBar({
   sessionId?: string
   onDraftWorkspaceChange: (nextDraft: ChatSessionWorkspaceDraft) => void
 }) {
+  const { isCompactLayout } = useResponsiveLayout()
+
   return (
-    <div className='chat-status-bar'>
+    <div className={`chat-status-bar ${isCompactLayout ? 'chat-status-bar--compact' : ''}`}>
       <div className='chat-status-bar__content'>
         {sessionId != null && sessionId !== ''
-          ? <ChatGitControls placement='topLeft' sessionId={sessionId} />
+          ? <ChatGitControls compact={isCompactLayout} placement='topLeft' sessionId={sessionId} />
           : (
             <DraftGitControls
+              compact={isCompactLayout}
               disabled={isCreating}
               draft={draftWorkspace}
               placement='topLeft'

--- a/apps/client/src/components/chat/terminal/ChatTerminalView.tsx
+++ b/apps/client/src/components/chat/terminal/ChatTerminalView.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DockPanel } from '#~/components/dock-panel/DockPanel'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useTerminalInstance } from './@hooks/use-terminal-instance'
 import { useTerminalSession } from './@hooks/use-terminal-session'
 
@@ -21,6 +22,7 @@ export function ChatTerminalView({
   sessionId: string
 }) {
   const { t } = useTranslation()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const inputHandlerRef = React.useRef<(data: string) => void>(() => undefined)
   const resizeHandlerRef = React.useRef<(cols: number, rows: number) => void>(() => undefined)
   const [shellLabel, setShellLabel] = useState('zsh')
@@ -77,11 +79,15 @@ export function ChatTerminalView({
       code: lastExit.exitCode ?? 'null',
       signal: lastExit.signal ?? 'null'
     })
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   return (
     <DockPanel
+      allowResize={!isCompactView}
       className='chat-terminal-view'
+      defaultHeight={isCompactView ? 208 : undefined}
       isOpen={isOpen}
+      maxHeight={isCompactView ? 320 : 520}
       title={t('chat.viewTerminal')}
       meta={shellLabel}
       closeLabel={t('common.close')}

--- a/apps/client/src/components/chat/tools/core/ToolCallBox.scss
+++ b/apps/client/src/components/chat/tools/core/ToolCallBox.scss
@@ -210,6 +210,7 @@
     padding: 0;
     overflow: hidden;
     background-color: var(--bg-color);
+    min-width: 0;
 
     .tool-call-box.result & {
       background-color: var(--bg-color);
@@ -218,6 +219,7 @@
 
     .tool-content {
       padding: 0;
+      min-width: 0;
     }
 
     .code-block-wrapper {
@@ -230,22 +232,26 @@
       flex-direction: column;
       gap: 8px;
       padding: 2px 0;
+      min-width: 0;
     }
 
     .tool-result-text {
       font-size: 13px;
       color: var(--text-color);
+      min-width: 0;
     }
 
     .tool-result-text-content {
       white-space: pre-wrap;
       line-height: 1.6;
+      overflow-wrap: anywhere;
     }
 
     .tool-result-image-wrapper {
       display: flex;
       flex-direction: column;
       gap: 6px;
+      min-width: 0;
     }
 
     .tool-result-image {
@@ -676,6 +682,19 @@
 
     &.tool-status--error {
       color: var(--danger-color);
+    }
+  }
+}
+
+@media (max-width: 960px) {
+  .tool-group {
+    .tool-call-header,
+    .tool-result-header {
+      min-width: 0;
+    }
+
+    .tool-call-box--inline .tool-call-body-shell.expanded {
+      padding-left: 12px;
     }
   }
 }

--- a/apps/client/src/components/chat/tools/core/ToolGroup.scss
+++ b/apps/client/src/components/chat/tools/core/ToolGroup.scss
@@ -114,18 +114,50 @@
     .msg-footer {
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
       gap: 8px;
+      min-width: 0;
       font-size: 11px;
       color: var(--sub-text-color, #9ca3af);
+
+      > * {
+        min-width: 0;
+      }
 
       .timestamp {
         user-select: none;
         cursor: pointer;
+        overflow-wrap: anywhere;
       }
     }
   }
 
   &:hover .tool-group-footer-wrapper {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 960px) {
+  .tool-group-container {
+    scroll-margin-top: 64px;
+
+    .tool-group-footer-wrapper {
+      margin-top: 2px;
+
+      .msg-footer {
+        gap: 6px;
+        font-size: 10px;
+      }
+    }
+
+    &.is-anchor-target {
+      border-radius: 8px;
+    }
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .tool-group-container .tool-group-footer-wrapper {
     opacity: 1;
   }
 }

--- a/apps/client/src/components/chat/tools/task/components/TaskToolCard.scss
+++ b/apps/client/src/components/chat/tools/task/components/TaskToolCard.scss
@@ -59,6 +59,8 @@
   }
 
   &__main {
+    min-width: 0;
+
     > .code-block-wrapper {
       border-radius: 8px;
       overflow: hidden;
@@ -70,6 +72,8 @@
     justify-content: space-between;
     align-items: flex-start;
     margin-bottom: 4px;
+    gap: 8px;
+    min-width: 0;
   }
 
   &__title {
@@ -77,7 +81,8 @@
     font-weight: 600;
     color: var(--text-color);
     flex: 1;
-    margin-right: 8px;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   &__session-id {
@@ -86,6 +91,10 @@
     opacity: .6;
     font-family: monospace;
     user-select: none;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 
@@ -95,6 +104,7 @@
     cursor: pointer;
     padding: 0;
     text-align: right;
+    min-width: 0;
 
     &:hover {
       color: var(--text-color);
@@ -123,5 +133,53 @@
     font-size: 10px;
     color: var(--sub-text-color);
     background: var(--bg-color);
+  }
+}
+
+@media (max-width: 960px) {
+  .task-tool-card {
+    grid-template-columns: 18px minmax(0, 1fr);
+    gap: 8px;
+    padding: 8px;
+
+    &__left {
+      gap: 4px;
+    }
+
+    &__status-icon,
+    &__execution-icon {
+      font-size: 16px;
+    }
+
+    &__header {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 4px;
+    }
+
+    &__title {
+      font-size: 12px;
+      line-height: 1.4;
+    }
+
+    &__session-link {
+      align-self: flex-start;
+      text-align: left;
+    }
+
+    &__session-id {
+      width: 100%;
+      font-size: 10px;
+    }
+
+    &__content {
+      font-size: 11px;
+      margin-bottom: 4px;
+    }
+
+    &__meta {
+      gap: 3px;
+      margin: 2px 0 4px;
+    }
   }
 }

--- a/apps/client/src/components/config/ConfigFieldRow.scss
+++ b/apps/client/src/components/config/ConfigFieldRow.scss
@@ -107,3 +107,31 @@
   font-size: 16px;
   color: var(--sub-text-color);
 }
+
+@media (max-width: 960px) {
+  .config-view__field-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .config-view__field-meta {
+    align-items: flex-start;
+  }
+
+  .config-view__field-title,
+  .config-view__field-desc {
+    white-space: normal;
+  }
+
+  .config-view__field-control {
+    min-width: 0;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .config-view__field-control > * {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+}

--- a/apps/client/src/components/dock-panel/DockPanel.scss
+++ b/apps/client/src/components/dock-panel/DockPanel.scss
@@ -47,11 +47,15 @@
   min-height: 24px;
   margin: -12px -12px 0;
   padding: 12px 12px 0;
-  cursor: row-resize;
+  cursor: default;
   flex-shrink: 0;
   transition: opacity .18s ease;
 
-  &:hover {
+  &.is-resizable {
+    cursor: row-resize;
+  }
+
+  &.is-resizable:hover {
     opacity: .92;
   }
 }

--- a/apps/client/src/components/dock-panel/DockPanel.tsx
+++ b/apps/client/src/components/dock-panel/DockPanel.tsx
@@ -6,22 +6,17 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 const DEFAULT_PANEL_HEIGHT = 240
 
-const clampPanelHeight = (height: number, minHeight: number, maxHeight: number) => {
-  return Math.min(Math.max(height, minHeight), Math.max(minHeight, maxHeight))
-}
+const clampPanelHeight = (height: number, minHeight: number, maxHeight: number) =>
+  Math.min(Math.max(height, minHeight), Math.max(minHeight, maxHeight))
 
-const shouldIgnoreResizePointerDown = (target: HTMLElement | null) => {
-  if (target == null) {
-    return false
-  }
-
-  return target.closest(
+const shouldIgnoreResizePointerDown = (target: HTMLElement | null) =>
+  target?.closest(
     'button, a, input, textarea, select, option, [role="button"], [data-dock-panel-no-resize="true"]'
   ) != null
-}
 
 export function DockPanel({
   enterMotion = 'slide-up',
+  allowResize = true,
   children,
   className,
   closeLabel,
@@ -38,6 +33,7 @@ export function DockPanel({
   actions
 }: {
   enterMotion?: 'none' | 'slide-up'
+  allowResize?: boolean
   actions?: ReactNode
   children: ReactNode
   className?: string
@@ -75,7 +71,7 @@ export function DockPanel({
   }, [])
 
   useEffect(() => {
-    if (!isResizing) {
+    if (!allowResize || !isResizing) {
       return
     }
 
@@ -110,7 +106,7 @@ export function DockPanel({
       window.removeEventListener('pointerup', stopResizing)
       window.removeEventListener('pointercancel', stopResizing)
     }
-  }, [isResizing, minHeight])
+  }, [allowResize, isResizing, minHeight])
 
   const handleResizePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (shouldIgnoreResizePointerDown(event.target as HTMLElement | null)) {
@@ -148,13 +144,13 @@ export function DockPanel({
       ref={panelRef}
       className={`dock-panel ${isOpen && enterMotion === 'slide-up' ? 'is-entering-slide-up' : ''} ${
         isOpen ? 'is-open' : 'is-closing'
-      } ${className ?? ''} ${isResizing ? 'is-resizing' : ''}`}
+      } ${className ?? ''} ${isResizing ? 'is-resizing' : ''} ${allowResize ? 'is-resizable' : 'is-static'}`}
       style={panelStyle as CSSProperties}
     >
       <div
-        className='dock-panel__resize-handle'
-        title={resizeLabel}
-        onPointerDown={handleResizePointerDown}
+        className={`dock-panel__resize-handle ${allowResize ? 'is-resizable' : 'is-static'}`}
+        title={allowResize ? resizeLabel : undefined}
+        onPointerDown={allowResize ? handleResizePointerDown : undefined}
       >
         <div className='dock-panel__header-main'>
           <span className='dock-panel__title'>{title}</span>

--- a/apps/client/src/components/knowledge-base/KnowledgeBaseView.scss
+++ b/apps/client/src/components/knowledge-base/KnowledgeBaseView.scss
@@ -2,6 +2,10 @@
   color: var(--text-color);
 }
 
+.knowledge-base-view__mobile-switcher-shell {
+  display: none;
+}
+
 .knowledge-base-view__body {
   display: flex;
   flex: 1;
@@ -156,7 +160,33 @@
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 960px) {
+  .knowledge-base-view--compact {
+    .knowledge-base-view__mobile-switcher-shell {
+      display: block;
+      padding: 12px;
+      padding-bottom: 0;
+    }
+
+    .knowledge-base-view__mobile-switcher {
+      width: 100%;
+
+      .ant-segmented-group {
+        gap: 4px;
+      }
+
+      .ant-segmented-item {
+        min-height: 32px;
+        font-size: 12px;
+      }
+    }
+
+    .knowledge-base-view__right {
+      margin: 12px;
+      margin-top: 12px;
+    }
+  }
+
   .knowledge-base-view__nav-item {
     padding: 8px 10px;
   }

--- a/apps/client/src/components/knowledge-base/KnowledgeBaseView.tsx
+++ b/apps/client/src/components/knowledge-base/KnowledgeBaseView.tsx
@@ -1,12 +1,13 @@
 import './KnowledgeBaseView.scss'
 
-import { App } from 'antd'
+import { App, Segmented } from 'antd'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
 
 import type { EntitySummary, RuleSummary, SpecSummary } from '#~/api.js'
 import { PageShell } from '#~/components/layout/PageShell.js'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useQueryParams } from '#~/hooks/useQueryParams.js'
 import { EntitiesTab } from './components/EntitiesTab.js'
 import { FlowsTab } from './components/FlowsTab.js'
@@ -20,6 +21,7 @@ interface KnowledgeQueryParams extends Record<string, string> {
 export function KnowledgeBaseView() {
   const { t } = useTranslation()
   const { message } = App.useApp()
+  const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const {
     data: specsRes,
     isLoading: isSpecsLoading,
@@ -243,6 +245,7 @@ export function KnowledgeBaseView() {
     () => sections.find(section => section.key === activeSectionKey) ?? sections[0],
     [activeSectionKey, sections]
   )
+  const isCompactView = isCompactLayout || isTouchInteraction
 
   React.useEffect(() => {
     if (values.kbTab !== activeSectionKey) {
@@ -252,32 +255,49 @@ export function KnowledgeBaseView() {
 
   return (
     <PageShell
-      className='knowledge-base-view'
+      className={`knowledge-base-view ${isCompactView ? 'knowledge-base-view--compact' : ''}`}
       bodyClassName='knowledge-base-view__body'
     >
-      <div className='knowledge-base-view__left'>
-        <div className='knowledge-base-view__sidebar'>
-          <div className='knowledge-base-view__nav-list'>
-            {sections.map((section) => (
-              <button
-                key={section.key}
-                type='button'
-                className={`knowledge-base-view__nav-item ${section.key === activeSectionKey ? 'is-active' : ''}`}
-                onClick={() => update({ kbTab: section.key })}
-              >
-                <span className='material-symbols-rounded knowledge-base-view__nav-icon'>{section.icon}</span>
-                <span className='knowledge-base-view__nav-main'>
-                  <span className='knowledge-base-view__nav-row'>
-                    <span className='knowledge-base-view__nav-label'>{section.label}</span>
-                    <span className='knowledge-base-view__nav-count'>{section.count}</span>
-                  </span>
-                  <span className='knowledge-base-view__nav-desc'>{section.description}</span>
-                </span>
-              </button>
-            ))}
+      {isCompactView
+        ? (
+          <div className='knowledge-base-view__mobile-switcher-shell'>
+            <Segmented
+              block
+              className='knowledge-base-view__mobile-switcher'
+              value={activeSectionKey}
+              onChange={(value) => update({ kbTab: value as string })}
+              options={sections.map((section) => ({
+                label: `${section.label} ${section.count}`,
+                value: section.key
+              }))}
+            />
           </div>
-        </div>
-      </div>
+        )
+        : (
+          <div className='knowledge-base-view__left'>
+            <div className='knowledge-base-view__sidebar'>
+              <div className='knowledge-base-view__nav-list'>
+                {sections.map((section) => (
+                  <button
+                    key={section.key}
+                    type='button'
+                    className={`knowledge-base-view__nav-item ${section.key === activeSectionKey ? 'is-active' : ''}`}
+                    onClick={() => update({ kbTab: section.key })}
+                  >
+                    <span className='material-symbols-rounded knowledge-base-view__nav-icon'>{section.icon}</span>
+                    <span className='knowledge-base-view__nav-main'>
+                      <span className='knowledge-base-view__nav-row'>
+                        <span className='knowledge-base-view__nav-label'>{section.label}</span>
+                        <span className='knowledge-base-view__nav-count'>{section.count}</span>
+                      </span>
+                      <span className='knowledge-base-view__nav-desc'>{section.description}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
       <div className='knowledge-base-view__right'>
         <div className='knowledge-base-view__right-body'>{activeSection?.content}</div>
       </div>

--- a/apps/client/src/components/layout/@hooks/use-mobile-sidebar-modal.ts
+++ b/apps/client/src/components/layout/@hooks/use-mobile-sidebar-modal.ts
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(', ')
+
+const getFocusableElements = (container: HTMLElement) => {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) =>
+      !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true' &&
+      element.offsetParent !== null
+    )
+}
+
+const focusElement = (element: HTMLElement) => {
+  try {
+    element.focus({ preventScroll: true })
+  } catch {
+    element.focus()
+  }
+}
+
+const focusFirstElement = (container: HTMLElement) => {
+  const focusableElements = getFocusableElements(container)
+  const firstFocusableElement = focusableElements[0]
+  if (firstFocusableElement != null) {
+    focusElement(firstFocusableElement)
+  } else {
+    focusElement(container)
+  }
+  return focusableElements
+}
+
+export function useMobileSidebarModal({
+  backgroundRefs,
+  isCompactLayout,
+  isMobileSidebarOpen,
+  setIsMobileSidebarOpen,
+  sheetRef
+}: {
+  backgroundRefs: Array<RefObject<HTMLElement | null>>
+  isCompactLayout: boolean
+  isMobileSidebarOpen: boolean
+  setIsMobileSidebarOpen: (nextOpen: boolean) => void
+  sheetRef: RefObject<HTMLDivElement | null>
+}) {
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!isCompactLayout) {
+      backgroundRefs.forEach((ref) => {
+        ref.current?.removeAttribute('inert')
+      })
+      return
+    }
+
+    backgroundRefs.forEach((ref) => {
+      const element = ref.current
+      if (element == null) {
+        return
+      }
+
+      if (isMobileSidebarOpen) {
+        element.setAttribute('inert', '')
+      } else {
+        element.removeAttribute('inert')
+      }
+    })
+
+    return () => {
+      backgroundRefs.forEach((ref) => {
+        ref.current?.removeAttribute('inert')
+      })
+    }
+  }, [backgroundRefs, isCompactLayout, isMobileSidebarOpen])
+
+  useEffect(() => {
+    if (!isCompactLayout || !isMobileSidebarOpen) {
+      return
+    }
+
+    const activeElement = document.activeElement
+    restoreFocusRef.current = activeElement instanceof HTMLElement ? activeElement : null
+
+    const focusFrame = window.requestAnimationFrame(() => {
+      const sheet = sheetRef.current
+      if (sheet == null) {
+        return
+      }
+
+      focusFirstElement(sheet)
+    })
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMobileSidebarOpen(false)
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const sheet = sheetRef.current
+      if (sheet == null) {
+        return
+      }
+
+      const focusableElements = getFocusableElements(sheet)
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        focusElement(sheet)
+        return
+      }
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+      const activeTarget = document.activeElement
+
+      if (event.shiftKey) {
+        if (activeTarget === firstElement || activeTarget === sheet) {
+          event.preventDefault()
+          focusElement(lastElement)
+        }
+        return
+      }
+
+      if (activeTarget === lastElement) {
+        event.preventDefault()
+        focusElement(firstElement)
+      }
+    }
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const sheet = sheetRef.current
+      const focusTarget = event.target
+      if (sheet == null || !(focusTarget instanceof HTMLElement)) {
+        return
+      }
+
+      if (sheet.contains(focusTarget)) {
+        return
+      }
+
+      focusFirstElement(sheet)
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('focusin', handleFocusIn)
+    return () => {
+      window.cancelAnimationFrame(focusFrame)
+      window.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('focusin', handleFocusIn)
+
+      const restoreFocusTarget = restoreFocusRef.current
+      if (restoreFocusTarget != null && document.contains(restoreFocusTarget)) {
+        window.requestAnimationFrame(() => {
+          if (document.contains(restoreFocusTarget)) {
+            focusElement(restoreFocusTarget)
+          }
+        })
+      }
+      restoreFocusRef.current = null
+    }
+  }, [isCompactLayout, isMobileSidebarOpen, setIsMobileSidebarOpen, sheetRef])
+
+  useEffect(() => {
+    if (!isCompactLayout || !isMobileSidebarOpen) {
+      return
+    }
+
+    const { body, documentElement } = document
+    const previousBodyOverflow = body.style.overflow
+    const previousDocumentOverflow = documentElement.style.overflow
+
+    body.style.overflow = 'hidden'
+    documentElement.style.overflow = 'hidden'
+
+    return () => {
+      body.style.overflow = previousBodyOverflow
+      documentElement.style.overflow = previousDocumentOverflow
+    }
+  }, [isCompactLayout, isMobileSidebarOpen])
+}

--- a/apps/client/src/components/layout/AppShell.scss
+++ b/apps/client/src/components/layout/AppShell.scss
@@ -1,5 +1,6 @@
 .app-shell {
-  height: 100vh;
+  min-height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: row;
   gap: 0;
@@ -14,6 +15,13 @@
   display: flex;
   flex-direction: row;
   flex-shrink: 0;
+  min-height: 0;
+}
+
+.app-shell__content-region {
+  flex: 1;
+  display: flex;
+  min-width: 0;
   min-height: 0;
 }
 
@@ -58,6 +66,73 @@
   border-radius: 0;
 }
 
+.app-shell__mobile-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  border: none;
+  background: rgba(0, 0, 0, .28);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity .24s ease, visibility 0s linear .24s;
+  z-index: 60;
+}
+
+.app-shell__mobile-sidebar-backdrop.is-open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+
+.app-shell__mobile-sidebar-sheet {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: min(320px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  padding: max(4px, env(safe-area-inset-top)) 0
+    max(4px, env(safe-area-inset-bottom)) max(4px, env(safe-area-inset-left));
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition:
+    transform .24s cubic-bezier(.4, 0, .2, 1),
+    visibility 0s linear .24s;
+  z-index: 61;
+  pointer-events: none;
+  overscroll-behavior: contain;
+}
+
+.app-shell__mobile-sidebar-sheet.is-open {
+  transform: translateX(0);
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+
+.app-shell__mobile-sidebar-sheet > * {
+  height: 100%;
+  overflow: hidden;
+  border-radius: 0 8px 8px 0;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, .22);
+  overscroll-behavior: contain;
+}
+
+.app-shell--compact {
+  flex-direction: column;
+
+  .app-shell__content {
+    padding: max(4px, env(safe-area-inset-top)) 4px 4px;
+    box-shadow: none;
+    background-color: var(--sub-bg-color);
+  }
+
+  .app-shell__content > * {
+    border-radius: 8px;
+  }
+}
+
 .app-shell--dark {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, .02), rgba(255, 255, 255, 0)),
@@ -65,7 +140,15 @@
 
   .app-shell__content {
     background-color: var(--sub-bg-color);
-    box-shadow: 0 18px 48px rgba(0, 0, 0, .3), 0 2px 10px rgba(0, 0, 0, .22);
+    box-shadow: none;
+  }
+
+  .app-shell__mobile-sidebar-backdrop {
+    background: rgba(0, 0, 0, .48);
+  }
+
+  .app-shell__mobile-sidebar-sheet > * {
+    box-shadow: 0 18px 44px rgba(0, 0, 0, .42);
   }
 
   .app-shell__content.is-flat {

--- a/apps/client/src/components/layout/AppShell.tsx
+++ b/apps/client/src/components/layout/AppShell.tsx
@@ -1,16 +1,21 @@
 import './AppShell.scss'
 
 import { Layout } from 'antd'
-import { useSetAtom } from 'jotai'
-import { useEffect } from 'react'
+import { useAtom, useSetAtom } from 'jotai'
+import { useEffect, useMemo, useRef } from 'react'
 import type { PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router-dom'
 
 import type { Session } from '@vibe-forge/core'
 
 import { NavRail } from '#~/components/NavRail'
 import { Sidebar } from '#~/components/Sidebar'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import { useSidebarQueryState } from '#~/hooks/use-sidebar-query-state'
-import { isSidebarCollapsedAtom } from '#~/store/index'
+import { isMobileSidebarOpenAtom, isSidebarCollapsedAtom } from '#~/store/index'
+import { useMobileSidebarModal } from './@hooks/use-mobile-sidebar-modal'
+import { MOBILE_SIDEBAR_DIALOG_ID } from './mobile-sidebar-constants'
 
 type AppShellProps = PropsWithChildren<{
   activeSessionId?: string
@@ -30,12 +35,119 @@ export function AppShell({
   showSidebar,
   sidebarWidth
 }: AppShellProps) {
+  const { t } = useTranslation()
   const { isSidebarCollapsed } = useSidebarQueryState()
+  const location = useLocation()
+  const { isCompactLayout } = useResponsiveLayout()
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useAtom(isMobileSidebarOpenAtom)
   const setIsSidebarCollapsed = useSetAtom(isSidebarCollapsedAtom)
+  const isDesktopSidebarCollapsed = !isCompactLayout && isSidebarCollapsed
+  const contentRegionRef = useRef<HTMLDivElement | null>(null)
+  const mobileNavRegionRef = useRef<HTMLDivElement | null>(null)
+  const mobileSidebarSheetRef = useRef<HTMLDivElement | null>(null)
+  const mobileSidebarBackgroundRefs = useMemo(
+    () => [contentRegionRef, mobileNavRegionRef],
+    []
+  )
 
   useEffect(() => {
-    setIsSidebarCollapsed(isSidebarCollapsed)
-  }, [isSidebarCollapsed, setIsSidebarCollapsed])
+    setIsSidebarCollapsed(isCompactLayout ? false : isSidebarCollapsed)
+  }, [isCompactLayout, isSidebarCollapsed, setIsSidebarCollapsed])
+
+  useEffect(() => {
+    setIsMobileSidebarOpen(false)
+  }, [isCompactLayout, location.pathname, setIsMobileSidebarOpen])
+
+  useEffect(() => {
+    if (!isCompactLayout || showSidebar) {
+      return
+    }
+
+    setIsMobileSidebarOpen(false)
+  }, [isCompactLayout, setIsMobileSidebarOpen, showSidebar])
+
+  useMobileSidebarModal({
+    backgroundRefs: mobileSidebarBackgroundRefs,
+    isCompactLayout,
+    isMobileSidebarOpen,
+    setIsMobileSidebarOpen,
+    sheetRef: mobileSidebarSheetRef
+  })
+
+  const resolvedSidebarWidth = isCompactLayout ? Math.min(sidebarWidth, 320) : sidebarWidth
+  const contentClassName = [
+    'app-shell__content',
+    showSidebar ? 'app-shell__content--session' : '',
+    isDesktopSidebarCollapsed ? 'is-sidebar-collapsed' : '',
+    showSidebar ? '' : 'is-flat'
+  ].filter(Boolean).join(' ')
+  const content = (
+    <div
+      ref={contentRegionRef}
+      className='app-shell__content-region'
+      aria-hidden={isCompactLayout && isMobileSidebarOpen ? true : undefined}
+    >
+      <Layout.Content className={contentClassName}>
+        {children}
+      </Layout.Content>
+    </div>
+  )
+
+  if (isCompactLayout) {
+    return (
+      <Layout className={`app-shell app-shell--compact ${isDarkMode ? 'app-shell--dark' : ''}`}>
+        {content}
+
+        {showSidebar && (
+          <>
+            <button
+              type='button'
+              className={`app-shell__mobile-sidebar-backdrop ${isMobileSidebarOpen ? 'is-open' : ''}`}
+              aria-label={t('common.close')}
+              aria-hidden={!isMobileSidebarOpen}
+              tabIndex={-1}
+              onClick={() => setIsMobileSidebarOpen(false)}
+            />
+            <div
+              ref={mobileSidebarSheetRef}
+              id={MOBILE_SIDEBAR_DIALOG_ID}
+              className={`app-shell__mobile-sidebar-sheet ${isMobileSidebarOpen ? 'is-open' : ''}`}
+              role='dialog'
+              aria-modal={isMobileSidebarOpen ? 'true' : undefined}
+              aria-label={t('common.sessions')}
+              aria-hidden={!isMobileSidebarOpen}
+              tabIndex={-1}
+            >
+              <Sidebar
+                width={resolvedSidebarWidth}
+                activeId={activeSessionId}
+                onSelectSession={(session, isNew) => {
+                  setIsMobileSidebarOpen(false)
+                  onSelectSession(session, isNew)
+                }}
+                onDeletedSession={(deletedId, nextId) => {
+                  setIsMobileSidebarOpen(false)
+                  onDeletedSession(deletedId, nextId)
+                }}
+                isCompactLayout
+                isMobileOpen={isMobileSidebarOpen}
+                onRequestClose={() => setIsMobileSidebarOpen(false)}
+              />
+            </div>
+          </>
+        )}
+
+        <div ref={mobileNavRegionRef}>
+          <NavRail
+            isCompactLayout
+            ariaHidden={isMobileSidebarOpen}
+            showSidebar={showSidebar}
+            onOpenSidebar={() => setIsMobileSidebarOpen(true)}
+          />
+        </div>
+      </Layout>
+    )
+  }
 
   return (
     <Layout className={`app-shell ${isDarkMode ? 'app-shell--dark' : ''}`}>
@@ -50,16 +162,7 @@ export function AppShell({
           />
         )}
       </div>
-      <Layout.Content
-        className={[
-          'app-shell__content',
-          showSidebar ? 'app-shell__content--session' : '',
-          showSidebar && isSidebarCollapsed ? 'is-sidebar-collapsed' : '',
-          showSidebar ? '' : 'is-flat'
-        ].filter(Boolean).join(' ')}
-      >
-        {children}
-      </Layout.Content>
+      {content}
     </Layout>
   )
 }

--- a/apps/client/src/components/layout/mobile-sidebar-constants.ts
+++ b/apps/client/src/components/layout/mobile-sidebar-constants.ts
@@ -1,0 +1,1 @@
+export const MOBILE_SIDEBAR_DIALOG_ID = 'mobile-sidebar-dialog'

--- a/apps/client/src/components/nav-rail-compact-config.ts
+++ b/apps/client/src/components/nav-rail-compact-config.ts
@@ -1,0 +1,114 @@
+import type { TFunction } from 'i18next'
+import type { NavigateFunction } from 'react-router-dom'
+
+import type { ThemeMode } from '#~/store'
+
+import type { NavRailCompactChoiceAction, NavRailCompactMoreAction } from './NavRailCompact'
+
+export function buildCompactMoreActions({
+  currentPath,
+  navigate,
+  onOpenSidebar,
+  showSidebar,
+  t
+}: {
+  currentPath: string
+  navigate: NavigateFunction
+  onOpenSidebar?: () => void
+  showSidebar: boolean
+  t: TFunction
+}): NavRailCompactMoreAction[] {
+  const actions: NavRailCompactMoreAction[] = []
+
+  if (showSidebar && onOpenSidebar != null) {
+    actions.push({
+      active: currentPath === '/' || currentPath.startsWith('/session/'),
+      icon: 'menu',
+      key: 'sessions',
+      label: t('common.sessions'),
+      onSelect: onOpenSidebar
+    })
+  }
+
+  actions.push({
+    active: currentPath === '/config',
+    icon: 'settings',
+    key: 'settings',
+    label: t('common.settings'),
+    onSelect: () => {
+      void navigate('/config')
+    }
+  })
+
+  return actions
+}
+
+export function buildCompactThemeActions({
+  setThemeMode,
+  t,
+  themeMode
+}: {
+  setThemeMode: (value: ThemeMode) => void
+  t: TFunction
+  themeMode: ThemeMode
+}): NavRailCompactChoiceAction[] {
+  return [
+    {
+      active: themeMode === 'light',
+      icon: 'light_mode',
+      key: 'light',
+      label: t('common.themeLight'),
+      onSelect: () => {
+        setThemeMode('light')
+        localStorage.setItem('theme', 'light')
+      }
+    },
+    {
+      active: themeMode === 'dark',
+      icon: 'dark_mode',
+      key: 'dark',
+      label: t('common.themeDark'),
+      onSelect: () => {
+        setThemeMode('dark')
+        localStorage.setItem('theme', 'dark')
+      }
+    },
+    {
+      active: themeMode === 'system',
+      icon: 'desktop_windows',
+      key: 'system',
+      label: t('common.themeSystem'),
+      onSelect: () => {
+        setThemeMode('system')
+        localStorage.setItem('theme', 'system')
+      }
+    }
+  ]
+}
+
+export function buildCompactLanguageActions({
+  currentLanguage,
+  onChangeLanguage
+}: {
+  currentLanguage: string
+  onChangeLanguage: (language: string) => void
+}): NavRailCompactChoiceAction[] {
+  return [
+    {
+      active: currentLanguage.startsWith('zh'),
+      key: 'zh',
+      label: '简体中文',
+      onSelect: () => {
+        onChangeLanguage('zh')
+      }
+    },
+    {
+      active: currentLanguage.startsWith('en'),
+      key: 'en',
+      label: 'English',
+      onSelect: () => {
+        onChangeLanguage('en')
+      }
+    }
+  ]
+}

--- a/apps/client/src/components/nav-rail-items.tsx
+++ b/apps/client/src/components/nav-rail-items.tsx
@@ -1,0 +1,181 @@
+import type { MenuProps } from 'antd'
+import type { TFunction } from 'i18next'
+import type { NavigateFunction } from 'react-router-dom'
+
+import type { ThemeMode } from '#~/store'
+
+export interface NavRailItem {
+  active: boolean
+  icon: string
+  key: string
+  label: string
+  path: string
+}
+
+export function buildLanguageItems({
+  currentLanguage,
+  onChangeLanguage
+}: {
+  currentLanguage: string
+  onChangeLanguage: (language: string) => unknown
+}): MenuProps['items'] {
+  return [
+    {
+      key: 'zh',
+      label: '简体中文',
+      icon: currentLanguage.startsWith('zh')
+        ? (
+          <span className='material-symbols-rounded nav-menu-icon active'>check</span>
+        )
+        : <div className='nav-menu-icon-placeholder' />,
+      onClick: () => {
+        void onChangeLanguage('zh')
+      }
+    },
+    {
+      key: 'en',
+      label: 'English',
+      icon: currentLanguage.startsWith('en')
+        ? (
+          <span className='material-symbols-rounded nav-menu-icon active'>check</span>
+        )
+        : <div className='nav-menu-icon-placeholder' />,
+      onClick: () => {
+        void onChangeLanguage('en')
+      }
+    }
+  ]
+}
+
+export function buildThemeItems({
+  setThemeMode,
+  t,
+  themeMode
+}: {
+  setThemeMode: (themeMode: ThemeMode) => void
+  t: TFunction
+  themeMode: ThemeMode
+}): MenuProps['items'] {
+  return [
+    {
+      key: 'light',
+      label: t('common.themeLight'),
+      icon: themeMode === 'light'
+        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
+        : <span className='material-symbols-rounded nav-menu-icon'>light_mode</span>,
+      onClick: () => {
+        setThemeMode('light')
+        localStorage.setItem('theme', 'light')
+      }
+    },
+    {
+      key: 'dark',
+      label: t('common.themeDark'),
+      icon: themeMode === 'dark'
+        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
+        : <span className='material-symbols-rounded nav-menu-icon'>dark_mode</span>,
+      onClick: () => {
+        setThemeMode('dark')
+        localStorage.setItem('theme', 'dark')
+      }
+    },
+    {
+      key: 'system',
+      label: t('common.themeSystem'),
+      icon: themeMode === 'system'
+        ? <span className='material-symbols-rounded nav-menu-icon active'>check</span>
+        : <span className='material-symbols-rounded nav-menu-icon'>desktop_windows</span>,
+      onClick: () => {
+        setThemeMode('system')
+        localStorage.setItem('theme', 'system')
+      }
+    }
+  ]
+}
+
+export function buildNavItems({
+  currentPath,
+  t
+}: {
+  currentPath: string
+  t: TFunction
+}): NavRailItem[] {
+  return [
+    {
+      key: 'sessions',
+      icon: 'chat_bubble',
+      label: t('common.sessions'),
+      path: '/',
+      active: currentPath === '/' || currentPath.startsWith('/session/')
+    },
+    {
+      key: 'knowledge',
+      icon: 'library_books',
+      label: t('common.knowledgeBase'),
+      path: '/knowledge',
+      active: currentPath === '/knowledge'
+    },
+    {
+      key: 'automation',
+      icon: 'schedule',
+      label: t('common.automation'),
+      path: '/automation',
+      active: currentPath === '/automation'
+    },
+    {
+      key: 'benchmark',
+      icon: 'speed',
+      label: t('common.benchmark'),
+      path: '/benchmark',
+      active: currentPath === '/benchmark'
+    },
+    {
+      key: 'archive',
+      icon: 'archive',
+      label: t('common.archivedSessions'),
+      path: '/archive',
+      active: currentPath === '/archive'
+    }
+  ]
+}
+
+export function buildCompactMoreItems({
+  langItems,
+  navigate,
+  t,
+  themeItems,
+  themeMode
+}: {
+  langItems: MenuProps['items']
+  navigate: NavigateFunction
+  t: TFunction
+  themeItems: MenuProps['items']
+  themeMode: ThemeMode
+}): MenuProps['items'] {
+  return [
+    {
+      key: 'settings',
+      label: t('common.settings'),
+      icon: <span className='material-symbols-rounded nav-menu-icon'>settings</span>,
+      onClick: () => {
+        void navigate('/config')
+      }
+    },
+    {
+      key: 'theme',
+      label: t('common.theme'),
+      icon: (
+        <span className='material-symbols-rounded nav-menu-icon'>
+          {themeMode === 'light' ? 'light_mode' : themeMode === 'dark' ? 'dark_mode' : 'desktop_windows'}
+        </span>
+      ),
+      children: themeItems
+    },
+    {
+      key: 'language',
+      label: t('common.language'),
+      icon: <span className='material-symbols-rounded nav-menu-icon'>language</span>,
+      children: langItems
+    }
+  ]
+}

--- a/apps/client/src/components/sidebar/SessionContextMenu.tsx
+++ b/apps/client/src/components/sidebar/SessionContextMenu.tsx
@@ -15,6 +15,7 @@ import type { SessionContextMenuEntry } from './SessionContextMenuContent'
 interface SessionContextMenuProps {
   children: ReactElement
   session: Session
+  trigger?: ('click' | 'contextMenu')[]
   onArchive: (id: string) => void | Promise<void>
   onDelete: (id: string) => void | Promise<void>
   onRename: (id: string, title: string) => Promise<void>
@@ -26,6 +27,7 @@ type PendingSessionMenuAction = 'archive' | 'delete' | null
 export function SessionContextMenu({
   children,
   session,
+  trigger = ['contextMenu'],
   onArchive,
   onDelete,
   onRename,
@@ -174,7 +176,7 @@ export function SessionContextMenu({
 
   return (
     <Dropdown
-      trigger={['contextMenu']}
+      trigger={trigger}
       open={open}
       onOpenChange={(nextOpen) => {
         setOpen(nextOpen)

--- a/apps/client/src/components/sidebar/SessionItem.scss
+++ b/apps/client/src/components/sidebar/SessionItem.scss
@@ -333,6 +333,68 @@
   }
 }
 
+.session-item--touch {
+  .session-header-side {
+    gap: 8px;
+  }
+
+  .time-display {
+    opacity: 1 !important;
+  }
+
+  .action-btn--more {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    color: var(--sub-text-color);
+
+    .material-symbols-rounded {
+      font-size: 18px;
+    }
+  }
+}
+
+.session-item--compact {
+  .session-info {
+    gap: 6px;
+  }
+
+  .session-header {
+    align-items: flex-start;
+  }
+
+  .session-header-side {
+    gap: 4px;
+    min-height: 0;
+  }
+
+  .time-display {
+    display: none;
+  }
+
+  .tags-container {
+    gap: 4px;
+
+    .session-tag {
+      max-width: 96px;
+
+      &--count {
+        padding: 0 5px;
+        color: var(--sub-text-color);
+      }
+    }
+  }
+}
+
+.session-item--compact.session-item--touch {
+  .action-btn--more {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+  }
+}
+
 @keyframes spin {
   from {
     transform: rotate(0deg);

--- a/apps/client/src/components/sidebar/SessionItem.tsx
+++ b/apps/client/src/components/sidebar/SessionItem.tsx
@@ -17,7 +17,9 @@ interface SessionItemProps {
   session: Session
   isActive: boolean
   isBatchMode: boolean
+  isCompactLayout: boolean
   isSelected: boolean
+  isTouchInteraction: boolean
   onSelect: (session: Session) => void
   onArchive: (id: string) => void | Promise<void>
   onDelete: (id: string) => void | Promise<void>
@@ -32,7 +34,9 @@ export function SessionItem({
   session,
   isActive,
   isBatchMode,
+  isCompactLayout,
   isSelected,
+  isTouchInteraction,
   onSelect,
   onArchive,
   onDelete,
@@ -44,6 +48,8 @@ export function SessionItem({
   const automationPrefix = 'automation:'
   const itemContentRef = useRef<HTMLDivElement | null>(null)
   const [pendingAction, setPendingAction] = useState<PendingSessionAction>(null)
+  const showCompactActionMenu = isCompactLayout || isTouchInteraction
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
   useEffect(() => {
     if (pendingAction == null) {
@@ -83,6 +89,9 @@ export function SessionItem({
 
   const archiveActionLabel = session.isArchived ? t('common.restore') : t('common.archive')
   const archiveConfirmLabel = t('common.confirmAction', { action: archiveActionLabel })
+  const sessionTags = session.tags ?? []
+  const visibleTags = isCompactLayout ? sessionTags.slice(0, 1) : sessionTags
+  const hiddenTagCount = Math.max(sessionTags.length - visibleTags.length, 0)
 
   const displayTitle = (session.title != null && session.title !== '')
     ? session.title
@@ -138,7 +147,7 @@ export function SessionItem({
         break
       case 'waiting_input':
         return (
-          <Tooltip title={title}>
+          <Tooltip title={resolveTooltipTitle(title)}>
             <div className='waiting-input-indicator' />
           </Tooltip>
         )
@@ -147,7 +156,7 @@ export function SessionItem({
     }
 
     return (
-      <Tooltip title={title}>
+      <Tooltip title={resolveTooltipTitle(title)}>
         <span
           className={`material-symbols-rounded status-icon ${status === 'running' ? 'spin' : ''}`}
           style={{
@@ -192,7 +201,7 @@ export function SessionItem({
         }}
         className={`session-item ${isActive ? 'active' : ''} ${isSelected ? 'selected' : ''} ${
           session.isStarred ? 'starred' : ''
-        }`}
+        } ${isCompactLayout ? 'session-item--compact' : ''} ${showCompactActionMenu ? 'session-item--touch' : ''}`}
       >
         <div ref={itemContentRef} className='session-item-content'>
           <div className={`session-leading ${adapterDisplay?.icon != null ? 'has-adapter' : ''}`}>
@@ -218,71 +227,102 @@ export function SessionItem({
               <div className='session-header-side'>
                 {!isBatchMode && (
                   <>
-                    <Tooltip title={timeDisplay.full}>
-                      <span className='time-display'>
-                        {timeDisplay.relative}
-                      </span>
-                    </Tooltip>
-                    <div className='session-item-actions'>
-                      <Tooltip title={session.isStarred ? t('common.unstar') : t('common.star')}>
-                        <Button
-                          type='text'
-                          size='small'
-                          className={`action-btn star-btn ${session.isStarred ? 'starred' : ''}`}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setPendingAction(null)
-                            void onStar(session.id, !session.isStarred)
-                          }}
-                          icon={
-                            <span
-                              className={`material-symbols-rounded ${session.isStarred ? 'filled' : ''}`}
-                            >
-                              star
-                            </span>
-                          }
-                        />
+                    {!isCompactLayout && (
+                      <Tooltip title={resolveTooltipTitle(timeDisplay.full)}>
+                        <span className='time-display'>
+                          {timeDisplay.relative}
+                        </span>
                       </Tooltip>
-                      <Tooltip
-                        title={pendingAction === 'archive' ? archiveConfirmLabel : archiveActionLabel}
-                      >
-                        <Button
-                          type='text'
-                          size='small'
-                          className={`action-btn archive-btn ${pendingAction === 'archive' ? 'is-confirming' : ''}`}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleConfirmableActionClick('archive')
-                          }}
+                    )}
+                    {showCompactActionMenu
+                      ? (
+                        <SessionContextMenu
+                          session={session}
+                          trigger={['click']}
+                          onArchive={onArchive}
+                          onDelete={onDelete}
+                          onRename={onRename}
+                          onStar={onStar}
                         >
-                          <span className='material-symbols-rounded'>
-                            {session.isArchived ? 'unarchive' : 'archive'}
-                          </span>
-                          {pendingAction === 'archive' && (
-                            <span className='action-btn__label'>{archiveConfirmLabel}</span>
-                          )}
-                        </Button>
-                      </Tooltip>
-                    </div>
+                          <Button
+                            type='text'
+                            size='small'
+                            className='action-btn action-btn--more'
+                            title={t('common.moreActions')}
+                            aria-label={t('common.moreActions')}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                            }}
+                            icon={<span className='material-symbols-rounded'>more_horiz</span>}
+                          />
+                        </SessionContextMenu>
+                      )
+                      : (
+                        <div className='session-item-actions'>
+                          <Tooltip
+                            title={resolveTooltipTitle(session.isStarred ? t('common.unstar') : t('common.star'))}
+                          >
+                            <Button
+                              type='text'
+                              size='small'
+                              className={`action-btn star-btn ${session.isStarred ? 'starred' : ''}`}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setPendingAction(null)
+                                void onStar(session.id, !session.isStarred)
+                              }}
+                              icon={
+                                <span
+                                  className={`material-symbols-rounded ${session.isStarred ? 'filled' : ''}`}
+                                >
+                                  star
+                                </span>
+                              }
+                            />
+                          </Tooltip>
+                          <Tooltip
+                            title={resolveTooltipTitle(
+                              pendingAction === 'archive' ? archiveConfirmLabel : archiveActionLabel
+                            )}
+                          >
+                            <Button
+                              type='text'
+                              size='small'
+                              className={`action-btn archive-btn ${pendingAction === 'archive' ? 'is-confirming' : ''}`}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                handleConfirmableActionClick('archive')
+                              }}
+                            >
+                              <span className='material-symbols-rounded'>
+                                {session.isArchived ? 'unarchive' : 'archive'}
+                              </span>
+                              {pendingAction === 'archive' && (
+                                <span className='action-btn__label'>{archiveConfirmLabel}</span>
+                              )}
+                            </Button>
+                          </Tooltip>
+                        </div>
+                      )}
                   </>
                 )}
               </div>
             </div>
-            {lastMessageSnippet != null && (
+            {!isCompactLayout && lastMessageSnippet != null && (
               <div className='last-message'>
                 {lastMessageSnippet}
               </div>
             )}
-            {session.tags != null && session.tags.length > 0 && (
+            {visibleTags.length > 0 && (
               <div className='tags-container'>
-                {session.tags.map((tag: string) => {
+                {visibleTags.map((tag: string) => {
                   const automationTag = parseAutomationTag(tag)
                   if (automationTag) {
                     const href = `/automation?rule=${encodeURIComponent(automationTag.ruleId)}`
                     return (
                       <Tooltip
                         key={tag}
-                        title={automationTag.ruleTitle}
+                        title={resolveTooltipTitle(automationTag.ruleTitle)}
                       >
                         <Tag
                           className='session-tag session-tag--automation'
@@ -302,7 +342,7 @@ export function SessionItem({
                   return (
                     <Tooltip
                       key={tag}
-                      title={tag}
+                      title={resolveTooltipTitle(tag)}
                     >
                       <Tag className='session-tag'>
                         <span className='session-tag__text'>
@@ -312,6 +352,11 @@ export function SessionItem({
                     </Tooltip>
                   )
                 })}
+                {hiddenTagCount > 0 && (
+                  <Tag className='session-tag session-tag--count'>
+                    +{hiddenTagCount}
+                  </Tag>
+                )}
               </div>
             )}
           </div>

--- a/apps/client/src/components/sidebar/SessionList.tsx
+++ b/apps/client/src/components/sidebar/SessionList.tsx
@@ -11,7 +11,9 @@ interface SessionListProps {
   activeId?: string
   hasActiveFilters: boolean
   isBatchMode: boolean
+  isCompactLayout: boolean
   selectedIds: Set<string>
+  isTouchInteraction: boolean
   searchQuery?: string
   onSelectSession: (session: Session) => void
   onArchiveSession: (id: string) => void | Promise<void>
@@ -26,7 +28,9 @@ export function SessionList({
   activeId,
   hasActiveFilters,
   isBatchMode,
+  isCompactLayout,
   selectedIds,
+  isTouchInteraction,
   searchQuery,
   onSelectSession,
   onArchiveSession,
@@ -142,7 +146,9 @@ export function SessionList({
                   session={s}
                   isActive={activeId === s.id}
                   isBatchMode={isBatchMode}
+                  isCompactLayout={isCompactLayout}
                   isSelected={selectedIds.has(s.id)}
+                  isTouchInteraction={isTouchInteraction}
                   onSelect={onSelectSession}
                   onArchive={onArchiveSession}
                   onDelete={onDeleteSession}

--- a/apps/client/src/components/sidebar/SidebarHeader.scss
+++ b/apps/client/src/components/sidebar/SidebarHeader.scss
@@ -357,3 +357,52 @@
     }
   }
 }
+
+.sidebar-header--compact {
+  padding-top: 12px;
+
+  .header-top {
+    align-items: stretch;
+  }
+
+  .new-chat-btn {
+    height: 40px;
+    min-height: 40px;
+    padding: 0 12px;
+    font-size: 13px;
+  }
+
+  .sidebar-collapse-btn,
+  .sidebar-new-chat-btn {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    border-radius: 8px;
+  }
+
+  .header-search-row {
+    margin-top: 8px;
+  }
+
+  .search-input {
+    height: 40px;
+    min-height: 40px;
+    padding: 0 10px !important;
+
+    .ant-input {
+      font-size: 13px;
+    }
+
+    .search-toggle-button {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+    }
+  }
+
+  .toolbar-filter-select .ant-select-selector,
+  .batch-select-toggle {
+    min-height: 40px;
+  }
+}

--- a/apps/client/src/components/sidebar/SidebarHeader.tsx
+++ b/apps/client/src/components/sidebar/SidebarHeader.tsx
@@ -4,6 +4,7 @@ import { Button, Tooltip } from 'antd'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import type { SidebarSessionSortOrder } from '#~/hooks/use-sidebar-query-state'
 import { SidebarHeaderSearchActions } from './SidebarHeaderSearchActions'
 
@@ -14,6 +15,7 @@ interface SidebarHeaderProps {
   createButtonRef: React.RefObject<HTMLButtonElement | null>
   hasActiveSearchControls: boolean
   isBatchMode: boolean
+  isCompactLayout: boolean
   isCreatingSession: boolean
   isSidebarCollapsed: boolean
   searchQuery: string
@@ -27,6 +29,7 @@ interface SidebarHeaderProps {
   onBatchDelete: () => void
   onBatchStar: () => void
   onAdapterFilterChange: (filters: string[]) => void
+  onCloseSidebar?: () => void
   onCreateSession: () => void
   onSearchChange: (query: string) => void
   onSortOrderChange: (sort?: SidebarSessionSortOrder) => void
@@ -43,6 +46,7 @@ export function SidebarHeader({
   createButtonRef,
   hasActiveSearchControls,
   isBatchMode,
+  isCompactLayout,
   isCreatingSession,
   isSidebarCollapsed,
   searchQuery,
@@ -56,6 +60,7 @@ export function SidebarHeader({
   onBatchDelete,
   onBatchStar,
   onAdapterFilterChange,
+  onCloseSidebar,
   onCreateSession,
   onSearchChange,
   onSortOrderChange,
@@ -65,11 +70,12 @@ export function SidebarHeader({
   onToggleSidebarCollapsed
 }: SidebarHeaderProps) {
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
   const [isSearchActionsOpen, setIsSearchActionsOpen] = useState(false)
   const shouldShowSearchActions = !isSidebarCollapsed && (isSearchActionsOpen || isBatchMode)
 
   return (
-    <div className='sidebar-header'>
+    <div className={`sidebar-header ${isCompactLayout ? 'sidebar-header--compact' : ''}`.trim()}>
       <div className='header-top'>
         {!isSidebarCollapsed
           ? (
@@ -93,7 +99,12 @@ export function SidebarHeader({
             </Button>
           )
           : (
-            <Tooltip title={isCreatingSession ? t('common.alreadyInNewChat') : t('common.newChat')} placement='right'>
+            <Tooltip
+              title={isTouchInteraction
+                ? undefined
+                : (isCreatingSession ? t('common.alreadyInNewChat') : t('common.newChat'))}
+              placement='right'
+            >
               <Button
                 className={`sidebar-new-chat-btn ${isCreatingSession ? 'active' : ''}`}
                 type='text'
@@ -106,14 +117,25 @@ export function SidebarHeader({
               </Button>
             </Tooltip>
           )}
-        <Tooltip title={isSidebarCollapsed ? t('common.expand') : t('common.collapse')}>
+        <Tooltip
+          title={isTouchInteraction ? undefined : (
+            isCompactLayout ? t('common.close') : (
+              isSidebarCollapsed ? t('common.expand') : t('common.collapse')
+            )
+          )}
+        >
           <Button
             className='sidebar-collapse-btn'
             type='text'
-            onClick={onToggleSidebarCollapsed}
+            aria-label={isCompactLayout ? t('common.close') : (
+              isSidebarCollapsed ? t('common.expand') : t('common.collapse')
+            )}
+            onClick={isCompactLayout
+              ? onCloseSidebar
+              : onToggleSidebarCollapsed}
           >
             <span className='material-symbols-rounded'>
-              {isSidebarCollapsed ? 'dock_to_right' : 'left_panel_close'}
+              {isCompactLayout ? 'close' : isSidebarCollapsed ? 'dock_to_right' : 'left_panel_close'}
             </span>
           </Button>
         </Tooltip>

--- a/apps/client/src/components/sidebar/SidebarHeaderBatchActions.tsx
+++ b/apps/client/src/components/sidebar/SidebarHeaderBatchActions.tsx
@@ -1,6 +1,8 @@
 import { Button, Checkbox, Popconfirm, Tooltip } from 'antd'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
+
 interface SidebarHeaderBatchActionsProps {
   isAllSelected: boolean
   selectedCount: number
@@ -21,10 +23,12 @@ export function SidebarHeaderBatchActions({
   onSelectAll
 }: SidebarHeaderBatchActionsProps) {
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
   return (
     <div className='header-batch-actions'>
-      <Tooltip title={isAllSelected ? t('common.deselectAll') : t('common.selectAll')}>
+      <Tooltip title={resolveTooltipTitle(isAllSelected ? t('common.deselectAll') : t('common.selectAll'))}>
         <label className='batch-select-toggle'>
           <Checkbox
             checked={isAllSelected}
@@ -33,7 +37,7 @@ export function SidebarHeaderBatchActions({
           />
         </label>
       </Tooltip>
-      <Tooltip title={t('common.star')}>
+      <Tooltip title={resolveTooltipTitle(t('common.star'))}>
         <Button
           className='sidebar-tool-btn is-icon-only'
           type='text'
@@ -50,7 +54,7 @@ export function SidebarHeaderBatchActions({
         okButtonProps={{ danger: false }}
         disabled={selectedCount === 0}
       >
-        <Tooltip title={t('common.archive')}>
+        <Tooltip title={resolveTooltipTitle(t('common.archive'))}>
           <Button
             className='sidebar-tool-btn is-icon-only'
             type='text'
@@ -67,7 +71,7 @@ export function SidebarHeaderBatchActions({
         okButtonProps={{ danger: true }}
         disabled={selectedCount === 0}
       >
-        <Tooltip title={t('common.delete')}>
+        <Tooltip title={resolveTooltipTitle(t('common.delete'))}>
           <Button
             className='sidebar-tool-btn is-icon-only is-danger'
             type='text'

--- a/apps/client/src/components/sidebar/SidebarHeaderSearchActions.tsx
+++ b/apps/client/src/components/sidebar/SidebarHeaderSearchActions.tsx
@@ -2,6 +2,7 @@ import { Button, Input, Tooltip } from 'antd'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 import type { SidebarSessionSortOrder } from '#~/hooks/use-sidebar-query-state'
 import { SidebarHeaderBatchActions } from './SidebarHeaderBatchActions'
 import { SidebarHeaderSelectField } from './SidebarHeaderSelectField'
@@ -56,9 +57,11 @@ export function SidebarHeaderSearchActions({
   onToggleSearchActions
 }: SidebarHeaderSearchActionsProps) {
   const { t } = useTranslation()
+  const { isTouchInteraction } = useResponsiveLayout()
   const isAllSelected = totalCount > 0 && selectedCount === totalCount
   const toOptions = useMemo(() => (values: string[]) => values.map((value) => ({ label: value, value })), [])
   const filterSuffixIcon = <span className='material-symbols-rounded toolbar-filter-chevron'>expand_more</span>
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
   const sortOptions = useMemo(
     () => [
       { label: t('automation.sortDesc'), value: 'desc' },
@@ -78,7 +81,7 @@ export function SidebarHeaderSearchActions({
             onChange={(e) => onSearchChange(e.target.value)}
             prefix={<span className='material-symbols-rounded search-icon'>search</span>}
             suffix={
-              <Tooltip title={t('common.searchActions')}>
+              <Tooltip title={resolveTooltipTitle(t('common.searchActions'))}>
                 <button
                   type='button'
                   className={`search-toggle-button ${shouldShowSearchActions ? 'is-open' : ''} ${
@@ -102,7 +105,7 @@ export function SidebarHeaderSearchActions({
             <div className='header-toolbar-leading'>
               {isBatchMode
                 ? (
-                  <Tooltip title={t('common.cancelBatch')}>
+                  <Tooltip title={resolveTooltipTitle(t('common.cancelBatch'))}>
                     <Button
                       className='sidebar-tool-btn is-icon-only'
                       type='text'
@@ -112,7 +115,7 @@ export function SidebarHeaderSearchActions({
                   </Tooltip>
                 )
                 : (
-                  <Tooltip title={t('common.batchMode')}>
+                  <Tooltip title={resolveTooltipTitle(t('common.batchMode'))}>
                     <Button
                       className='sidebar-tool-btn is-icon-only'
                       type='text'

--- a/apps/client/src/components/sidebar/SidebarUtilityFooter.tsx
+++ b/apps/client/src/components/sidebar/SidebarUtilityFooter.tsx
@@ -1,0 +1,69 @@
+import { Button, Dropdown } from 'antd'
+import type { MenuProps } from 'antd'
+import { useAtom } from 'jotai'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+import { themeAtom } from '#~/store'
+import { buildLanguageItems, buildThemeItems } from '../nav-rail-items'
+
+export function SidebarUtilityFooter() {
+  const { t, i18n } = useTranslation()
+  const [themeMode, setThemeMode] = useAtom(themeAtom)
+  const navigate = useNavigate()
+
+  const languageItems: MenuProps['items'] = useMemo(() =>
+    buildLanguageItems({
+      currentLanguage: i18n.language,
+      onChangeLanguage: (language) => i18n.changeLanguage(language)
+    }), [i18n.language])
+
+  const themeItems: MenuProps['items'] = useMemo(() =>
+    buildThemeItems({
+      setThemeMode,
+      t,
+      themeMode
+    }), [setThemeMode, t, themeMode])
+
+  return (
+    <div className='sidebar-utility-footer'>
+      <Dropdown menu={{ items: themeItems, triggerSubMenuAction: 'click' }} placement='topLeft' trigger={['click']}>
+        <Button
+          type='text'
+          className='sidebar-utility-footer__action'
+          icon={
+            <span className='material-symbols-rounded'>
+              {themeMode === 'light' ? 'light_mode' : themeMode === 'dark' ? 'dark_mode' : 'desktop_windows'}
+            </span>
+          }
+        >
+          <span>{t('common.theme')}</span>
+        </Button>
+      </Dropdown>
+
+      <Dropdown
+        menu={{ items: languageItems, triggerSubMenuAction: 'click' }}
+        placement='topLeft'
+        trigger={['click']}
+      >
+        <Button
+          type='text'
+          className='sidebar-utility-footer__action'
+          icon={<span className='material-symbols-rounded'>language</span>}
+        >
+          <span>{t('common.language')}</span>
+        </Button>
+      </Dropdown>
+
+      <Button
+        type='text'
+        className='sidebar-utility-footer__action'
+        icon={<span className='material-symbols-rounded'>settings</span>}
+        onClick={() => void navigate('/config')}
+      >
+        <span>{t('common.settings')}</span>
+      </Button>
+    </div>
+  )
+}

--- a/apps/client/src/hooks/chat/use-chat-scroll.ts
+++ b/apps/client/src/hooks/chat/use-chat-scroll.ts
@@ -6,6 +6,7 @@ export function useChatScroll({ contentVersion }: { contentVersion: number }) {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const messagesContentRef = useRef<HTMLDivElement>(null)
+  const scrollTimeoutRef = useRef<number | null>(null)
   const [showScrollBottom, setShowScrollBottom] = useState(false)
 
   const updateScrollState = useCallback(() => {
@@ -15,16 +16,30 @@ export function useChatScroll({ contentVersion }: { contentVersion: number }) {
     setShowScrollBottom(distanceToBottom > SCROLL_THRESHOLD)
   }, [])
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    setTimeout(() => {
-      if (messagesContainerRef.current) {
-        messagesContainerRef.current.scrollTo({
-          top: messagesContainerRef.current.scrollHeight,
-          behavior
-        })
-      }
-    }, 50)
+  const clearScrollTimeout = useCallback(() => {
+    if (scrollTimeoutRef.current == null) {
+      return
+    }
+
+    window.clearTimeout(scrollTimeoutRef.current)
+    scrollTimeoutRef.current = null
   }, [])
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    clearScrollTimeout()
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      const container = messagesContainerRef.current
+      scrollTimeoutRef.current = null
+      if (!container) {
+        return
+      }
+
+      container.scrollTo({
+        top: container.scrollHeight,
+        behavior
+      })
+    }, 50)
+  }, [clearScrollTimeout])
 
   useEffect(() => {
     const container = messagesContainerRef.current
@@ -40,6 +55,8 @@ export function useChatScroll({ contentVersion }: { contentVersion: number }) {
   useEffect(() => {
     updateScrollState()
   }, [contentVersion, updateScrollState])
+
+  useEffect(() => clearScrollTimeout, [clearScrollTimeout])
 
   return {
     messagesEndRef,

--- a/apps/client/src/hooks/use-responsive-layout.ts
+++ b/apps/client/src/hooks/use-responsive-layout.ts
@@ -1,0 +1,115 @@
+import { useSyncExternalStore } from 'react'
+
+const COMPACT_LAYOUT_QUERY = '(max-width: 960px)'
+const TOUCH_INTERACTION_QUERY = '(hover: none), (pointer: coarse)'
+
+export interface ResponsiveLayoutState {
+  isCompactLayout: boolean
+  isTouchInteraction: boolean
+}
+
+const DEFAULT_RESPONSIVE_LAYOUT: ResponsiveLayoutState = {
+  isCompactLayout: false,
+  isTouchInteraction: false
+}
+
+const listeners = new Set<() => void>()
+
+let compactMediaQuery: MediaQueryList | null = null
+let touchMediaQuery: MediaQueryList | null = null
+let currentSnapshot = DEFAULT_RESPONSIVE_LAYOUT
+let mediaListenersInstalled = false
+let removeMediaQueryListeners: (() => void) | null = null
+
+const getMediaQueryMatch = (query: string) => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+
+  return window.matchMedia(query).matches
+}
+
+const readResponsiveLayoutSnapshot = (): ResponsiveLayoutState => ({
+  isCompactLayout: compactMediaQuery?.matches ?? getMediaQueryMatch(COMPACT_LAYOUT_QUERY),
+  isTouchInteraction: touchMediaQuery?.matches ?? getMediaQueryMatch(TOUCH_INTERACTION_QUERY)
+})
+
+const isSameResponsiveLayoutSnapshot = (
+  left: ResponsiveLayoutState,
+  right: ResponsiveLayoutState
+) => left.isCompactLayout === right.isCompactLayout && left.isTouchInteraction === right.isTouchInteraction
+
+const refreshResponsiveLayoutSnapshot = () => {
+  const nextSnapshot = readResponsiveLayoutSnapshot()
+  if (!isSameResponsiveLayoutSnapshot(currentSnapshot, nextSnapshot)) {
+    currentSnapshot = nextSnapshot
+  }
+
+  return currentSnapshot
+}
+
+const emitIfChanged = () => {
+  const nextSnapshot = readResponsiveLayoutSnapshot()
+  if (isSameResponsiveLayoutSnapshot(currentSnapshot, nextSnapshot)) {
+    return
+  }
+
+  currentSnapshot = nextSnapshot
+  listeners.forEach(listener => listener())
+}
+
+const addMediaQueryListener = (mediaQuery: MediaQueryList, listener: () => void) => {
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', listener)
+    return () => mediaQuery.removeEventListener('change', listener)
+  }
+
+  mediaQuery.addListener(listener)
+  return () => mediaQuery.removeListener(listener)
+}
+
+const ensureResponsiveLayoutListeners = () => {
+  if (
+    mediaListenersInstalled ||
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return
+  }
+
+  compactMediaQuery = window.matchMedia(COMPACT_LAYOUT_QUERY)
+  touchMediaQuery = window.matchMedia(TOUCH_INTERACTION_QUERY)
+  currentSnapshot = refreshResponsiveLayoutSnapshot()
+  const removeCompactMediaQueryListener = addMediaQueryListener(compactMediaQuery, emitIfChanged)
+  const removeTouchMediaQueryListener = addMediaQueryListener(touchMediaQuery, emitIfChanged)
+  removeMediaQueryListeners = () => {
+    removeCompactMediaQueryListener()
+    removeTouchMediaQueryListener()
+    compactMediaQuery = null
+    touchMediaQuery = null
+    mediaListenersInstalled = false
+  }
+  mediaListenersInstalled = true
+}
+
+const subscribeResponsiveLayout = (listener: () => void) => {
+  ensureResponsiveLayoutListeners()
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) {
+      removeMediaQueryListeners?.()
+      removeMediaQueryListeners = null
+    }
+  }
+}
+
+const getResponsiveLayoutSnapshot = () => refreshResponsiveLayoutSnapshot()
+
+export function useResponsiveLayout() {
+  return useSyncExternalStore(
+    subscribeResponsiveLayout,
+    getResponsiveLayoutSnapshot,
+    () => DEFAULT_RESPONSIVE_LAYOUT
+  )
+}

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -165,6 +165,8 @@
     "lastRunAt": "Last run: {{time}}",
     "noRunYet": "No runs yet",
     "emptyRules": "No automation rules",
+    "mobileRules": "Rules",
+    "mobileDetails": "Details",
     "selectRule": "Select an automation rule",
     "ruleId": "Rule ID",
     "createdAt": "Created At",
@@ -209,6 +211,8 @@
     "caseId": "Case:",
     "searchPlaceholder": "Search category, title, or summary",
     "emptyCases": "No benchmark cases",
+    "mobileCases": "Cases",
+    "mobileDetails": "Details",
     "noSummary": "No summary",
     "configTitle": "Case Config",
     "baseCommit": "Base Commit",
@@ -654,6 +658,7 @@
       "announcements": {
         "title": "Announcements"
       },
+      "moreCount": "{{count}} more",
       "specs": {
         "title": "Existing Flows",
         "params": "{{count}} params",

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -166,6 +166,8 @@
     "lastRunAt": "最近运行：{{time}}",
     "noRunYet": "暂无运行记录",
     "emptyRules": "暂无自动化任务",
+    "mobileRules": "规则",
+    "mobileDetails": "详情",
     "selectRule": "请选择一个自动化任务",
     "ruleId": "规则 ID",
     "createdAt": "创建时间",
@@ -210,6 +212,8 @@
     "caseId": "用例：",
     "searchPlaceholder": "搜索分类、标题或摘要",
     "emptyCases": "暂无 benchmark 用例",
+    "mobileCases": "用例",
+    "mobileDetails": "详情",
     "noSummary": "暂无摘要",
     "configTitle": "用例配置",
     "baseCommit": "基线 Commit",
@@ -655,6 +659,7 @@
       "announcements": {
         "title": "最新公告"
       },
+      "moreCount": "还有 {{count}} 项",
       "specs": {
         "title": "已有流程",
         "params": "{{count}} 个参数",

--- a/apps/client/src/routes/ChatRoute.scss
+++ b/apps/client/src/routes/ChatRoute.scss
@@ -30,11 +30,18 @@
 .new-session-guide-wrapper {
   display: flex;
   justify-content: center;
+  width: 100%;
+  min-width: 0;
 }
 
 .chat-messages {
   flex: 1;
+  min-width: 0;
+  min-height: 0;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable both-edges;
   padding: 6px 12px 0;
   position: relative;
   opacity: 0;
@@ -50,7 +57,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0;
   min-height: 100%;
+  padding-bottom: 8px;
 }
 
 .chat-turn {
@@ -206,6 +215,7 @@
   align-self: center;
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin: 0 auto;
   padding: 8px 14px;
@@ -219,7 +229,10 @@
   color: #2563eb;
   font-size: 13px;
   font-weight: 500;
-  box-shadow: 0 8px 24px rgba(59, 130, 246, .08);
+  line-height: 1.4;
+  max-width: 100%;
+  text-align: center;
+  box-shadow: none;
 
   .material-symbols-rounded {
     font-size: 16px;
@@ -231,6 +244,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
   justify-content: flex-end;
   transition:
     flex .4s cubic-bezier(.4, 0, .2, 1),
@@ -239,13 +253,15 @@
 
 .chat-composer-stack {
   flex: 0;
-  padding: 0 12px 8px;
+  min-width: 0;
+  padding: 0 12px max(8px, env(safe-area-inset-bottom));
 }
 
 .chat-composer-stack__inner {
   width: 100%;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .chat-composer-stack__inner > * {
@@ -275,20 +291,21 @@
 
 .scroll-bottom-btn {
   position: sticky;
-  bottom: 24px;
+  bottom: max(16px, env(safe-area-inset-bottom));
   left: 100%;
-  transform: translateX(-40px);
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  transform: translateX(-44px);
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, .1);
+  box-shadow: none;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   color: var(--sub-text-color, #6b7280);
+  touch-action: manipulation;
   z-index: 10;
 
   &:hover {
@@ -327,7 +344,83 @@
 }
 
 @media (max-width: 768px) {
+  .chat-container.is-new-session {
+    .new-session-guide-wrapper.is-compact-layout {
+      flex: 1;
+      min-height: 0;
+      align-items: stretch;
+      justify-content: flex-start;
+      overflow-y: auto;
+      overscroll-behavior-y: contain;
+      -webkit-overflow-scrolling: touch;
+      padding: max(8px, env(safe-area-inset-top))
+        max(12px, env(safe-area-inset-right)) 12px
+        max(12px, env(safe-area-inset-left));
+    }
+
+    .chat-composer-stack {
+      padding-top: 0;
+    }
+  }
+
+  .chat-messages {
+    padding: 6px max(12px, env(safe-area-inset-right)) 0
+      max(12px, env(safe-area-inset-left));
+  }
+
+  .chat-turn-summary {
+    gap: 8px;
+    font-size: 12px;
+
+    &::before,
+    &::after {
+      min-width: 18px;
+    }
+  }
+
+  .chat-turn-summary__content {
+    flex: 1;
+    justify-content: center;
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+
+  .chat-turn-summary__meta {
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: 2px;
+  }
+
+  .chat-turn-summary__time,
+  .chat-turn-summary__count {
+    white-space: normal;
+  }
+
+  .chat-turn-summary__count::before {
+    margin-right: 6px;
+  }
+
+  .chat-pending-session-banner {
+    width: min(100%, 320px);
+    padding: 8px 12px;
+    border-radius: 8px;
+  }
+
   .chat-composer-stack {
-    padding: 0 12px 8px;
+    padding: 0 max(12px, env(safe-area-inset-right))
+      max(8px, env(safe-area-inset-bottom))
+      max(12px, env(safe-area-inset-left));
+  }
+
+  .chat-settings-panel {
+    padding: 12px max(12px, env(safe-area-inset-right))
+      calc(16px + env(safe-area-inset-bottom))
+      max(12px, env(safe-area-inset-left));
+  }
+
+  .scroll-bottom-btn {
+    transform: translateX(-48px);
+    width: 40px;
+    height: 40px;
   }
 }

--- a/apps/client/src/routes/ChatRoute.tsx
+++ b/apps/client/src/routes/ChatRoute.tsx
@@ -1,6 +1,7 @@
 import './ChatRoute.scss'
 
 import { Button, Empty } from 'antd'
+import { useSetAtom } from 'jotai'
 import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
@@ -17,6 +18,8 @@ import { buildChatHistoryStatusNotices } from '#~/components/chat/messages/build
 import { ChatTerminalView } from '#~/components/chat/terminal/ChatTerminalView.js'
 import { useChatSession } from '#~/hooks/chat/use-chat-session'
 import { useTerminalDockVisibility } from '#~/hooks/chat/use-terminal-dock-visibility'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
+import { isMobileSidebarOpenAtom } from '#~/store/index'
 
 export function ChatRoute() {
   const { t } = useTranslation()
@@ -27,9 +30,7 @@ export function ChatRoute() {
     () => listSessions('active')
   )
   const session = sessionId == null ? undefined : sessionsRes?.sessions.find(item => item.id === sessionId)
-
   if (sessionId != null && isLoading) return null
-
   if (sessionId != null && session == null) {
     return (
       <div className='chat-route__empty-state'>
@@ -45,6 +46,9 @@ export function ChatRoute() {
 function ChatRouteView({ session }: { session?: Session }) {
   const { t } = useTranslation()
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const { isCompactLayout } = useResponsiveLayout()
+  const setIsMobileSidebarOpen = useSetAtom(isMobileSidebarOpenAtom)
   const {
     messages,
     sessionInfo,
@@ -99,9 +103,10 @@ function ChatRouteView({ session }: { session?: Session }) {
   const isEmptyNewSession = !session?.id && messages.length === 0 && historyStatusNotices.length === 0
   const resolvedActiveView = session?.id != null ? activeView : 'history'
   const shouldShowTerminal = session?.id != null && isTerminalOpen
-  const { isRendered: isTerminalRendered, isVisible: isTerminalVisible } = useTerminalDockVisibility(shouldShowTerminal)
+  const { isRendered: isTerminalRendered, isVisible: isTerminalVisible } = useTerminalDockVisibility(
+    shouldShowTerminal
+  )
   const handledDeepLinkTargetRef = useRef('')
-
   useEffect(() => {
     if (deepLinkTargetKey === '') {
       handledDeepLinkTargetRef.current = ''
@@ -112,31 +117,35 @@ function ChatRouteView({ session }: { session?: Session }) {
       }
     }
   }, [activeView, deepLinkTargetKey, setActiveView])
-
   return (
     <div
       className={`chat-container ${isReady ? 'ready' : ''} ${isEmptyNewSession ? 'is-new-session' : ''} ${
         shouldShowTerminal ? 'has-terminal' : ''
       }`}
     >
-      {session?.id && (
+      {(session?.id != null || isCompactLayout) && (
         <ChatHeader
           sessionInfo={sessionInfo}
-          sessionId={session.id}
-          sessionTitle={session.title}
-          sessionStatus={session.status}
-          isStarred={session.isStarred}
-          isArchived={session.isArchived}
-          tags={session.tags}
-          lastMessage={session.lastMessage}
-          lastUserMessage={session.lastUserMessage}
+          sessionId={session?.id}
+          sessionTitle={session?.title}
+          sessionStatus={session?.status}
+          isStarred={session?.isStarred}
+          isArchived={session?.isArchived}
+          tags={session?.tags}
+          lastMessage={session?.lastMessage}
+          lastUserMessage={session?.lastUserMessage}
           activeView={resolvedActiveView}
           isTerminalOpen={isTerminalOpen}
+          onCreateSession={() => {
+            void navigate('/')
+          }}
+          onOpenSidebar={() => {
+            setIsMobileSidebarOpen(true)
+          }}
           onViewChange={setActiveView}
           onToggleTerminal={() => setIsTerminalOpen(!isTerminalOpen)}
         />
       )}
-
       {resolvedActiveView === 'history' && (
         <ChatHistoryView
           isReady={isReady}
@@ -175,26 +184,11 @@ function ChatRouteView({ session }: { session?: Session }) {
           hasAvailableModels={hasAvailableModels}
         />
       )}
-
-      {resolvedActiveView === 'timeline' && (
-        <ChatTimelineView messages={messages} />
-      )}
-
-      {resolvedActiveView === 'settings' && session?.id && (
-        <ChatSettingsView
-          session={session}
-          sessionInfo={sessionInfo}
-          onClose={() => setActiveView('history')}
-        />
-      )}
-
-      {isTerminalRendered && session?.id && (
-        <ChatTerminalView
-          isOpen={isTerminalVisible}
-          sessionId={session.id}
-          onClose={() => setIsTerminalOpen(false)}
-        />
-      )}
+      {resolvedActiveView === 'timeline' && <ChatTimelineView messages={messages} />}
+      {resolvedActiveView === 'settings' && session?.id &&
+        <ChatSettingsView session={session} sessionInfo={sessionInfo} onClose={() => setActiveView('history')} />}
+      {isTerminalRendered && session?.id &&
+        <ChatTerminalView isOpen={isTerminalVisible} sessionId={session.id} onClose={() => setIsTerminalOpen(false)} />}
     </div>
   )
 }

--- a/apps/client/src/store/index.ts
+++ b/apps/client/src/store/index.ts
@@ -11,6 +11,8 @@ export const isSidebarResizingAtom = atom<boolean>(false)
 // 侧边栏是否折叠
 export const isSidebarCollapsedAtom = atom(false)
 
+export const isMobileSidebarOpenAtom = atom(false)
+
 // 当前选中的会话 ID (全局 UI 状态，用于控制高亮等)
 export const activeSessionIdAtom = atom<string | undefined>(undefined)
 


### PR DESCRIPTION
## Summary
- polish the mobile chat shell, sender, status bar, sidebar, and compact navigation flow
- adapt timeline, settings, config, automation, benchmark, knowledge, terminal, and archive views for narrow touch layouts
- share responsive layout state to avoid per-row matchMedia listeners and tighten compact controls for mobile

## Verification
- pnpm typecheck
- pnpm exec eslint apps/client/src/components apps/client/src/hooks apps/client/src/routes apps/client/src/store/index.ts
- pnpm exec dprint check <changed apps/client/src files>
- git diff --check