### PR TITLE
Support launch-dir env overrides for workspace and config paths

### DIFF
--- a/apps/client/cli.cjs
+++ b/apps/client/cli.cjs
@@ -2,20 +2,15 @@ const { realpathSync } = require('node:fs')
 const { resolve } = require('node:path')
 const process = require('node:process')
 
-const resolveAiBaseDir = () => (
-  process.env.__VF_PROJECT_AI_BASE_DIR__?.trim()?.replace(/[\\/]+$/, '') || '.ai'
-)
+const {
+  resolveProjectAiBaseDir,
+  resolveProjectWorkspaceFolder
+} = require('@vibe-forge/register/dotenv')
 
-require('@vibe-forge/register/dotenv')
-
-process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ?? process.cwd()
+process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
 process.env.__VF_PROJECT_PACKAGE_DIR__ = __dirname
 process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
-process.env.HOME = resolve(
-  process.env.__VF_PROJECT_WORKSPACE_FOLDER__,
-  resolveAiBaseDir(),
-  '.mock'
-)
+process.env.HOME = resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
 
 const cwd = realpathSync(resolve(__dirname, './'))
 const args = process.env.__VF_PROJECT_AI_CLIENT_MODE__ === 'dev' ? [] : ['preview']

--- a/apps/server/cli.js
+++ b/apps/server/cli.js
@@ -1,20 +1,15 @@
 const { resolve } = require('node:path')
 const process = require('node:process')
 
-const resolveAiBaseDir = () => (
-  process.env.__VF_PROJECT_AI_BASE_DIR__?.trim()?.replace(/[\\/]+$/, '') || '.ai'
-)
+const {
+  resolveProjectAiBaseDir,
+  resolveProjectWorkspaceFolder
+} = require('@vibe-forge/register/dotenv')
 
-require('@vibe-forge/register/dotenv')
-
-process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ?? process.cwd()
+process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
 process.env.__VF_PROJECT_PACKAGE_DIR__ = __dirname
 process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
