### PR TITLE
chore(config): enable all adapters

### DIFF
--- a/.ai.config.json
+++ b/.ai.config.json
@@ -6,6 +6,8 @@
       }
     },
     "codex": {},
+    "copilot": {},
+    "gemini": {},
     "kimi": {},
     "opencode": {}
   },


### PR DESCRIPTION
## Summary
- enable the Copilot and Gemini adapters in the workspace config
- keep existing adapter-specific settings unchanged

## Verification
- node apps/cli/cli.js config get adapters --source merged --json
- pnpm exec dprint check .ai.config.json
- git diff --check