### PR TITLE
fix(config): handle worktree environment cleanup edge cases

### DIFF
--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -34,7 +34,7 @@
 - `start.sh`、`start.macos.sh`、`start.linux.sh`、`start.windows.ps1`：会话 adapter 进程启动前执行。
 - `destroy.sh`、`destroy.macos.sh`、`destroy.linux.sh`、`destroy.windows.ps1`：托管 worktree 删除前执行；兼容旧拼写 `destory*.sh`。
 
-Windows 下 `*.ps1` 会通过 PowerShell 执行；如果你手动维护文件，也兼容同名 `*.windows.cmd` 和 `*.windows.bat`。通用脚本在 Windows 下还支持 `create.ps1` / `start.ps1` / `destroy.ps1`、`.cmd` 和 `.bat` 变体，避免强依赖 `sh`。
+Windows 下 `*.ps1` 会通过 PowerShell 执行；如果你手动维护文件，也兼容同名 `*.windows.cmd` 和 `*.windows.bat`。通用脚本在 Windows 下支持 `create.ps1` / `start.ps1` / `destroy.ps1`、`.cmd` 和 `.bat` 变体；`.sh` 基础脚本不会在 Windows 上作为默认脚本执行，避免强依赖 `sh`。
 
 配置页右上角选择“项目”时，新建环境会写入 `.ai/env/<environment-id>/`，可随项目提交；选择“本地”时，新建环境会写入 `.ai/env.local/<environment-id>/`，并维护根目录 `.gitignore` 中的 `.ai/env.local/`，作为当前用户自己的配置。旧版 `.ai/env/<environment-id>.local/` 仍会按本地环境读取，但新建和保存都会使用 `.ai/env.local/`。
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .ai/env.local/
 .ai/logs
 .ai/results
-.ai/worktress
+.ai/worktrees/
 .ai.dev.config.json
 
 ### Node template

