### PR TITLE
fix(cli): honor configured workspace cwd

### DIFF
--- a/apps/cli/__tests__/session-cache.spec.ts
+++ b/apps/cli/__tests__/session-cache.spec.ts
@@ -27,6 +27,7 @@ const createTempDir = async () => {
 afterEach(async () => {
   vi.restoreAllMocks()
   process.chdir(originalCwd)
+  delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { force: true, recursive: true })))
 })
 

--- a/apps/cli/__tests__/workspace.spec.ts
+++ b/apps/cli/__tests__/workspace.spec.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { Command } from 'commander'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@vibe-forge/app-runtime', () => ({
+  generateAdapterQueryOptions: vi.fn(async () => [
+    {},
+    {
+      systemPrompt: undefined,
+      tools: undefined,
+      mcpServers: undefined,
+      promptAssetIds: undefined,
+      assetBundle: undefined
+    }
+  ]),
+  run: vi.fn(async () => ({
+    session: {
+      pid: 321,
+      kill: vi.fn(),
+      stop: vi.fn()
+    },
+    resolvedAdapter: 'codex'
+  }))
+}))
+
+vi.mock('@vibe-forge/config', () => ({
+  loadInjectDefaultSystemPromptValue: vi.fn(async () => undefined),
+  mergeSystemPrompts: vi.fn(({ generatedSystemPrompt, userSystemPrompt }) => (
+    userSystemPrompt ?? generatedSystemPrompt
+  ))
+}))
+
+vi.mock('@vibe-forge/hooks', () => ({
+  callHook: vi.fn(async () => undefined)
+}))
+
+import { generateAdapterQueryOptions, run } from '@vibe-forge/app-runtime'
+
+import { registerRunCommand } from '#~/commands/run.js'
+import { listCliSessions, writeCliSessionRecord } from '#~/session-cache.js'
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
+
+const tempDirs: string[] = []
+const originalCwd = process.cwd()
+
+const createWorkspaceFixture = async () => {
+  const cleanupDir = await fs.mkdtemp(path.join(tmpdir(), 'vf-cli-workspace-'))
+  tempDirs.push(cleanupDir)
+
+  const workspaceDir = await fs.realpath(cleanupDir)
+  const launchDir = path.join(workspaceDir, 'business_modules', 'Miniapp')
+  await fs.mkdir(launchDir, { recursive: true })
+
+  return {
+    workspaceDir,
+    launchDir
+  }
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  process.chdir(originalCwd)
+  delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+  await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe('cli workspace resolution', () => {
+  it('resolves the effective workspace cwd from env overrides', async () => {
+    const { workspaceDir, launchDir } = await createWorkspaceFixture()
+
+    process.chdir(launchDir)
+    process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = '../..'
+
+    expect(resolveCliWorkspaceCwd()).toBe(workspaceDir)
+  })
+
+  it('passes the resolved workspace cwd into run command execution', async () => {
+    const { workspaceDir, launchDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    process.chdir(launchDir)
+    process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = '../..'
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync(['run', '--print', '现在工作目录是什么'], { from: 'user' })
+
+    expect(generateAdapterQueryOptions).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(generateAdapterQueryOptions).mock.calls[0]?.[2]).toBe(workspaceDir)
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.any(Object)
+    )
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('reads cached sessions from the resolved workspace cwd', async () => {
+    const { workspaceDir, launchDir } = await createWorkspaceFixture()
+
+    await writeCliSessionRecord(workspaceDir, 'ctx-demo', 'session-demo', {
+      resume: {
+        version: 1,
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        cwd: workspaceDir,
+        description: 'Check workspace override',
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAdapter: 'codex',
+        taskOptions: {
+          adapter: 'codex',
+          cwd: workspaceDir,
+          ctxId: 'ctx-demo'
+        },
+        adapterOptions: {
+          runtime: 'cli',
+          sessionId: 'session-demo',
+          mode: 'direct'
+        },
+        outputFormat: 'text'
+      }
+    })
+
+    process.chdir(launchDir)
+    process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = '../..'
+
+    const records = await listCliSessions(resolveCliWorkspaceCwd())
+    expect(records.some(record => record.resume?.sessionId === 'session-demo')).toBe(true)
+  })
+})

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/cli/src/commands/kill.ts
+++ b/apps/cli/src/commands/kill.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import type { Command } from 'commander'
 
 import { formatListCommand, formatResumeCommand } from '#~/session-cache.js'
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
 
 import { signalCliSession } from './session-control'
 
@@ -21,7 +22,7 @@ Examples:
     .action(async (sessionId: string) => {
       try {
         const result = await signalCliSession({
-          cwd: process.cwd(),
+          cwd: resolveCliWorkspaceCwd(),
           sessionId,
           signal: 'SIGKILL'
         })

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -17,6 +17,7 @@ import {
   resolveCliSessionModel,
   resolveCliSessionUpdatedAt
 } from '#~/session-cache.js'
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
 
 interface ListOptions {
   all?: boolean
@@ -176,7 +177,7 @@ Examples:
     )
     .action(async (opts: ListOptions) => {
       try {
-        const records = await listCliSessions(process.cwd())
+        const records = await listCliSessions(resolveCliWorkspaceCwd())
         if (records.length === 0) {
           console.log('No cached sessions found.')
           return

--- a/apps/cli/src/commands/run/command.ts
+++ b/apps/cli/src/commands/run/command.ts
@@ -25,6 +25,7 @@ import {
   readCliSessionPermissionRecovery,
   writeCliSessionPermissionRecovery
 } from '#~/session-permission-cache.js'
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
 import { createAdapterOption } from '../@core/adapter-option'
 import { extraOptions } from '../@core/extra-options'
 import { attachInputBridge } from './input-bridge'
@@ -122,7 +123,7 @@ Notes:
         let inputClosed = false
         let pendingInteraction: AdapterInteractionRequest | undefined
         const exitController = createSessionExitController()
-        const cwd = process.cwd()
+        const cwd = resolveCliWorkspaceCwd()
         const generatedSessionId = opts.sessionId ?? uuid()
 
         if (opts.spec && opts.entity) {

--- a/apps/cli/src/commands/stop.ts
+++ b/apps/cli/src/commands/stop.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import type { Command } from 'commander'
 
 import { formatListCommand, formatResumeCommand } from '#~/session-cache.js'
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
 
 import { signalCliSession } from './session-control'
 
@@ -21,7 +22,7 @@ Examples:
     .action(async (sessionId: string) => {
       try {
         const result = await signalCliSession({
-          cwd: process.cwd(),
+          cwd: resolveCliWorkspaceCwd(),
           sessionId,
           signal: 'SIGTERM'
         })

--- a/apps/cli/src/workspace.ts
+++ b/apps/cli/src/workspace.ts
@@ -1,0 +1,12 @@
+import process from 'node:process'
+
+import { resolveProjectWorkspaceFolder } from '@vibe-forge/utils'
+
+export const resolveCliWorkspaceCwd = (
+  cwd: string = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env
+) => {
+  const workspaceCwd = resolveProjectWorkspaceFolder(cwd, env)
+  env.__VF_PROJECT_WORKSPACE_FOLDER__ = workspaceCwd
+  return workspaceCwd
+}

--- a/changelog/1.0.1/cli.md
+++ b/changelog/1.0.1/cli.md
@@ -1,0 +1,18 @@
+# @vibe-forge/cli 1.0.1
+
+发布日期：2026-04-17
+
+## 发布范围
+
+- 发布 `@vibe-forge/cli@1.0.1`
+
+## 主要变更
+
+- `vf run` 现在会把 `__VF_PROJECT_WORKSPACE_FOLDER__` 解析后的目录作为真正的运行工作目录，而不是继续固定使用启动目录。
+- `vf list`、`vf stop`、`vf kill` 会与 `vf run` 共享同一套 workspace cwd 解析，session cache 不会再落到启动目录和工作目录两个位置。
+- CLI 会把解析后的 `__VF_PROJECT_WORKSPACE_FOLDER__` 归一成绝对路径，避免相对路径在后续命令链路中被二次展开。
+
+## 兼容性说明
+
+- 本次为向后兼容的 patch 发布，不新增命令参数。
+- 未配置 `__VF_PROJECT_WORKSPACE_FOLDER__` 的项目会继续保持现有默认行为。


### PR DESCRIPTION
## Summary
- resolve CLI workspace cwd from __VF_PROJECT_WORKSPACE_FOLDER__ instead of hard-coding process.cwd()
- make run/list/stop/kill share the same resolved workspace root
- release @vibe-forge/cli@1.0.1 with workspace cwd regression coverage

## Testing
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/cli/__tests__
- npm pack --dry-run (apps/cli)