### PR TITLE
fix: resolve workspace root from nested launch dirs

### DIFF
--- a/.ai/docs/asset-directories.md
+++ b/.ai/docs/asset-directories.md
@@ -72,9 +72,11 @@ __VF_PROJECT_AI_ENTITIES_DIR__=knowledge/entities
 
 - `.ai.config.json` / `.ai.config.yaml` / `.ai.config.yml`
 - `.ai.dev.config.*`
-- 这些配置文件位于项目根或 `./infra/` 的规则
+- 这些配置文件默认位于解析后的 workspace 根目录或 `./infra/` 的规则
 
-也就是说，当前可配置的是“数据资产目录”，不是“配置文件文件名与位置”。
+也就是说，`__VF_PROJECT_AI_BASE_DIR__` / `__VF_PROJECT_AI_ENTITIES_DIR__` 只配置“数据资产目录”，不配置“配置文件文件名与位置”。
+
+如果你需要改配置文件目录，应单独使用 `__VF_PROJECT_CONFIG_DIR__`；否则配置读写会默认跟随解析后的 workspace 根目录。
 
 ## 使用建议
 

--- a/.ai/docs/usage/cli.md
+++ b/.ai/docs/usage/cli.md
@@ -18,6 +18,11 @@
 - `vf stop <sessionId>`：优雅停止正在运行的 CLI 会话
 - `vf kill <sessionId>`：强制终止正在运行的 CLI 会话
 
+这些命令默认以项目根目录作为 workspace。
+
+- 如果显式设置了 `__VF_PROJECT_WORKSPACE_FOLDER__`，会直接使用该目录。
+- 如果没有设置，`vf` / `vf-mcp` / `vf-call-hook` / `vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，因此可以在项目任意子目录下启动。
+
 ## 内建 Skills
 
 `@vibe-forge/cli` 会默认注入 companion 插件 `@vibe-forge/plugin-cli-skills`，可直接通过 `--include-skill` 使用：

--- a/.ai/docs/usage/cli.md
+++ b/.ai/docs/usage/cli.md
@@ -22,6 +22,7 @@
 
 - 如果显式设置了 `__VF_PROJECT_WORKSPACE_FOLDER__`，会直接使用该目录。
 - 如果没有设置，`vf` / `vf-mcp` / `vf-call-hook` / `vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，因此可以在项目任意子目录下启动。
+- 配置文件默认会跟随这个解析后的 workspace 根目录读取；如果需要把 `.ai.config.*` 放到别的目录，可以显式设置 `__VF_PROJECT_CONFIG_DIR__`。
 
 ## 内建 Skills
 

--- a/.ai/docs/usage/install.md
+++ b/.ai/docs/usage/install.md
@@ -35,11 +35,27 @@ npx -y vfui-client --help
 
 ## 配置文件
 
-在你的项目根目录准备：
+默认情况下，Vibe Forge 会把解析后的 workspace 根目录作为项目配置根目录。
+
+- 如果显式设置了 `__VF_PROJECT_WORKSPACE_FOLDER__`，直接使用该目录。
+- 如果没有设置，会从当前启动目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录。
+
+在这个配置根目录准备：
 
 - `.ai.config.json` / `.ai.config.yaml` / `.ai.config.yml`
 - 可选开发态配置：`.ai.dev.config.*`
 - 同名配置也可放在 `./infra/` 下
+
+如果你希望把配置文件放到别的目录，可以额外在启动环境里设置：
+
+```env
+__VF_PROJECT_CONFIG_DIR__=.config/vibe
+```
+
+`__VF_PROJECT_CONFIG_DIR__` 支持：
+
+- 相对启动目录（launch cwd）的路径
+- 绝对路径
 
 配置支持 `${ENV_VAR}` 变量替换。使用 TS 配置时：
 
@@ -79,5 +95,6 @@ __VF_PROJECT_AI_ENTITIES_DIR__=knowledge/entities
 
 注意：
 