--- a/apps/server/__tests__/services/session-workspace.spec.ts
+++ b/apps/server/__tests__/services/session-workspace.spec.ts
@@ -90,6 +90,7 @@ describe('session workspace service', () => {
   })
 
   afterEach(async () => {
+    vi.doUnmock('node:process')
     process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = previousWorkspaceEnv
     process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__ = previousPrimaryWorkspaceEnv
     db.close()
@@ -247,6 +248,28 @@ describe('session workspace service', () => {
     ).resolves.toBe('Write-Output "start windows"\n')
   })
 
+  it('does not run shell base scripts as Windows worktree environment defaults', async () => {
+    vi.doMock('node:process', async () => {
+      const actual = await vi.importActual<typeof import('node:process')>('node:process')
+      return {
+        ...actual,
+        platform: 'win32'
+      }
+    })
+    const { runConfiguredWorktreeEnvironmentScripts } = await import('#~/services/worktree-environments.js')
+    const environmentDir = path.join(primaryWorkspaceRoot, '.ai', 'env', 'env-windows-default')
+    await mkdir(environmentDir, { recursive: true })
+    await writeFile(path.join(environmentDir, 'create.sh'), 'exit 42\n', 'utf8')
+
+    await expect(
+      runConfiguredWorktreeEnvironmentScripts({
+        operation: 'create',
+        workspaceFolder: workspaceRoot,
+        environmentId: 'env-windows-default'
+      })
+    ).resolves.toEqual([])
+  })
+
   it('marks local worktree environments as user config and ignores them from git', async () => {
     const {
       getWorktreeEnvironment,
@@ -297,6 +320,40 @@ describe('session workspace service', () => {
 
     expect(workspace.worktreeEnvironment).toBe('env-explicit')
     expect(log.trim()).toBe('env-explicit')
+  })
+
+  it('runs configured destroy scripts when create scripts fail after creating a managed worktree', async () => {
+    const { provisionSessionWorkspace } = await import('#~/services/session/workspace.js')
+    db.createSession('Create Fail Cleanup Env', 'sess-create-fail-cleanup')
+
+    const environmentDir = path.join(primaryWorkspaceRoot, '.ai', 'env', 'env-create-fail-cleanup')
+    const markerPath = path.join(primaryWorkspaceRoot, 'create-fail-destroy.log')
+    await mkdir(environmentDir, { recursive: true })
+    await writeFile(
+      path.join(environmentDir, getBaseScriptFileName('create')),
+      buildScriptContent(
+        'printf "created\\n" > create-resource.log\nexit 17\n',
+        'Set-Content -Path create-resource.log -Value "created"\nexit 17\n'
+      ),
+      'utf8'
+    )
+    await writeFile(
+      path.join(environmentDir, getBaseScriptFileName('destroy')),
+      buildScriptContent(
+        `printf "%s:%s\\n" "$VF_WORKTREE_PATH" "$VF_WORKTREE_FORCE" > "${markerPath}"\n`,
+        `Set-Content -Path "${markerPath}" -Value "$($env:VF_WORKTREE_PATH):$($env:VF_WORKTREE_FORCE)"\n`
+      ),
+      'utf8'
+    )
+
+    await expect(
+      provisionSessionWorkspace('sess-create-fail-cleanup', {
+        worktreeEnvironment: 'env-create-fail-cleanup'
+      })
+    ).rejects.toThrow('Worktree environment script failed')
+    await expect(readFile(markerPath, 'utf8')).resolves.toBe(
+      `${resolveExpectedManagedWorktreePath(primaryWorkspaceRoot, workspaceRoot, 'sess-create-fail-cleanup')}:true\n`
+    )
   })
 
   it('runs configured worktree environment destroy scripts before removing a managed worktree', async () => {

--- a/apps/server/src/services/session/workspace.ts
+++ b/apps/server/src/services/session/workspace.ts
@@ -179,6 +179,21 @@ const buildManagedWorkspace = async (
     })
   } catch (error) {
     if (worktreeCreated) {
+      await runConfiguredWorktreeEnvironmentScripts({
+        operation: 'destroy',
+        workspaceFolder: worktreePath,
+        sourceWorkspaceFolder: workspaceFolder,
+        repositoryRoot: worktreePath,
+        baseRef,
+        environmentId: worktreeEnvironment,
+        force: true,
+        sessionId
+      }).catch((cleanupError) => {
+        console.error(
+          '[sessions] Failed to run worktree environment destroy scripts after create failure:',
+          cleanupError
+        )
+      })
       await removeGitWorktree({
         cwd: repositoryRoot,
         path: worktreePath,

--- a/apps/server/src/services/worktree-environments.ts
+++ b/apps/server/src/services/worktree-environments.ts
@@ -486,11 +486,9 @@ const getOperationScriptFileNames = (
         'destroy.cmd',
         'destory.cmd',
         'destroy.bat',
-        'destory.bat',
-        'destroy.sh',
-        'destory.sh'
+        'destory.bat'
       ]
-      : [`${operation}.ps1`, `${operation}.cmd`, `${operation}.bat`, `${operation}.sh`]
+      : [`${operation}.ps1`, `${operation}.cmd`, `${operation}.bat`]
     : operation === 'destroy'
     ? ['destroy.sh', 'destory.sh']
     : [`${operation}.sh`]


### PR DESCRIPTION
## Summary
- avoid running .sh base worktree environment scripts on Windows
- run destroy hooks when create hooks fail after managed worktree creation
- ignore .ai/worktrees runtime directories by default

## Verification
- pnpm exec vitest run apps/server/__tests__/services/session-workspace.spec.ts
- pnpm exec dprint check .ai/docs/usage/web.md apps/server/src/services/worktree-environments.ts apps/server/src/services/session/workspace.ts apps/server/__tests__/services/session-workspace.spec.ts
- pnpm exec eslint apps/server/src/services/worktree-environments.ts apps/server/src/services/session/workspace.ts apps/server/__tests__/services/session-workspace.spec.ts
- git diff --check