### PR TITLE
feat: load default entity files

### DIFF
--- a/.ai/docs/usage/plugins.md
+++ b/.ai/docs/usage/plugins.md
@@ -101,6 +101,27 @@ pnpm add -D @vibe-forge/plugin-standard-dev @vibe-forge/plugin-logger
 
 其中 `spec` 和 `entity` 还支持在文档前置元数据里通过 `plugins: { mode, list }` 对当前任务的插件列表做 `extend` 或 `override`。
 
+## 实体目录默认文件
+
+目录型实体可以把常驻内容拆成几个默认文件：
+
+```text
+.ai/entities/reviewer/
+  README.md
+  INTRODUCTION.md
+  PERSONALITY.md
+  MEMORY.md
+```
+
+说明：
+
+- `README.md` 或 `index.json` 仍然是实体入口，用来声明 `description`、`skills`、`rules` 等元数据。
+- 当选择该实体运行任务时，会在实体主体后依次追加 `INTRODUCTION.md`、`PERSONALITY.md`、`MEMORY.md` 的内容。
+- 三个默认文件都是可选的，缺失时会自动跳过。
+- 文件名也兼容小写和中文形式：`introduction.md` / `介绍.md`、`personality.md` / `人格.md`、`memory.md` / `记忆.md`。
+- `index.json` 里的 `prompt` / `promptPath` 也会作为主体，再追加这些默认文件。
+- 单文件实体如 `.ai/entities/reviewer.md` 不会读取旁边的默认文件。
+
 ## 本地数据资产目录
 
 项目内置资产默认从 `./.ai/` 读取：