-- `.ai.config.json` / `.ai.config.yaml` / `.ai.dev.config.*` 的文件名和位置不受这些环境变量影响
+- `__VF_PROJECT_AI_BASE_DIR__` / `__VF_PROJECT_AI_ENTITIES_DIR__` 只影响数据资产目录，不改变配置文件文件名与位置
+- 配置文件默认仍然位于解析后的 workspace 根目录或其 `./infra/` 下；只有显式设置 `__VF_PROJECT_CONFIG_DIR__` 时才会改到别的目录
 - 修改 `.env` 后需要重启相关 server / CLI / adapter 进程，已有进程不会自动重载

--- a/.ai/docs/usage/native-plugins.md
+++ b/.ai/docs/usage/native-plugins.md
@@ -41,7 +41,9 @@ npx vf plugin --adapter claude add <source>
 
 ## Marketplace 配置
 
-在项目根目录的 `.ai.config.yaml`、`.ai.config.json`、`.ai.dev.config.yaml` 或 `.ai.dev.config.json` 中配置 `marketplaces`。
+默认在解析后的 workspace 根目录的 `.ai.config.yaml`、`.ai.config.json`、`.ai.dev.config.yaml` 或 `.ai.dev.config.json` 中配置 `marketplaces`。
+
+如果显式设置了 `__VF_PROJECT_CONFIG_DIR__`，则会从该目录读取 marketplace 配置。
 
 Claude marketplace entry 的格式是：
 

--- a/.ai/docs/usage/plugins.md
+++ b/.ai/docs/usage/plugins.md
@@ -25,7 +25,7 @@ pnpm add -D @vibe-forge/plugin-standard-dev @vibe-forge/plugin-logger
 
 ## 基本配置
 
-在项目根目录的 `.ai.config.json` 或 `.ai.config.yaml` 中配置 `plugins`：
+默认情况下，在解析后的 workspace 根目录的 `.ai.config.json` 或 `.ai.config.yaml` 中配置 `plugins`：
 
 ```json
 {
@@ -136,7 +136,8 @@ __VF_PROJECT_AI_ENTITIES_DIR__=knowledge/entities
 边界说明：
 
 - 这里修改的是项目数据资产目录，不是配置文件位置
-- `.ai.config.json` / `.ai.dev.config.*` 仍然放在项目根或 `./infra/`
+- `.ai.config.json` / `.ai.dev.config.*` 默认仍然放在解析后的 workspace 根目录或 `./infra/`
+- 如果显式设置了 `__VF_PROJECT_CONFIG_DIR__`，插件配置会改为从该目录读取
 - 修改 `.env` 后需要重启相关进程
 
 ## Adapter 兼容范围

--- a/.ai/docs/usage/runtime.md
+++ b/.ai/docs/usage/runtime.md
@@ -23,6 +23,7 @@ wait
 
 - `__VF_PROJECT_WORKSPACE_FOLDER__` 指向你的项目根目录。
 - 如果没有显式设置 `__VF_PROJECT_WORKSPACE_FOLDER__`，`vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，并自动把项目根目录作为 workspace。
+- 项目配置默认也会跟随这个解析后的 workspace 根目录读取；如果需要单独改配置目录，可以显式设置 `__VF_PROJECT_CONFIG_DIR__`。
 - `__VF_PROJECT_AI_BASE_DIR__` 可选；默认是 `.ai`，也可以设成 `.vf` 或 `.config/vibe/ai-data` 之类的嵌套目录。
 - `__VF_PROJECT_AI_ENTITIES_DIR__` 可选；默认是 `entities`，会基于 AI 基目录继续解析。
 - `HOME` 可用于隔离运行环境，默认跟随 AI 基目录落到项目内的 `.mock` 子目录。

--- a/.ai/docs/usage/runtime.md
+++ b/.ai/docs/usage/runtime.md
@@ -22,6 +22,7 @@ wait
 ## 说明
 
 - `__VF_PROJECT_WORKSPACE_FOLDER__` 指向你的项目根目录。