-process.env.HOME = resolve(
-  process.env.__VF_PROJECT_WORKSPACE_FOLDER__,
-  resolveAiBaseDir(),
-  '.mock'
-)
+process.env.HOME = resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
 
 require('node:child_process').spawnSync(
   'node',

--- a/packages/cli-helper/entry.js
+++ b/packages/cli-helper/entry.js
@@ -1,10 +1,6 @@
 const path = require('node:path')
 const process = require('node:process')
 
-const resolveAiBaseDir = () => (
-  process.env.__VF_PROJECT_AI_BASE_DIR__?.trim()?.replace(/[\\/]+$/, '') || '.ai'
-)
-
 const runCliPackageEntrypoint = (options) => {
   const {
     packageDir,
@@ -16,16 +12,15 @@ const runCliPackageEntrypoint = (options) => {
     throw new Error('packageDir is required')
   }
 
-  require('@vibe-forge/register/dotenv')
+  const {
+    resolveProjectAiBaseDir,
+    resolveProjectWorkspaceFolder
+  } = require('@vibe-forge/register/dotenv')
 
-  process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ?? process.cwd()
+  process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
   process.env.__VF_PROJECT_PACKAGE_DIR__ = packageDir
   process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
-  process.env.HOME = path.resolve(
-    process.env.__VF_PROJECT_WORKSPACE_FOLDER__,
-    resolveAiBaseDir(),
-    '.mock'
-  )
+  process.env.HOME = path.resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
   process.env.__VF_PROJECT_CLI_BIN_SOURCE_ENTRY__ = sourceEntry
   process.env.__VF_PROJECT_CLI_BIN_DIST_ENTRY__ = distEntry
 

--- a/packages/config/__tests__/load.spec.ts
+++ b/packages/config/__tests__/load.spec.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { loadConfig, resetConfigCache } from '#~/load.js'
+import { buildConfigJsonVariables, loadConfig, resetConfigCache } from '#~/load.js'
 
 const DISABLE_DEV_CONFIG_ENV = '__VF_PROJECT_AI_DISABLE_DEV_CONFIG__'
 
@@ -89,6 +89,56 @@ describe('loadConfig', () => {
       resetConfigCache()
       await rm(primaryDir, { force: true, recursive: true })
       await rm(worktreeDir, { force: true, recursive: true })
+    }
+  })
+
+  it('loads project config from __VF_PROJECT_CONFIG_DIR__ while keeping workspace json variables', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-workspace-'))
+    const launchDir = path.join(workspaceDir, 'c', 'd', 'e')
+    const previousConfigDir = process.env.__VF_PROJECT_CONFIG_DIR__
+    const previousLaunchCwd = process.env.__VF_PROJECT_LAUNCH_CWD__
+    const previousWorkspaceFolder = process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+
+    try {
+      await mkdir(launchDir, { recursive: true })
+      await writeFile(
+        path.join(launchDir, '.ai.config.json'),
+        JSON.stringify({
+          env: {
+            WORKSPACE_ROOT: '${WORKSPACE_FOLDER}'
+          }
+        })
+      )
+
+      process.env.__VF_PROJECT_LAUNCH_CWD__ = launchDir
+      process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = '../../..'
+      process.env.__VF_PROJECT_CONFIG_DIR__ = '.'
+      resetConfigCache()
+
+      const [projectConfig] = await loadConfig({
+        cwd: launchDir,
+        jsonVariables: buildConfigJsonVariables(launchDir, process.env)
+      })
+
+      expect(projectConfig?.env?.WORKSPACE_ROOT).toBe(workspaceDir)
+    } finally {
+      if (previousConfigDir == null) {
+        delete process.env.__VF_PROJECT_CONFIG_DIR__
+      } else {
+        process.env.__VF_PROJECT_CONFIG_DIR__ = previousConfigDir
+      }
+      if (previousLaunchCwd == null) {
+        delete process.env.__VF_PROJECT_LAUNCH_CWD__
+      } else {
+        process.env.__VF_PROJECT_LAUNCH_CWD__ = previousLaunchCwd
+      }
+      if (previousWorkspaceFolder == null) {
+        delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+      } else {
+        process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = previousWorkspaceFolder
+      }
+      resetConfigCache()
+      await rm(workspaceDir, { force: true, recursive: true })
     }
   })
 

--- a/packages/config/__tests__/update.spec.ts
+++ b/packages/config/__tests__/update.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
@@ -185,6 +185,58 @@ describe('updateConfigFile', () => {
       })
     } finally {
       await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes config updates into __VF_PROJECT_CONFIG_DIR__ when provided', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-update-workspace-'))
+    const launchDir = path.join(workspaceDir, 'c', 'd', 'e')
+    const previousConfigDir = process.env.__VF_PROJECT_CONFIG_DIR__
+    const previousLaunchCwd = process.env.__VF_PROJECT_LAUNCH_CWD__
+    const previousWorkspaceFolder = process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+
+    try {
+      await mkdir(launchDir, { recursive: true })
+      await writeFile(
+        path.join(launchDir, '.ai.config.json'),
+        JSON.stringify({
+          defaultModel: 'gpt-5.4'
+        }, null, 2)
+      )
+
+      process.env.__VF_PROJECT_LAUNCH_CWD__ = launchDir
+      process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = '../../..'
+      process.env.__VF_PROJECT_CONFIG_DIR__ = '.'
+
+      const result = await updateConfigFile({
+        workspaceFolder: launchDir,
+        source: 'project',
+        section: 'general',
+        value: {
+          defaultModel: 'gpt-5.4-mini'
+        }
+      })
+
+      expect(result.configPath).toBe(path.join(launchDir, '.ai.config.json'))
+      const written = JSON.parse(await readFile(result.configPath, 'utf-8'))
+      expect(written.defaultModel).toBe('gpt-5.4-mini')
+    } finally {
+      if (previousConfigDir == null) {
+        delete process.env.__VF_PROJECT_CONFIG_DIR__
+      } else {
+        process.env.__VF_PROJECT_CONFIG_DIR__ = previousConfigDir
+      }
+      if (previousLaunchCwd == null) {
+        delete process.env.__VF_PROJECT_LAUNCH_CWD__
+      } else {
+        process.env.__VF_PROJECT_LAUNCH_CWD__ = previousLaunchCwd
+      }
+      if (previousWorkspaceFolder == null) {
+        delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+      } else {
+        process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = previousWorkspaceFolder
+      }
+      await rm(workspaceDir, { recursive: true, force: true })
     }
   })
 })

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -6,6 +6,11 @@ import { dirname, extname, resolve } from 'node:path'
 import process from 'node:process'
 
 import type { Config } from '@vibe-forge/types'
