### PR TITLE
fix(client): ignore wildcard runtime server host

### DIFF
--- a/apps/client/__tests__/runtime-config.spec.ts
+++ b/apps/client/__tests__/runtime-config.spec.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { resolveDevDocumentTitle } from '#~/runtime-config'
+import { getServerHostEnv, resolveDevDocumentTitle } from '#~/runtime-config'
+
+const getGlobalScope = () => (
+  globalThis as { __VF_PROJECT_AI_RUNTIME_ENV__?: { __VF_PROJECT_AI_SERVER_HOST__: string } }
+)
+
+const setRuntimeServerHost = (host: string) => {
+  getGlobalScope().__VF_PROJECT_AI_RUNTIME_ENV__ = {
+    __VF_PROJECT_AI_SERVER_HOST__: host
+  }
+}
+
+const clearRuntimeEnv = () => {
+  delete getGlobalScope().__VF_PROJECT_AI_RUNTIME_ENV__
+}
 
 describe('resolveDevDocumentTitle', () => {
   it('keeps the base title in production', () => {
@@ -29,5 +43,23 @@ describe('resolveDevDocumentTitle', () => {
       isDev: true,
       gitRef: 'codex/feature-a'
     })).toBe('Vibe Forge Web [codex/feature-a]')
+  })
+})
+
+describe('getServerHostEnv', () => {
+  afterEach(() => {
+    clearRuntimeEnv()
+  })
+
+  it('ignores unspecified listen addresses for browser requests', () => {
+    for (const host of ['0.0.0.0', '::', '[::]', '   ']) {
+      setRuntimeServerHost(host)
+      expect(getServerHostEnv()).toBeUndefined()
+    }
+  })
+
+  it('returns a concrete runtime host', () => {
+    setRuntimeServerHost(' 192.168.31.125 ')
+    expect(getServerHostEnv()).toBe('192.168.31.125')
   })
 })

--- a/apps/client/src/runtime-config.ts
+++ b/apps/client/src/runtime-config.ts
@@ -57,6 +57,14 @@ const normalizePath = (value?: string) => {
   return next
 }
 
+const normalizeServerHost = (value?: string) => {
+  const next = value?.trim()
+  if (next == null || next === '' || next === '0.0.0.0' || next === '::' || next === '[::]') {
+    return undefined
+  }
+  return next
+}
+
 export const getRuntimeEnv = (): RuntimeEnv => getGlobalRuntimeEnv() ?? {}
 
 export const resolveClientBase = (...values: Array<string | undefined>) => (
@@ -73,8 +81,10 @@ export const getClientBase = () => (
 )
 
 export const getServerHostEnv = () =>
-  getRuntimeEnv().__VF_PROJECT_AI_SERVER_HOST__ ??
-    import.meta.env.__VF_PROJECT_AI_SERVER_HOST__
+  normalizeServerHost(
+    getRuntimeEnv().__VF_PROJECT_AI_SERVER_HOST__ ??
+      import.meta.env.__VF_PROJECT_AI_SERVER_HOST__
+  )
 
 export const getServerPortEnv = () =>
   getRuntimeEnv().__VF_PROJECT_AI_SERVER_PORT__ ??


### PR DESCRIPTION
## Summary\n- Treat wildcard listen hosts as unset in client runtime config\n- Let LAN browsers fall back to the page hostname for API and WebSocket requests\n- Add runtime config coverage for wildcard and concrete hosts\n\nFixes #125\n\n## Tests\n- pnpm exec dprint check apps/client/src/runtime-config.ts apps/client/__tests__/runtime-config.spec.ts\n- pnpm exec eslint apps/client/src/runtime-config.ts apps/client/__tests__/runtime-config.spec.ts\n- pnpm exec vitest run apps/client/__tests__/runtime-config.spec.ts\n- pnpm typecheck