### PR TITLE
feat: support local dev rules

### DIFF
--- a/.ai/docs/usage/plugins.md
+++ b/.ai/docs/usage/plugins.md
@@ -101,11 +101,10 @@ pnpm add -D @vibe-forge/plugin-standard-dev @vibe-forge/plugin-logger
 
 其中 `spec` 和 `entity` 还支持在文档前置元数据里通过 `plugins: { mode, list }` 对当前任务的插件列表做 `extend` 或 `override`。
 
-## 实体目录默认文件
+## 资产细节
 
-目录型实体可以把常驻内容拆到 `INTRODUCTION.md`、`PERSONALITY.md`、`MEMORY.md`。
-
-继续看：[实体目录默认文件](./plugins/entity-default-files.md)。
+- [实体目录默认文件](./plugins/entity-default-files.md)
+- [本地私有规则](./plugins/local-rules.md)
 
 ## 本地数据资产目录
 

--- a/.ai/docs/usage/plugins/local-rules.md
+++ b/.ai/docs/usage/plugins/local-rules.md
@@ -1,0 +1,17 @@
+# 本地私有规则
+
+返回入口：[插件与数据资产](../plugins.md)
+
+项目规则默认从 `.ai/rules/*.md` 读取。除了随项目提交的规则，也可以使用本地私有规则：
+
+```text
+.ai/rules/my-preferences.local.md
+.ai/rules/debug.dev.md
+```
+
+说明：
+
+- `*.local.md` 和 `*.dev.md` 会像普通 rule 一样参与加载。
+- 仓库默认 `.gitignore` 会忽略 `.ai/rules/*.local.md`、`.ai/rules/*.dev.md` 及其子目录同名格式，避免提交到远端。
+- 这些文件只存在当前用户的工作区，因此适合存放个人偏好、临时调试约束、本地环境规则。
+- 如果项目通过 `__VF_PROJECT_AI_BASE_DIR__` 改了资产根目录，请在项目自己的 `.gitignore` 里为新目录添加对应忽略规则。

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 .ai/results
 .ai/worktrees/
 .ai.dev.config.json
+.ai/rules/*.local.md
+.ai/rules/*.dev.md
+.ai/rules/**/*.local.md
+.ai/rules/**/*.dev.md
 
 ### Node template
 # Logs

--- a/packages/workspace-assets/__tests__/bundle.spec.ts
+++ b/packages/workspace-assets/__tests__/bundle.spec.ts
@@ -103,6 +103,35 @@ describe('resolveWorkspaceAssetBundle', () => {
     }
   })
 
+  it('loads local and dev rule files as workspace rules', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/rules/team.md'),
+      '---\ndescription: 团队规则\n---\n团队共享约束'
+    )
+    await writeDocument(
+      join(workspace, '.ai/rules/preference.local.md'),
+      '---\ndescription: 本地偏好\nalwaysApply: true\n---\n使用当前用户偏好的输出风格'
+    )
+    await writeDocument(
+      join(workspace, '.ai/rules/debug.dev.md'),
+      '---\ndescription: 本地调试\nalwaysApply: true\n---\n优先保留调试证据'
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      configs: [undefined, undefined],
+      useDefaultVibeForgeMcpServer: false
+    })
+
+    expect(bundle.rules.map(asset => asset.displayName).sort()).toEqual(['debug.dev', 'preference.local', 'team'])
+    expect(bundle.rules.find(asset => asset.displayName === 'preference.local')?.payload.definition.body)
+      .toContain('当前用户偏好')
+    expect(bundle.rules.find(asset => asset.displayName === 'debug.dev')?.payload.definition.attributes.alwaysApply)
+      .toBe(true)
+  })
+
   it('installs selected missing skill dependencies from an API-compatible registry cache', async () => {
     const workspace = await createWorkspace()
     const fetchMock = vi.fn(async (url: string) => {


### PR DESCRIPTION
## Summary
- document .local.md and .dev.md rule files as current-user private rules
- ignore .ai/rules/*.local.md and .ai/rules/*.dev.md from git by default
- add bundle coverage that local/dev rules are loaded as workspace rules

## Verification
- pnpm -C packages/workspace-assets test
- pnpm exec dprint check .gitignore .ai/docs/usage/plugins.md .ai/docs/usage/plugins/local-rules.md packages/workspace-assets/__tests__/bundle.spec.ts
- pnpm exec eslint .
- git check-ignore -v .ai/rules/preference.local.md .ai/rules/debug.dev.md .ai/rules/private/preference.local.md .ai/rules/private/debug.dev.md