+import {
+  PROJECT_WORKSPACE_FOLDER_ENV,
+  resolveProjectConfigDir,
+  resolveProjectWorkspaceFolder
+} from '@vibe-forge/utils'
 import { load } from 'js-yaml'
 
 import { mergeDefaultVibeForgeMcpPermissions } from './default-vibe-forge-mcp'
@@ -43,10 +48,12 @@ const serializeJsonVariables = (value: Record<string, string | null | undefined>
 )
 
 const resolveConfigCacheKey = (options: LoadConfigOptions) => {
-  const cwd = options.cwd ?? process.cwd()
+  const launchCwd = options.cwd ?? process.cwd()
+  const workspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
+  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? resolve(launchCwd)
   const disableDevConfig = options.disableDevConfig === true ? '1' : '0'
   const jsonVariables = serializeJsonVariables(options.jsonVariables ?? {})
-  return `${cwd}\n${disableDevConfig}\n${jsonVariables}`
+  return `${launchCwd}\n${workspaceFolder}\n${configCwd}\n${disableDevConfig}\n${jsonVariables}`
 }
 
 const resolveConfigPath = (cwd: string, filePath: string) => resolve(cwd, filePath)
@@ -109,8 +116,8 @@ export const buildConfigJsonVariables = (
   env: Record<string, string | null | undefined> = process.env
 ) => ({
   ...env,
-  WORKSPACE_FOLDER: cwd,
-  __VF_PROJECT_WORKSPACE_FOLDER__: cwd
+  WORKSPACE_FOLDER: resolveProjectWorkspaceFolder(cwd, env),
+  [PROJECT_WORKSPACE_FOLDER_ENV]: resolveProjectWorkspaceFolder(cwd, env)
 })
 
 const isRecord = (value: unknown): value is Record<string, unknown> => (
@@ -342,14 +349,16 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
     return cachedConfig as Promise<readonly [Config | undefined, Config | undefined]>
   }
 