--- a/packages/task/src/schema.ts
+++ b/packages/task/src/schema.ts
@@ -85,7 +85,7 @@ export const Entity = z.object({
   promptPath: z
     .string()
     .describe(
-      '实体的描述文件路径，文件内容为实体的描述。默认为当前目录下的 AGENTS.md 文件。'
+      '实体的描述文件路径，文件内容为实体的描述。目录型实体还会按顺序追加 INTRODUCTION.md、PERSONALITY.md、MEMORY.md。'
     )
     .optional(),
   rules: z

--- a/packages/workspace-assets/__tests__/prompt-selection.spec.ts
+++ b/packages/workspace-assets/__tests__/prompt-selection.spec.ts
@@ -435,6 +435,94 @@ describe('resolvePromptAssetSelection', () => {
     expect(options.systemPrompt).not.toContain('<skill-content>\n先读 README.md\n</skill-content>')
   })
 
+  it('appends conventional prompt files when loading a directory entity', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/README.md'),
+      [
+        '---',
+        'description: 代码评审实体',
+        '---',
+        '基础身份。'
+      ].join('\n')
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/INTRODUCTION.md'),
+      '负责发现行为回归。'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/PERSONALITY.md'),
+      '说话克制，先给出高风险问题。'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/MEMORY.md'),
+      '记住上次评审指出过缺少验证。'
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      useDefaultVibeForgeMcpServer: false
+    })
+    const [data, options] = await resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'reviewer'
+    })
+
+    expect(data.targetBody).toContain('基础身份。')
+    expect(data.targetBody).toContain('## Introduction\n\n负责发现行为回归。')
+    expect(data.targetBody).toContain('## Personality\n\n说话克制，先给出高风险问题。')
+    expect(data.targetBody).toContain('## Memory\n\n记住上次评审指出过缺少验证。')
+    expect(options.systemPrompt).toContain('## Introduction\n\n负责发现行为回归。')
+    expect(data.targetBody.indexOf('基础身份。')).toBeLessThan(data.targetBody.indexOf('## Introduction'))
+    expect(data.targetBody.indexOf('## Introduction')).toBeLessThan(data.targetBody.indexOf('## Personality'))
+    expect(data.targetBody.indexOf('## Personality')).toBeLessThan(data.targetBody.indexOf('## Memory'))
+  })
+
+  it('appends alias prompt files for index json entities', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/index.json'),
+      JSON.stringify(
+        {
+          description: '代码评审实体',
+          prompt: '基础身份。'
+        },
+        null,
+        2
+      )
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/介绍.md'),
+      '负责发现行为回归。'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/personality.md'),
+      '说话克制，先给出高风险问题。'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/reviewer/记忆.md'),
+      '记住上次评审指出过缺少验证。'
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      useDefaultVibeForgeMcpServer: false
+    })
+    const [data] = await resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'reviewer'
+    })
+
+    expect(data.targetBody).toContain('基础身份。')
+    expect(data.targetBody).toContain('## Introduction\n\n负责发现行为回归。')
+    expect(data.targetBody).toContain('## Personality\n\n说话克制，先给出高风险问题。')
+    expect(data.targetBody).toContain('## Memory\n\n记住上次评审指出过缺少验证。')
+  })
+
   it('does not preload all skills when the target entity omits skill references', async () => {
     const workspace = await createWorkspace()
 

--- a/packages/workspace-assets/src/bundle-internal.ts
+++ b/packages/workspace-assets/src/bundle-internal.ts
@@ -51,6 +51,69 @@ const isRecord = (value: unknown): value is Record<string, unknown> => (
   value != null && typeof value === 'object' && !Array.isArray(value)
 )
 
+const ENTITY_DIRECTORY_ENTRY_FILES = new Set(['readme.md', 'index.json'])
+
+const DEFAULT_ENTITY_PROMPT_FILE_SECTIONS = [
+  {
+    heading: 'Introduction',
+    fileNames: ['INTRODUCTION.md', 'introduction.md', '介绍.md']
+  },
+  {
+    heading: 'Personality',
+    fileNames: ['PERSONALITY.md', 'personality.md', '人格.md']
+  },
+  {
+    heading: 'Memory',
+    fileNames: ['MEMORY.md', 'memory.md', '记忆.md']
+  }
+] as const
+
+const isMissingFileError = (error: unknown) => (
+  error != null &&
+  typeof error === 'object' &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
+)
+
+const readOptionalMarkdownBody = async (path: string) => {
+  try {
+    const content = await readFile(path, 'utf-8')
+    return fm<Record<string, never>>(content).body.trim()
+  } catch (err) {
+    if (isMissingFileError(err)) return undefined
+    throw err
+  }
+}
+
+const loadDefaultEntityPromptSection = async (
+  entityDir: string,
+  section: (typeof DEFAULT_ENTITY_PROMPT_FILE_SECTIONS)[number]
+) => {
+  for (const fileName of section.fileNames) {
+    const body = await readOptionalMarkdownBody(resolve(entityDir, fileName))
+    if (body == null || body === '') continue
+
+    return `## ${section.heading}\n\n${body}`
+  }
+
+  return undefined
+}
+
+const appendDefaultEntityPromptFiles = async (path: string, body: string) => {
+  if (!ENTITY_DIRECTORY_ENTRY_FILES.has(basename(path).toLowerCase())) return body
+
+  const sections = await Promise.all(
+    DEFAULT_ENTITY_PROMPT_FILE_SECTIONS.map(section => loadDefaultEntityPromptSection(dirname(path), section))
+  )
+
+  return [
+    body.trim(),
+    ...sections
+  ]
+    .filter((section): section is string => section != null && section !== '')
+    .join('\n\n')
+}
+
 const resolveDisplayName = (name: string, scope?: string) => (
   scope != null && scope.trim() !== '' ? `${scope}/${name}` : name
 )
@@ -74,6 +137,15 @@ const parseFrontmatterDocument = async <TDefinition extends object>(
   }
 }
 
+const parseEntityMarkdownDocument = async (path: string): Promise<Definition<Entity>> => {
+  const definition = await parseFrontmatterDocument<Entity>(path)
+
+  return {
+    ...definition,
+    body: await appendDefaultEntityPromptFiles(path, definition.body)
+  }
+}
+
 const parseEntityIndexJson = async (path: string): Promise<Definition<Entity>> => {
   const raw = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>
   const promptPath = typeof raw.promptPath === 'string'
@@ -87,7 +159,7 @@ const parseEntityIndexJson = async (path: string): Promise<Definition<Entity>> =
 
   return {
     path,
-    body: prompt,
+    body: await appendDefaultEntityPromptFiles(path, prompt),
     attributes: raw as Entity
   }
 }
@@ -412,7 +484,7 @@ export async function collectWorkspaceAssets(params: {
   await pushDocumentAssets('rule', localScan.rulePaths, 'workspace')
   await pushDocumentAssets('skill', localScan.skillPaths, 'workspace')
   await pushDocumentAssets('spec', localScan.specPaths, 'workspace')
-  await pushDocumentAssets('entity', localScan.entityDocPaths, 'workspace')
+  await pushDocumentAssets('entity', localScan.entityDocPaths, 'workspace', undefined, parseEntityMarkdownDocument)
   await pushDocumentAssets('entity', localScan.entityJsonPaths, 'workspace', undefined, parseEntityIndexJson)
 
   for (let index = 0; index < flattenedPluginInstances.length; index++) {
@@ -421,7 +493,7 @@ export async function collectWorkspaceAssets(params: {
     await pushDocumentAssets('rule', scan.rulePaths, 'plugin', instance)
     await pushDocumentAssets('skill', scan.skillPaths, 'plugin', instance)
     await pushDocumentAssets('spec', scan.specPaths, 'plugin', instance)
-    await pushDocumentAssets('entity', scan.entityDocPaths, 'plugin', instance)
+    await pushDocumentAssets('entity', scan.entityDocPaths, 'plugin', instance, parseEntityMarkdownDocument)
     await pushDocumentAssets('entity', scan.entityJsonPaths, 'plugin', instance, parseEntityIndexJson)
   }
 


### PR DESCRIPTION
## Summary
- append directory entity default files for introduction, personality, and memory
- support README and index.json entity entries plus lowercase/Chinese aliases
- document the entity directory convention

## Verification
- pnpm -C packages/workspace-assets test
- pnpm -C packages/task test
- pnpm exec dprint check packages/workspace-assets/src/bundle-internal.ts packages/workspace-assets/__tests__/prompt-selection.spec.ts packages/task/src/schema.ts .ai/docs/usage/plugins.md
- pnpm exec eslint packages/workspace-assets/src/bundle-internal.ts packages/workspace-assets/__tests__/prompt-selection.spec.ts packages/task/src/schema.ts