+- 如果没有显式设置 `__VF_PROJECT_WORKSPACE_FOLDER__`，`vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，并自动把项目根目录作为 workspace。
 - `__VF_PROJECT_AI_BASE_DIR__` 可选；默认是 `.ai`，也可以设成 `.vf` 或 `.config/vibe/ai-data` 之类的嵌套目录。
 - `__VF_PROJECT_AI_ENTITIES_DIR__` 可选；默认是 `entities`，会基于 AI 基目录继续解析。
 - `HOME` 可用于隔离运行环境，默认跟随 AI 基目录落到项目内的 `.mock` 子目录。

--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -13,7 +13,7 @@
 - 如果新建会话启用了 worktree，但没有显式指定分支，server 会默认从源 worktree 当前分支派生一个新的 session worktree 分支；只有源目录本身是 detached HEAD 时，才会退回 detached 模式。
 - session managed worktree 会落在 `.ai/worktrees/sessions/<sessionId>/<repo-name>`；最后一级目录始终跟随当前 git 根目录名，方便和真实仓库目录保持一致。
 - 如果当前 session 分支还没有对应的远端分支，`同步` 会优先尝试同名远端分支；如果远端还没有这条分支，则会回退到 worktree 记录的基线分支继续同步。
-- 如果你想给项目设默认值，可以在 `.ai.config.json` / `.ai.config.yaml` 的 `conversation.createSessionWorktree` 里配置；Web UI 新建会话时会按这个项目配置初始化。
+- 如果你想给项目设默认值，可以在解析后的 workspace 根目录配置文件（默认是 `.ai.config.json` / `.ai.config.yaml`，也支持 `./infra/` 或显式 `__VF_PROJECT_CONFIG_DIR__`）里设置 `conversation.createSessionWorktree`；Web UI 新建会话时会按这个项目配置初始化。
 
 ## Terminal 视图是什么
 
@@ -24,7 +24,7 @@
 
 ## 使用前提
 
-- `__VF_PROJECT_WORKSPACE_FOLDER__` 要指向你真正想操作的项目目录。
+- `__VF_PROJECT_WORKSPACE_FOLDER__` 要指向你真正想操作的项目目录；如果没显式设置，server 启动时会从当前目录向上探测 workspace 根目录。
 - server 进程需要能在该 workspace 下启动 shell；如果运行环境缺少 PTY 能力，交互体验会退化。
 - terminal 主题跟随当前 Web UI 的浅色 / 深色 token，不需要额外配置第二套主题参数。
 

--- a/packages/cli-helper/__tests__/loader.spec.ts
+++ b/packages/cli-helper/__tests__/loader.spec.ts
@@ -43,8 +43,11 @@ describe('cli-helper loader wrapper', () => {
     const workspaceDir = await mkdtemp(resolve(tmpdir(), 'vf-cli-helper-entry-'))
     tempDirs.push(workspaceDir)
 
+    const nestedCwd = resolve(workspaceDir, 'packages/demo/src')
     const packageDir = resolve(workspaceDir, 'packages/fake-cli')
+    await mkdir(nestedCwd, { recursive: true })
     await mkdir(packageDir, { recursive: true })
+    await writeFile(resolve(workspaceDir, '.ai.config.json'), '{}\n')
     const realWorkspaceDir = await realpath(workspaceDir)
     const entryPath = resolve(process.cwd(), 'packages/cli-helper/entry.js')
     const result = spawnSync(
@@ -58,7 +61,10 @@ const originalLoad = Module._load
 
 Module._load = function(request, parent, isMain) {
   if (request === '@vibe-forge/register/dotenv') {
-    return {}
+    return {
+      resolveProjectWorkspaceFolder: () => ${JSON.stringify(realWorkspaceDir)},
+      resolveProjectAiBaseDir: () => ${JSON.stringify(resolve(realWorkspaceDir, '.ai'))}
+    }
   }
 
   if (request === './loader' && parent?.filename === entryPath) {
@@ -84,7 +90,7 @@ require(entryPath).runCliPackageEntrypoint({
       `
       ],
       {
-        cwd: workspaceDir,
+        cwd: nestedCwd,
         env: {
           ...process.env,
           HOME: '/tmp/original-home'

--- a/packages/cli-helper/loader.js
+++ b/packages/cli-helper/loader.js
@@ -139,7 +139,9 @@ if (!process.env.__IS_LOADER_CLI__) {
     process.exit(code ?? 0)
   })
 } else {
-  process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = process.env.__VF_PROJECT_WORKSPACE_FOLDER__ ?? process.cwd()
+  const { resolveProjectWorkspaceFolder } = require('@vibe-forge/register/dotenv')
+
+  process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
   process.env.__VF_PROJECT_PACKAGE_DIR__ = process.env.__VF_PROJECT_PACKAGE_DIR__ ?? process.cwd()
   process.env.__VF_PROJECT_CLI_PACKAGE_DIR__ = process.env.__VF_PROJECT_CLI_PACKAGE_DIR__ ??
     process.env.__VF_PROJECT_PACKAGE_DIR__

--- a/packages/config/__tests__/load.spec.ts
+++ b/packages/config/__tests__/load.spec.ts
@@ -143,6 +143,54 @@ describe('loadConfig', () => {
     }
   })
 