-  const cwd = options.cwd ?? process.cwd()
+  const launchCwd = options.cwd ?? process.cwd()
+  const workspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
+  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? resolve(launchCwd)
   const shouldLoadDevConfig = options.disableDevConfig !== true &&
     process.env[DISABLE_DEV_CONFIG_ENV] !== '1'
   const jsonVariables = options.jsonVariables ?? {}
 
   const nextConfig = (async () => {
     const projectConfig = await loadConfigFromPaths(
-      cwd,
+      configCwd,
       [
         './.ai.config.json',
         './infra/.ai.config.json',
@@ -364,7 +373,7 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
     let userConfig: Config | undefined
     if (shouldLoadDevConfig) {
       userConfig = await loadConfigFromPaths(
-        cwd,
+        configCwd,
         [
           './.ai.dev.config.json',
           './infra/.ai.dev.config.json',
@@ -376,7 +385,7 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
         jsonVariables
       )
       if (userConfig == null) {
-        const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(cwd)
+        const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder)
         if (primaryWorkspaceFolder != null) {
           userConfig = await loadConfigFromPaths(
             primaryWorkspaceFolder,

--- a/packages/config/src/update.ts
+++ b/packages/config/src/update.ts
@@ -5,6 +5,10 @@ import { dirname, extname, resolve } from 'node:path'
 import process from 'node:process'
 
 import type { Config, ConfigSource } from '@vibe-forge/types'
+import {
+  resolveProjectConfigDir,
+  resolveProjectWorkspaceFolder
+} from '@vibe-forge/utils'
 import { dump, load } from 'js-yaml'
 
 import { resetConfigCache } from './load'
@@ -76,17 +80,23 @@ const resolvePrimaryWorkspaceFolder = (
   }
 }
 
-const resolveWritableConfigPath = (workspaceFolder: string, source: ConfigSource) => {
+const resolveWritableConfigPath = (
+  workspaceFolder: string,
+  source: ConfigSource,
+  env: Record<string, string | null | undefined> = process.env
+) => {
+  const resolvedWorkspaceFolder = resolveProjectWorkspaceFolder(workspaceFolder, env)
+  const configFolder = resolveProjectConfigDir(workspaceFolder, env) ?? resolve(workspaceFolder)
   const paths = source === 'project' ? projectConfigPaths : userConfigPaths
   for (const path of paths) {
-    const resolvedPath = resolve(workspaceFolder, path)
+    const resolvedPath = resolve(configFolder, path)
     if (existsSync(resolvedPath)) {
       return resolvedPath
     }
   }
 
   if (source === 'user') {
-    const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder)
+    const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(resolvedWorkspaceFolder, env)
     if (primaryWorkspaceFolder != null) {
       for (const path of paths) {
         const resolvedPath = resolve(primaryWorkspaceFolder, path)
@@ -98,7 +108,7 @@ const resolveWritableConfigPath = (workspaceFolder: string, source: ConfigSource
     }
   }
 
-  return resolve(workspaceFolder, paths[0])
+  return resolve(configFolder, paths[0])
 }
 
 const parseConfigContent = (format: string, content: string) => {

--- a/packages/hooks/call-hook.js
+++ b/packages/hooks/call-hook.js
@@ -4,10 +4,6 @@ const Module = require('node:module')
 const path = require('node:path')
 const process = require('node:process')
 
-const resolveAiBaseDir = () => (
-  process.env.__VF_PROJECT_AI_BASE_DIR__?.trim()?.replace(/[\\/]+$/, '') || '.ai'
-)
-
 const splitNodePath = (value) => (
   typeof value === 'string'
     ? value
@@ -47,15 +43,14 @@ const bootstrapNodePath = () => {
 
 bootstrapNodePath()
 
-process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ?? process.cwd()
-process.env.__VF_PROJECT_PACKAGE_DIR__ = process.env.__VF_PROJECT_PACKAGE_DIR__ ?? __dirname
-require('@vibe-forge/register/dotenv')
+const {
+  resolveProjectAiBaseDir,
+  resolveProjectWorkspaceFolder
+} = require('@vibe-forge/register/dotenv')
 
-process.env.HOME = path.resolve(
-  process.env.__VF_PROJECT_WORKSPACE_FOLDER__,
-  resolveAiBaseDir(),
-  '.mock'
-)
+process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
+process.env.__VF_PROJECT_PACKAGE_DIR__ = process.env.__VF_PROJECT_PACKAGE_DIR__ ?? __dirname
+process.env.HOME = path.resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
 
 const sourceEntrypoint = path.resolve(__dirname, './src/entry.ts')
 const distEntrypoint = path.resolve(__dirname, './dist/entry.js')

--- a/packages/register/__tests__/dotenv.spec.ts
+++ b/packages/register/__tests__/dotenv.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
@@ -9,10 +9,12 @@ import { afterEach, describe, expect, it } from 'vitest'
 const require = createRequire(import.meta.url)
 
 describe('loadDotenv', () => {
-  const restoreKeys = ['TEST_PRIMARY_ONLY', 'TEST_SHARED_VALUE']
+  const restoreKeys = ['TEST_PRIMARY_ONLY', 'TEST_SHARED_VALUE', 'TEST_CONFIG_ONLY']
   const restoreEnv = new Map<string, string | undefined>()
   const restoreScopedEnv = [
+    '__VF_PROJECT_LAUNCH_CWD__',
     '__VF_PROJECT_WORKSPACE_FOLDER__',
+    '__VF_PROJECT_CONFIG_DIR__',
     '__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__',
     '__VF_PROJECT_DOTENV_FILES__',
     '__VF_PROJECT_PACKAGE_DIR__'
@@ -82,6 +84,62 @@ describe('loadDotenv', () => {
     } finally {
       await rm(primaryDir, { force: true, recursive: true })
       await rm(worktreeDir, { force: true, recursive: true })
+    }
+  })
+
+  it('loads config-dir env files after launch-dir env sets workspace and config overrides', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-dotenv-workspace-'))
+    const launchDir = path.join(workspaceDir, 'c', 'd', 'e')
+    const configDir = path.join(launchDir, '.iac', 'ai')
+    const previousCwd = process.cwd()
+
+    for (const key of ['TEST_CONFIG_ONLY']) {
+      restoreEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    for (const key of restoreScopedEnv) {
+      restoreScopedValues.set(key, process.env[key])
+    }
+
+    try {
+      await mkdir(configDir, { recursive: true })
+      await writeFile(
+        path.join(launchDir, '.env'),
+        [
+          '__VF_PROJECT_WORKSPACE_FOLDER__=../../..',
+          '__VF_PROJECT_CONFIG_DIR__=.iac/ai'
+        ].join('\n')
+      )
+      await writeFile(
+        path.join(configDir, '.env.dev'),
+        'TEST_CONFIG_ONLY=config-value\n'
+      )
+
+      process.chdir(launchDir)
+
+      const modulePath = require.resolve('../dotenv.js')
+      delete require.cache[modulePath]
+      const {
+        loadDotenv,
+        resolveProjectWorkspaceFolder,
+        resolveProjectConfigDir
+      } = require(modulePath) as {
+        loadDotenv: (options?: { workspaceFolder?: string; files?: string[] }) => void
+        resolveProjectWorkspaceFolder: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+        resolveProjectConfigDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string | undefined
+      }
+
+      delete process.env.TEST_CONFIG_ONLY
+      loadDotenv()
+
+      const realWorkspaceDir = await realpath(workspaceDir)
+      const realConfigDir = await realpath(configDir)
+      expect(process.env.TEST_CONFIG_ONLY).toBe('config-value')
+      expect(resolveProjectWorkspaceFolder(process.cwd(), process.env)).toBe(realWorkspaceDir)
+      expect(resolveProjectConfigDir(process.cwd(), process.env)).toBe(realConfigDir)
+    } finally {
+      process.chdir(previousCwd)
+      await rm(workspaceDir, { force: true, recursive: true })
     }
   })
 })

--- a/packages/register/dotenv.d.ts
+++ b/packages/register/dotenv.d.ts
@@ -5,3 +5,7 @@ export interface LoadDotenvOptions {
 
 export declare const loadDotenv: (options?: LoadDotenvOptions) => void
 export declare const resolvePrimaryWorkspaceFolder: (workspaceFolder: string) => string | undefined
+export declare const resolveProjectLaunchCwd: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+export declare const resolveProjectWorkspaceFolder: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+export declare const resolveProjectConfigDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string | undefined
+export declare const resolveProjectAiBaseDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string

--- a/packages/register/dotenv.js
+++ b/packages/register/dotenv.js
@@ -1,10 +1,60 @@
 const { spawnSync } = require('node:child_process')
-const { dirname, resolve } = require('node:path')
+const { dirname, isAbsolute, resolve } = require('node:path')
 const process = require('node:process')
 
 const dotenv = require('dotenv')
 
 const PRIMARY_WORKSPACE_ENV = '__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__'
+const PROJECT_LAUNCH_CWD_ENV = '__VF_PROJECT_LAUNCH_CWD__'
+const PROJECT_WORKSPACE_FOLDER_ENV = '__VF_PROJECT_WORKSPACE_FOLDER__'
+const PROJECT_CONFIG_DIR_ENV = '__VF_PROJECT_CONFIG_DIR__'
+const PROJECT_AI_BASE_DIR_ENV = '__VF_PROJECT_AI_BASE_DIR__'
+const DEFAULT_PROJECT_AI_BASE_DIR = '.ai'
+
+const normalizeDirPath = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : undefined
+  if (!trimmed) {
+    return undefined
+  }
+
+  return trimmed.replace(/[\\/]+$/, '')
+}
+
+const resolvePathFromBase = (baseDir, value) => {
+  const normalizedValue = normalizeDirPath(value)
+  if (normalizedValue == null) {
+    return undefined
+  }
+
+  return isAbsolute(normalizedValue)
+    ? resolve(normalizedValue)
+    : resolve(baseDir, normalizedValue)
+}
+
+const resolveProjectLaunchCwd = (cwd = process.cwd(), env = process.env) => (
+  resolvePathFromBase(resolve(cwd), env[PROJECT_LAUNCH_CWD_ENV]) ?? resolve(cwd)
+)
+
+const resolvePathFromLaunchCwd = (cwd, value, env = process.env) => (
+  resolvePathFromBase(resolveProjectLaunchCwd(cwd, env), value)
+)
+
+const resolveProjectWorkspaceFolder = (cwd = process.cwd(), env = process.env) => (
+  resolvePathFromLaunchCwd(cwd, env[PROJECT_WORKSPACE_FOLDER_ENV], env) ?? resolve(cwd)
+)
+
+const resolveProjectConfigDir = (cwd = process.cwd(), env = process.env) => (
+  resolvePathFromLaunchCwd(cwd, env[PROJECT_CONFIG_DIR_ENV], env)
+)
+
+const resolveProjectAiBaseDir = (cwd = process.cwd(), env = process.env) => {
+  const configuredBaseDir = normalizeDirPath(env[PROJECT_AI_BASE_DIR_ENV])
+  if (configuredBaseDir == null) {
+    return resolve(resolveProjectWorkspaceFolder(cwd, env), DEFAULT_PROJECT_AI_BASE_DIR)
+  }
+
+  return resolvePathFromLaunchCwd(cwd, configuredBaseDir, env)
+}
 
 const resolvePrimaryWorkspaceFolder = (workspaceFolder) => {
   const normalizedWorkspaceFolder = resolve(workspaceFolder)
@@ -40,10 +90,12 @@ const resolvePrimaryWorkspaceFolder = (workspaceFolder) => {
 }
 
 const loadDotenv = (options = {}) => {
-  const workspaceFolder = options.workspaceFolder ??
-    process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ??
-    process.cwd()
-  const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder)
+  const launchCwd = resolveProjectLaunchCwd(
+    options.workspaceFolder ?? process.cwd(),
+    process.env
+  )
+  process.env[PROJECT_LAUNCH_CWD_ENV] = launchCwd
+
   const envFiles = process.env.__VF_PROJECT_DOTENV_FILES__
     ? process.env.__VF_PROJECT_DOTENV_FILES__
       .split(',')
@@ -52,22 +104,56 @@ const loadDotenv = (options = {}) => {
     : undefined
   const files = options.files ?? envFiles ?? ['.env', '.env.dev']
   const packageDir = process.env.__VF_PROJECT_PACKAGE_DIR__
-  const roots = [
-    workspaceFolder,
-    ...(packageDir && packageDir !== workspaceFolder ? [packageDir] : []),
-    ...(primaryWorkspaceFolder &&
-        primaryWorkspaceFolder !== workspaceFolder &&
-        primaryWorkspaceFolder !== packageDir
-      ? [primaryWorkspaceFolder]
-      : [])
-  ]
+  const seenFiles = new Set()
 
-  for (const root of roots) {
-    for (const file of files) {
+  while (true) {
+    const workspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
+    const configDir = resolveProjectConfigDir(launchCwd, process.env)
+    const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder)
+    const roots = [
+      launchCwd,
+      workspaceFolder,
+      ...(configDir != null ? [configDir] : []),
+      ...(packageDir && packageDir !== workspaceFolder ? [packageDir] : []),
+      ...(primaryWorkspaceFolder &&
+          primaryWorkspaceFolder !== launchCwd &&
+          primaryWorkspaceFolder !== workspaceFolder &&
+          primaryWorkspaceFolder !== configDir &&
+          primaryWorkspaceFolder !== packageDir
+        ? [primaryWorkspaceFolder]
+        : [])
+    ]
+    const pendingFiles = []
+
+    for (const root of roots) {
+      for (const file of files) {
+        const filePath = resolve(root, file)
+        if (seenFiles.has(filePath)) {
+          continue
+        }
+
+        pendingFiles.push(filePath)
+      }
+    }
+
+    if (pendingFiles.length === 0) {
+      break
+    }
+
+    for (const filePath of pendingFiles) {
+      seenFiles.add(filePath)
       dotenv.config({
         quiet: true,
-        path: resolve(root, file)
+        path: filePath
       })
+    }
+
+    const resolvedWorkspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
+    const resolvedConfigDir = resolveProjectConfigDir(launchCwd, process.env)
+
+    process.env[PROJECT_WORKSPACE_FOLDER_ENV] = resolvedWorkspaceFolder
+    if (resolvedConfigDir != null) {
+      process.env[PROJECT_CONFIG_DIR_ENV] = resolvedConfigDir
     }
   }
 }
@@ -76,5 +162,9 @@ loadDotenv()
 
 module.exports = {
   loadDotenv,
-  resolvePrimaryWorkspaceFolder
+  resolvePrimaryWorkspaceFolder,
+  resolveProjectAiBaseDir,
+  resolveProjectConfigDir,
+  resolveProjectLaunchCwd,
+  resolveProjectWorkspaceFolder
 }

--- a/packages/utils/__tests__/ai-path.spec.ts
+++ b/packages/utils/__tests__/ai-path.spec.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROJECT_AI_BASE_DIR,
   DEFAULT_PROJECT_AI_ENTITIES_DIR,
   resolveProjectAiBaseDirName,
+  resolveProjectConfigDir,
   resolveProjectAiEntitiesDir,
   resolveProjectAiEntitiesDirName
 } from '#~/ai-path.js'
@@ -25,5 +26,19 @@ describe('ai path utils', () => {
     expect(resolveProjectAiEntitiesDir('/tmp/project', {
       __VF_PROJECT_AI_ENTITIES_DIR__: 'knowledge/entities'
     })).toBe('/tmp/project/.ai/knowledge/entities')
+  })
+
+  it('resolves relative AI and config paths from the launch cwd', () => {
+    expect(resolveProjectAiEntitiesDir('/tmp/project/c/d/e', {
+      __VF_PROJECT_LAUNCH_CWD__: '/tmp/project/c/d/e',
+      __VF_PROJECT_WORKSPACE_FOLDER__: '../../..',
+      __VF_PROJECT_AI_BASE_DIR__: '.iac/ai',
+      __VF_PROJECT_AI_ENTITIES_DIR__: 'agents'
+    })).toBe('/tmp/project/c/d/e/.iac/ai/agents')
+
+    expect(resolveProjectConfigDir('/tmp/project/c/d/e', {
+      __VF_PROJECT_LAUNCH_CWD__: '/tmp/project/c/d/e',
+      __VF_PROJECT_CONFIG_DIR__: '.'
+    })).toBe('/tmp/project/c/d/e')
   })
 })

--- a/packages/utils/src/ai-path.ts
+++ b/packages/utils/src/ai-path.ts
@@ -1,6 +1,9 @@
 import { isAbsolute, resolve } from 'node:path'
 import process from 'node:process'
 
+export const PROJECT_LAUNCH_CWD_ENV = '__VF_PROJECT_LAUNCH_CWD__'
+export const PROJECT_WORKSPACE_FOLDER_ENV = '__VF_PROJECT_WORKSPACE_FOLDER__'
+export const PROJECT_CONFIG_DIR_ENV = '__VF_PROJECT_CONFIG_DIR__'
 export const PROJECT_AI_BASE_DIR_ENV = '__VF_PROJECT_AI_BASE_DIR__'
 export const DEFAULT_PROJECT_AI_BASE_DIR = '.ai'
 export const PROJECT_AI_ENTITIES_DIR_ENV = '__VF_PROJECT_AI_ENTITIES_DIR__'
@@ -12,7 +15,48 @@ const normalizeDirPath = (value: string | null | undefined) => {
   return trimmed.replace(/[\\/]+$/, '')
 }
 
+const resolvePathFromBase = (
+  baseDir: string,
+  value: string | null | undefined,
+) => {
+  const normalizedValue = normalizeDirPath(value)
+  if (normalizedValue == null) {
+    return undefined
+  }
+
+  if (isAbsolute(normalizedValue)) {
+    return resolve(normalizedValue)
+  }
+
+  return resolve(baseDir, normalizedValue)
+}
+
 const toPathSegments = (value: string) => value.split(/[\\/]+/).filter(Boolean)
+
+export const resolveProjectLaunchCwd = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => (
+  resolvePathFromBase(resolve(cwd), env[PROJECT_LAUNCH_CWD_ENV]) ?? resolve(cwd)
+)
+
+const resolvePathFromLaunchCwd = (
+  cwd: string,
+  value: string | null | undefined,
+  env: Record<string, string | null | undefined> = process.env
+) => resolvePathFromBase(resolveProjectLaunchCwd(cwd, env), value)
+
+export const resolveProjectWorkspaceFolder = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => (
+  resolvePathFromLaunchCwd(cwd, env[PROJECT_WORKSPACE_FOLDER_ENV], env) ?? resolve(cwd)
+)
+
+export const resolveProjectConfigDir = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => resolvePathFromLaunchCwd(cwd, env[PROJECT_CONFIG_DIR_ENV], env)
 
 export const resolveProjectAiBaseDirName = (
   env: Record<string, string | null | undefined> = process.env
@@ -31,7 +75,15 @@ export const resolveProjectAiBaseDir = (
   env: Record<string, string | null | undefined> = process.env
 ) => {
   const baseDir = resolveProjectAiBaseDirName(env)
-  return isAbsolute(baseDir) ? resolve(baseDir) : resolve(cwd, baseDir)
+  if (isAbsolute(baseDir)) {
+    return resolve(baseDir)
+  }
+
+  if (normalizeDirPath(env[PROJECT_AI_BASE_DIR_ENV]) != null) {
+    return resolve(resolveProjectLaunchCwd(cwd, env), baseDir)
+  }
+
+  return resolve(resolveProjectWorkspaceFolder(cwd, env), baseDir)
 }
 
 export const resolveProjectAiPath = (


### PR DESCRIPTION
## Summary

- support `__VF_PROJECT_WORKSPACE_FOLDER__`, `__VF_PROJECT_AI_BASE_DIR__`, and `__VF_PROJECT_CONFIG_DIR__` as launch-dir env overrides
- make config load/update and entry scripts resolve workspace/config/ai paths through the same upstream helpers
- teach dotenv to load launch-dir env first and then continue from resolved workspace/config locations
- add regression coverage for config-dir overrides and launch-dir env resolution

Closes #119

## Testing

- pnpm -C packages/utils test
- pnpm -C packages/config test
- pnpm exec vitest run packages/register/__tests__/dotenv.spec.ts
- pnpm -C apps/cli test
