### PR TITLE
feat: add default worktree environment

### DIFF
--- a/.ai.config.json
+++ b/.ai.config.json
@@ -79,5 +79,9 @@
     "sendMessage": "mod+enter",
     "clearInput": "escape",
     "newSession": "mod+k"
+  },
+  "conversation": {
+    "createSessionWorktree": true,
+    "worktreeEnvironment": "default"
   }
 }

--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -42,6 +42,8 @@
 - `start.sh`、`start.macos.sh`、`start.linux.sh`、`start.windows.ps1`：会话 adapter 进程启动前执行。
 - `destroy.sh`、`destroy.macos.sh`、`destroy.linux.sh`、`destroy.windows.ps1`：托管 worktree 删除前执行；兼容旧拼写 `destory*.sh`。
 
+本仓库内置项目环境 `default`。新建托管 worktree 时，它会先拉取默认远端；如果当前 session 分支有同名远端分支，则同步该分支，否则回退同步创建 worktree 时记录的基线分支。
+
 Windows 下 `*.ps1` 会通过 PowerShell 执行；如果你手动维护文件，也兼容同名 `*.windows.cmd` 和 `*.windows.bat`。通用脚本在 Windows 下支持 `create.ps1` / `start.ps1` / `destroy.ps1`、`.cmd` 和 `.bat` 变体；`.sh` 基础脚本不会在 Windows 上作为默认脚本执行，避免强依赖 `sh`。
 
 配置页右上角选择“项目”时，新建环境会写入 `.ai/env/<environment-id>/`，可随项目提交；选择“本地”时，新建环境会写入 `.ai/env.local/<environment-id>/`，并维护根目录 `.gitignore` 中的 `.ai/env.local/`，作为当前用户自己的配置。旧版 `.ai/env/<environment-id>.local/` 仍会按本地环境读取，但新建和保存都会使用 `.ai/env.local/`。

--- a/.ai/env/default/create.sh
+++ b/.ai/env/default/create.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -eu
+
+log() {
+  printf '[default worktree env] %s\n' "$*"
+}
+
+is_commit_ref() {
+  printf '%s' "$1" | grep -Eq '^[0-9a-fA-F]{7,40}$'
+}
+
+pick_default_remote() {
+  if git remote get-url origin >/dev/null 2>&1; then
+    printf '%s\n' origin
+    return
+  fi
+
+  git remote | sed -n '1p'
+}
+
+remote_branch_exists() {
+  remote="$1"
+  branch="$2"
+  [ -n "$remote" ] &&
+    [ -n "$branch" ] &&
+    git ls-remote --exit-code --heads "$remote" "refs/heads/$branch" >/dev/null 2>&1
+}
+
+resolve_target_from_ref() {
+  ref="$1"
+  default_remote="$2"
+  TARGET_REMOTE=
+  TARGET_BRANCH=
+
+  case "$ref" in
+    '' | HEAD)
+      return 1
+      ;;
+    refs/heads/*)
+      TARGET_REMOTE="$default_remote"
+      TARGET_BRANCH="${ref#refs/heads/}"
+      ;;
+    refs/remotes/*)
+      remote_ref="${ref#refs/remotes/}"
+      TARGET_REMOTE="${remote_ref%%/*}"
+      TARGET_BRANCH="${remote_ref#*/}"
+      ;;
+    */*)
+      possible_remote="${ref%%/*}"
+      possible_branch="${ref#*/}"
+      if git remote get-url "$possible_remote" >/dev/null 2>&1; then
+        TARGET_REMOTE="$possible_remote"
+        TARGET_BRANCH="$possible_branch"
+      else
+        TARGET_REMOTE="$default_remote"
+        TARGET_BRANCH="$ref"
+      fi
+      ;;
+    *)
+      if is_commit_ref "$ref"; then
+        return 1
+      fi
+      TARGET_REMOTE="$default_remote"
+      TARGET_BRANCH="$ref"
+      ;;
+  esac
+
+  [ -n "$TARGET_REMOTE" ] && [ -n "$TARGET_BRANCH" ]
+}
+
+current_branch="$(git branch --show-current 2>/dev/null || true)"
+default_remote="$(pick_default_remote)"
+
+if [ -z "$default_remote" ]; then
+  log 'No git remote configured; skipping remote sync.'
+  exit 0
+fi
+
+git fetch --prune "$default_remote"
+
+target_remote=
+target_branch=
+
+if [ -n "$current_branch" ] && remote_branch_exists "$default_remote" "$current_branch"; then
+  target_remote="$default_remote"
+  target_branch="$current_branch"
+else
+  base_ref="${VF_WORKTREE_BASE_REF:-}"
+  if resolve_target_from_ref "$base_ref" "$default_remote" &&
+    remote_branch_exists "$TARGET_REMOTE" "$TARGET_BRANCH"; then
+    target_remote="$TARGET_REMOTE"
+    target_branch="$TARGET_BRANCH"
+  fi
+fi
+
+if [ -z "$target_remote" ] || [ -z "$target_branch" ]; then
+  log "No matching remote branch found for ${current_branch:-detached HEAD}; skipping remote sync."
+  exit 0
+fi
+
+if [ -n "$current_branch" ]; then
+  log "Pulling latest code from $target_remote/$target_branch into $current_branch."
+  git pull --rebase --autostash "$target_remote" "$target_branch"
+else
+  log "Checking out latest code from $target_remote/$target_branch in detached mode."
+  git fetch "$target_remote" "$target_branch"
+  git checkout --detach FETCH_HEAD
+fi


### PR DESCRIPTION
## Summary
- add a project-level `default` worktree environment that fetches the default remote when a managed worktree is created
- configure new conversations to create managed worktrees with the `default` environment
- document the built-in environment behavior

## Verification
- `sh -n .ai/env/default/create.sh`
- `node -e "JSON.parse(require('node:fs').readFileSync('.ai.config.json', 'utf8'))"`
- `git diff --check`