+  it('loads project config from the resolved workspace root when launched from a nested directory', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-root-load-'))
+    const launchDir = path.join(workspaceDir, 'apps', 'client', 'src')
+    const previousLaunchCwd = process.env.__VF_PROJECT_LAUNCH_CWD__
+    const previousWorkspaceFolder = process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+    const previousConfigDir = process.env.__VF_PROJECT_CONFIG_DIR__
+
+    try {
+      await mkdir(launchDir, { recursive: true })
+      await writeFile(
+        path.join(workspaceDir, '.ai.config.json'),
+        JSON.stringify({
+          defaultModel: 'root-model'
+        })
+      )
+
+      process.env.__VF_PROJECT_LAUNCH_CWD__ = launchDir
+      process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = workspaceDir
+      delete process.env.__VF_PROJECT_CONFIG_DIR__
+      resetConfigCache()
+
+      const [projectConfig] = await loadConfig({
+        cwd: launchDir,
+        jsonVariables: buildConfigJsonVariables(launchDir, process.env)
+      })
+
+      expect(projectConfig?.defaultModel).toBe('root-model')
+    } finally {
+      if (previousLaunchCwd == null) {
+        delete process.env.__VF_PROJECT_LAUNCH_CWD__
+      } else {
+        process.env.__VF_PROJECT_LAUNCH_CWD__ = previousLaunchCwd
+      }
+      if (previousWorkspaceFolder == null) {
+        delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+      } else {
+        process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = previousWorkspaceFolder
+      }
+      if (previousConfigDir == null) {
+        delete process.env.__VF_PROJECT_CONFIG_DIR__
+      } else {
+        process.env.__VF_PROJECT_CONFIG_DIR__ = previousConfigDir
+      }
+      resetConfigCache()
+      await rm(workspaceDir, { force: true, recursive: true })
+    }
+  })
+
   it('resolves extend chains with layered merge semantics', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-extend-'))
 

--- a/packages/config/__tests__/update.spec.ts
+++ b/packages/config/__tests__/update.spec.ts
@@ -243,4 +243,60 @@ describe('updateConfigFile', () => {
       await rm(workspaceDir, { recursive: true, force: true })
     }
   })
+
+  it('writes project config updates into the resolved workspace root when launched from a nested directory', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-update-root-'))
+    const launchDir = path.join(workspaceDir, 'apps', 'client', 'src')
+    const previousLaunchCwd = process.env.__VF_PROJECT_LAUNCH_CWD__
+    const previousWorkspaceFolder = process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+    const previousConfigDir = process.env.__VF_PROJECT_CONFIG_DIR__
+
+    try {
+      await mkdir(launchDir, { recursive: true })
+      await writeFile(
+        path.join(workspaceDir, '.ai.config.json'),
+        JSON.stringify(
+          {
+            defaultModel: 'gpt-5.4'
+          },
+          null,
+          2
+        )
+      )
+
+      process.env.__VF_PROJECT_LAUNCH_CWD__ = launchDir
+      process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = workspaceDir
+      delete process.env.__VF_PROJECT_CONFIG_DIR__
+
+      const result = await updateConfigFile({
+        workspaceFolder: launchDir,
+        source: 'project',
+        section: 'general',
+        value: {
+          defaultModel: 'gpt-5.4-mini'
+        }
+      })
+
+      expect(result.configPath).toBe(path.join(workspaceDir, '.ai.config.json'))
+      const written = JSON.parse(await readFile(result.configPath, 'utf-8'))
+      expect(written.defaultModel).toBe('gpt-5.4-mini')
+    } finally {
+      if (previousLaunchCwd == null) {
+        delete process.env.__VF_PROJECT_LAUNCH_CWD__
+      } else {
+        process.env.__VF_PROJECT_LAUNCH_CWD__ = previousLaunchCwd
+      }
+      if (previousWorkspaceFolder == null) {
+        delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+      } else {
+        process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = previousWorkspaceFolder
+      }
+      if (previousConfigDir == null) {
+        delete process.env.__VF_PROJECT_CONFIG_DIR__
+      } else {
+        process.env.__VF_PROJECT_CONFIG_DIR__ = previousConfigDir
+      }
+      await rm(workspaceDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -46,7 +46,7 @@ const serializeJsonVariables = (value: Record<string, string | null | undefined>
 const resolveConfigCacheKey = (options: LoadConfigOptions) => {
   const launchCwd = options.cwd ?? process.cwd()
   const workspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
-  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? resolve(launchCwd)
+  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? workspaceFolder
   const disableDevConfig = options.disableDevConfig === true ? '1' : '0'
   const jsonVariables = serializeJsonVariables(options.jsonVariables ?? {})
   return `${launchCwd}\n${workspaceFolder}\n${configCwd}\n${disableDevConfig}\n${jsonVariables}`
@@ -347,7 +347,7 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
 
   const launchCwd = options.cwd ?? process.cwd()
   const workspaceFolder = resolveProjectWorkspaceFolder(launchCwd, process.env)
-  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? resolve(launchCwd)
+  const configCwd = resolveProjectConfigDir(launchCwd, process.env) ?? workspaceFolder
   const shouldLoadDevConfig = options.disableDevConfig !== true &&
     process.env[DISABLE_DEV_CONFIG_ENV] !== '1'
   const jsonVariables = options.jsonVariables ?? {}

--- a/packages/config/src/update.ts
+++ b/packages/config/src/update.ts
@@ -83,7 +83,7 @@ const resolveWritableConfigPath = (
   env: Record<string, string | null | undefined> = process.env
 ) => {
   const resolvedWorkspaceFolder = resolveProjectWorkspaceFolder(workspaceFolder, env)
-  const configFolder = resolveProjectConfigDir(workspaceFolder, env) ?? resolve(workspaceFolder)
+  const configFolder = resolveProjectConfigDir(workspaceFolder, env) ?? resolvedWorkspaceFolder
   const paths = source === 'project' ? projectConfigPaths : userConfigPaths
   for (const path of paths) {
     const resolvedPath = resolve(configFolder, path)

--- a/packages/register/__tests__/dotenv.spec.ts
+++ b/packages/register/__tests__/dotenv.spec.ts
@@ -93,7 +93,7 @@ describe('loadDotenv', () => {
     const configDir = path.join(launchDir, '.iac', 'ai')
     const previousCwd = process.cwd()
 
-    for (const key of ['TEST_CONFIG_ONLY']) {
+    for (const key of restoreKeys) {
       restoreEnv.set(key, process.env[key])
       delete process.env[key]
     }
@@ -139,6 +139,46 @@ describe('loadDotenv', () => {
       expect(resolveProjectConfigDir(process.cwd(), process.env)).toBe(realConfigDir)
     } finally {
       process.chdir(previousCwd)
+      await rm(workspaceDir, { force: true, recursive: true })
+    }
+  })
+
+  it('loads env files from the detected workspace root when given a nested startup directory', async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'vf-dotenv-root-'))
+    const nestedDir = path.join(workspaceDir, 'packages', 'demo', 'src')
+
+    for (const key of restoreKeys) {
+      restoreEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    for (const key of restoreScopedEnv) {
+      restoreScopedValues.set(key, process.env[key])
+      delete process.env[key]
+    }
+
+    try {
+      await mkdir(nestedDir, { recursive: true })
+      await writeFile(path.join(workspaceDir, '.ai.config.json'), '{}\n')
+      await writeFile(path.join(workspaceDir, '.env'), 'TEST_PRIMARY_ONLY=nested-root\nTEST_SHARED_VALUE=root\n')
+
+      const modulePath = require.resolve('../dotenv.js')
+      delete require.cache[modulePath]
+      const {
+        loadDotenv,
+        resolveProjectWorkspaceFolder
+      } = require(modulePath) as {
+        loadDotenv: (options?: { workspaceFolder?: string; files?: string[] }) => void
+        resolveProjectWorkspaceFolder: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+      }
+
+      delete process.env.TEST_PRIMARY_ONLY
+      delete process.env.TEST_SHARED_VALUE
+      loadDotenv({ workspaceFolder: nestedDir })
+
+      expect(process.env.TEST_PRIMARY_ONLY).toBe('nested-root')
+      expect(process.env.TEST_SHARED_VALUE).toBe('root')
+      expect(resolveProjectWorkspaceFolder(nestedDir, process.env)).toBe(await realpath(workspaceDir))
+    } finally {
       await rm(workspaceDir, { force: true, recursive: true })
     }
   })

--- a/packages/register/__tests__/workspace.spec.ts
+++ b/packages/register/__tests__/workspace.spec.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+
+describe('workspace root resolver', () => {
+  const restoreKeys = [
+    '__VF_PROJECT_AI_BASE_DIR__',
+    '__VF_PROJECT_WORKSPACE_FOLDER__'
+  ] as const
+  const restoreValues = new Map<string, string | undefined>()
+
+  afterEach(() => {
+    for (const key of restoreKeys) {
+      const previousValue = restoreValues.get(key)
+      if (previousValue == null) {
+        delete process.env[key]
+      } else {
+        process.env[key] = previousValue
+      }
+    }
+    restoreValues.clear()
+  })
+
+  it('finds the nearest configured workspace root instead of stopping at a nested package', async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'vf-workspace-root-'))
+    const nestedDir = path.join(workspaceRoot, 'packages', 'demo', 'src')
+    const realWorkspaceRoot = await realpath(workspaceRoot)
+
+    for (const key of restoreKeys) {
+      restoreValues.set(key, process.env[key])
+    }
+
+    try {
+      await mkdir(path.join(workspaceRoot, '.ai'), { recursive: true })
+      await mkdir(nestedDir, { recursive: true })
+      await writeFile(path.join(workspaceRoot, 'package.json'), '{"name":"root"}\n')
+      await writeFile(path.join(workspaceRoot, 'packages', 'demo', 'package.json'), '{"name":"demo"}\n')
+
+      const modulePath = require.resolve('../workspace.js')
+      delete require.cache[modulePath]
+      const { findWorkspaceRoot } = require(modulePath) as {
+        findWorkspaceRoot: (startDir?: string) => string
+      }
+
+      expect(findWorkspaceRoot(nestedDir)).toBe(realWorkspaceRoot)
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('falls back to the git root when no workspace markers are present', async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'vf-workspace-git-'))
+    const nestedDir = path.join(workspaceRoot, 'packages', 'demo', 'src')
+    const realWorkspaceRoot = await realpath(workspaceRoot)
+
+    for (const key of restoreKeys) {
+      restoreValues.set(key, process.env[key])
+    }
+
+    try {
+      await mkdir(nestedDir, { recursive: true })
+      await writeFile(path.join(workspaceRoot, 'package.json'), '{"name":"root"}\n')
+      await writeFile(path.join(workspaceRoot, 'packages', 'demo', 'package.json'), '{"name":"demo"}\n')
+
+      const initResult = spawnSync('git', ['init'], {
+        cwd: workspaceRoot,
+        encoding: 'utf8'
+      })
+      expect(initResult.status).toBe(0)
+
+      const modulePath = require.resolve('../workspace.js')
+      delete require.cache[modulePath]
+      const { findWorkspaceRoot } = require(modulePath) as {
+        findWorkspaceRoot: (startDir?: string) => string
+      }
+
+      expect(findWorkspaceRoot(nestedDir)).toBe(realWorkspaceRoot)
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('respects an explicit workspace folder override', async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'vf-workspace-explicit-'))
+    const nestedDir = path.join(workspaceRoot, 'src', 'nested')
+    const realNestedDir = await realpath(path.join(workspaceRoot))
+
+    for (const key of restoreKeys) {
+      restoreValues.set(key, process.env[key])
+    }
+
+    try {
+      await mkdir(nestedDir, { recursive: true })
+      process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = nestedDir
+
+      const modulePath = require.resolve('../workspace.js')
+      delete require.cache[modulePath]
+      const { resolveWorkspaceFolder } = require(modulePath) as {
+        resolveWorkspaceFolder: (startDir?: string) => string
+      }
+
+      expect(resolveWorkspaceFolder(workspaceRoot)).toBe(path.join(realNestedDir, 'src', 'nested'))
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true })
+    }
+  })
+})

--- a/packages/register/dotenv.js
+++ b/packages/register/dotenv.js
@@ -3,6 +3,7 @@ const { dirname, isAbsolute, resolve } = require('node:path')
 const process = require('node:process')
 
 const dotenv = require('dotenv')
+const { findWorkspaceRoot } = require('./workspace')
 
 const PRIMARY_WORKSPACE_ENV = '__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__'
 const PROJECT_LAUNCH_CWD_ENV = '__VF_PROJECT_LAUNCH_CWD__'
@@ -40,7 +41,8 @@ const resolvePathFromLaunchCwd = (cwd, value, env = process.env) => (
 )
 
 const resolveProjectWorkspaceFolder = (cwd = process.cwd(), env = process.env) => (
-  resolvePathFromLaunchCwd(cwd, env[PROJECT_WORKSPACE_FOLDER_ENV], env) ?? resolve(cwd)
+  resolvePathFromLaunchCwd(cwd, env[PROJECT_WORKSPACE_FOLDER_ENV], env) ??
+    findWorkspaceRoot(resolveProjectLaunchCwd(cwd, env))
 )
 
 const resolveProjectConfigDir = (cwd = process.cwd(), env = process.env) => (
@@ -90,12 +92,17 @@ const resolvePrimaryWorkspaceFolder = (workspaceFolder) => {
 }
 
 const loadDotenv = (options = {}) => {
+  if (options.workspaceFolder != null) {
+    delete process.env[PROJECT_LAUNCH_CWD_ENV]
+    delete process.env[PROJECT_WORKSPACE_FOLDER_ENV]
+    delete process.env[PROJECT_CONFIG_DIR_ENV]
+  }
+
   const launchCwd = resolveProjectLaunchCwd(
     options.workspaceFolder ?? process.cwd(),
     process.env
   )
   process.env[PROJECT_LAUNCH_CWD_ENV] = launchCwd
-
   const envFiles = process.env.__VF_PROJECT_DOTENV_FILES__
     ? process.env.__VF_PROJECT_DOTENV_FILES__
       .split(',')

--- a/packages/register/index.d.ts
+++ b/packages/register/index.d.ts
@@ -5,6 +5,11 @@ declare module '@vibe-forge/register/dotenv' {
   }
 
   export const loadDotenv: (options?: LoadDotenvOptions) => void
+  export const resolvePrimaryWorkspaceFolder: (workspaceFolder: string) => string | undefined
+  export const resolveProjectLaunchCwd: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+  export const resolveProjectWorkspaceFolder: (cwd?: string, env?: NodeJS.ProcessEnv) => string
+  export const resolveProjectConfigDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string | undefined
+  export const resolveProjectAiBaseDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string
 }
 
 declare module '@vibe-forge/register/esbuild' {}

--- a/packages/register/workspace.js
+++ b/packages/register/workspace.js
@@ -1,0 +1,99 @@
+const { spawnSync } = require('node:child_process')
+const { existsSync, realpathSync } = require('node:fs')
+const { dirname, resolve } = require('node:path')
+const process = require('node:process')
+
+const WORKSPACE_CONFIG_MARKERS = [
+  '.ai.config.json',
+  '.ai.config.yaml',
+  '.ai.config.yml',
+  'infra/.ai.config.json',
+  'infra/.ai.config.yaml',
+  'infra/.ai.config.yml'
+]
+
+const WORKSPACE_ROOT_MARKERS = [
+  'pnpm-workspace.yaml',
+  '.git'
+]
+
+const resolveAiBaseDir = () => (
+  process.env.__VF_PROJECT_AI_BASE_DIR__?.trim()?.replace(/[\\/]+$/, '') || '.ai'
+)
+
+const normalizePath = (value) => {
+  const resolvedPath = resolve(value)
+
+  try {
+    return typeof realpathSync.native === 'function'
+      ? realpathSync.native(resolvedPath)
+      : realpathSync(resolvedPath)
+  } catch {
+    return resolvedPath
+  }
+}
+
+const hasWorkspaceConfigMarker = (dir) => (
+  WORKSPACE_CONFIG_MARKERS.some(marker => existsSync(resolve(dir, marker)))
+)
+
+const hasWorkspaceRootMarker = (dir) => (
+  existsSync(resolve(dir, resolveAiBaseDir())) ||
+  WORKSPACE_ROOT_MARKERS.some(marker => existsSync(resolve(dir, marker)))
+)
+
+const findGitRoot = (startDir) => {
+  try {
+    const result = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: startDir,
+      encoding: 'utf8'
+    })
+    if (result.status !== 0) {
+      return undefined
+    }
+
+    const gitRoot = result.stdout?.trim()
+    return gitRoot ? normalizePath(gitRoot) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const findWorkspaceRoot = (startDir = process.cwd()) => {
+  const normalizedStartDir = normalizePath(startDir)
+  const gitRoot = findGitRoot(normalizedStartDir)
+  let packageJsonCandidate
+  let currentDir = normalizedStartDir
+
+  while (true) {
+    if (hasWorkspaceConfigMarker(currentDir) || hasWorkspaceRootMarker(currentDir)) {
+      return currentDir
+    }
+
+    if (packageJsonCandidate == null && existsSync(resolve(currentDir, 'package.json'))) {
+      packageJsonCandidate = currentDir
+    }
+
+    if (gitRoot != null && currentDir === gitRoot) {
+      break
+    }
+
+    const parentDir = dirname(currentDir)
+    if (parentDir === currentDir) {
+      break
+    }
+    currentDir = parentDir
+  }
+
+  return gitRoot ?? packageJsonCandidate ?? normalizedStartDir
+}
+
+const resolveWorkspaceFolder = (startDir = process.cwd()) => {
+  const explicitWorkspaceFolder = process.env.__VF_PROJECT_WORKSPACE_FOLDER__?.trim()
+  return explicitWorkspaceFolder ? normalizePath(explicitWorkspaceFolder) : findWorkspaceRoot(startDir)
+}
+
+module.exports = {
+  findWorkspaceRoot,
+  resolveWorkspaceFolder
+}


### PR DESCRIPTION
## Summary
- detect the workspace root by walking up from nested launch directories when no explicit workspace env is set
- align dotenv and config load/update defaults so project config resolves from the detected workspace root
- add regression coverage for register, cli-helper, config, and path resolution behavior

## Testing
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/register/__tests__/workspace.spec.ts packages/register/__tests__/dotenv.spec.ts packages/cli-helper/__tests__/loader.spec.ts packages/config/__tests__/load.spec.ts packages/config/__tests__/update.spec.ts packages/utils/__tests__/ai-path.spec.ts