### PR TITLE
feat: add entity inheritance

### DIFF
--- a/.ai/docs/usage/plugins.md
+++ b/.ai/docs/usage/plugins.md
@@ -104,6 +104,7 @@ pnpm add -D @vibe-forge/plugin-standard-dev @vibe-forge/plugin-logger
 ## 资产细节
 
 - [实体目录默认文件](./plugins/entity-default-files.md)
+- [实体继承](./plugins/entity-inheritance.md)
 - [本地私有规则](./plugins/local-rules.md)
 
 ## 本地数据资产目录

--- a/.ai/docs/usage/plugins/entity-inheritance.md
+++ b/.ai/docs/usage/plugins/entity-inheritance.md
@@ -1,0 +1,32 @@
+# 实体继承
+
+返回入口：[插件与数据资产](../plugins.md)
+
+实体可以通过 `extends` 继承本地实体或插件实体：
+
+```yaml
+---
+name: frontend-reviewer
+description: 前端评审实体
+extends:
+  - std/dev-reviewer
+inherit:
+  prompt: append
+  rules: merge
+  skills: merge
+  tools: replace
+  mcpServers: replace
+---
+
+在标准评审要求上，额外关注交互、样式、focus、主题和移动端布局。
+```
+
+说明：
+
+- `extends` 可以是单个实体标识，也可以是有序列表。
+- 插件实体使用现有 `scope/name` 标识，例如 `std/dev-reviewer`。
+- 多个父实体会先按 `extends` 顺序组合成一个 inherited base。
+- `inherit` 只控制当前实体如何继承 inherited base，不控制父实体之间的组合。
+- 默认会追加 prompt，并合并 `tags`、`rules`、`skills`。
+- `tools` 和 `mcpServers` 默认使用子实体配置；子实体未配置时继承父实体组合结果。
+- `plugins` 不会从父实体继承。

--- a/.ai/rfcs/0002-entity-inheritance.md
+++ b/.ai/rfcs/0002-entity-inheritance.md
@@ -1,0 +1,158 @@
+---
+rfc: 0002
+title: Entity Inheritance
+status: draft
+authors:
+  - Codex
+created: 2026-04-19
+updated: 2026-04-19
+targetVersion: vNext
+trackingIssue: https://github.com/vibe-forge-ai/vibe-forge.ai/issues/137
+futureIssue: https://github.com/vibe-forge-ai/vibe-forge.ai/issues/138
+---
+
+# RFC 0002: Entity Inheritance
+
+## Summary
+
+Add `extends` and `inherit` fields to Vibe Forge entities so a project entity can build on existing local or plugin entities.
+
+The first version keeps inheritance easy to reason about:
+
+- `extends` accepts one entity reference or an ordered list of references.
+- plugin entities are referenced through the existing `scope/name` asset identifier.
+- multiple parents are composed in `extends` order into an inherited base.
+- `inherit` controls only how the current entity receives that inherited base.
+- prompt, rules, skills, and tags are additive by default.
+- tool and MCP filters are conservative by default and use child values when present.
+
+Advanced per-parent merge policies are intentionally deferred to a separate issue.
+
+## Motivation
+
+Project teams already use shared entities from plugins such as `standard-dev`, then add project-specific constraints. Today they must copy the whole entity body and metadata, which makes plugin updates hard to consume and encourages drift.
+
+Inheritance lets users write small, focused project entities:
+
+```yaml
+---
+name: frontend-reviewer
+description: 前端评审实体
+extends:
+  - std/dev-reviewer
+inherit:
+  prompt: append
+  rules: merge
+  skills: merge
+  tools: replace
+  mcpServers: replace
+---
+
+在标准评审要求上，额外关注交互、样式、focus、主题和移动端布局。
+```
+
+## Goals
+
+- Support `extends: <entity-ref>` and `extends: [<entity-ref>, ...]` in Markdown and `index.json` entities.
+- Support references to scoped plugin entities, for example `std/dev-reviewer`.
+- Merge multiple parents in the order listed by `extends`.
+- Add `inherit` controls for the current entity versus the inherited base.
+- Include inherited entity asset ids in `promptAssetIds`.
+- Detect missing parents, ambiguous references, and inheritance cycles.
+- Add tests for local inheritance, plugin inheritance, multiple parents, replacement behavior, and cycles.
+
+## Non-Goals
+
+- Do not support per-parent merge strategy objects in V1.
+- Do not inherit parent `plugins` overlays in V1.
+- Do not introduce package-name entity references such as `@vibe-forge/plugin-standard-dev/dev-reviewer`.
+- Do not change entity route listing semantics.
+- Do not change how rules, skills, MCP servers, or tools are resolved outside selected entity mode.
+
+## Entity References
+
+Entity references reuse existing asset selection semantics:
+
+- `reviewer`: resolve a local or globally unique entity named `reviewer`.
+- `std/dev-reviewer`: resolve entity `dev-reviewer` from plugin scope `std`.
+- inside a plugin entity, unscoped refs first resolve to the same plugin instance.
+- ambiguous unscoped references fail and ask users to use a scoped reference.
+
+## Parent Composition
+
+When `extends` contains multiple parents, parents are composed into one inherited base first:
+
+```text
+parentA -> parentB -> currentEntity
+```
+
+Parent-to-parent composition is fixed in V1:
+
+| Field                                   | Parent composition                                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| prompt/body                             | append in extends order                                                               |
+| introduction/personality/memory content | already part of body, append in extends order                                         |
+| tags                                    | merge and de-duplicate                                                                |
+| rules                                   | merge and de-duplicate                                                                |
+| skills                                  | merge include lists when possible; later non-mergeable selectors replace earlier ones |
+| tools                                   | later parent overrides earlier parent                                                 |
+| mcpServers                              | later parent overrides earlier parent                                                 |
+| description                             | later parent overrides earlier parent                                                 |
+| always                                  | later parent overrides earlier parent                                                 |
+| name                                    | never inherited                                                                       |
+| plugins                                 | never inherited                                                                       |
+
+## Current Entity Inheritance
+
+After parent composition, the current entity applies `inherit` against the inherited base.
+
+Default behavior:
+
+```yaml
+inherit:
+  prompt: append
+  tags: merge
+  rules: merge
+  skills: merge
+  tools: replace
+  mcpServers: replace
+```
+
+Supported modes:
+
+- `append`: parent value first, child value second.
+- `prepend`: child value first, parent value second.
+- `merge`: merge compatible values and de-duplicate.
+- `replace`: use the child value when present; otherwise keep the inherited value.
+- `none`: ignore the inherited value and use only the child value.
+
+`inherit` may also be a single mode string that applies as `default`.
+
+Example:
+
+```yaml
+extends:
+  - std/dev-reviewer
+  - frontend-reviewer-base
+inherit:
+  rules: replace
+  tools: replace
+```
+
+Here, `std/dev-reviewer` and `frontend-reviewer-base` first merge their rules into the inherited base. Then `rules: replace` means the current entity uses only its own `rules`.
+
+## Error Handling
+
+- Missing parent: include available entity display names in the error.
+- Ambiguous parent: reuse the existing ambiguous asset reference error.
+- Circular inheritance: report the full chain, for example `a -> b -> a`.
+- Invalid inherit mode: fail fast and name the invalid field.
+
+## Future Work
+
+Advanced inheritance controls are deferred:
+
+- per-parent merge modes;
+- explicit `extends` entries with `ref`, `mode`, or field strategies;
+- parent-specific field suppression;
+- inheriting plugin overlays with a clearer plugin graph model.

--- a/packages/task/src/schema.ts
+++ b/packages/task/src/schema.ts
@@ -78,6 +78,28 @@ export const Options = z
 export type Options = z.infer<typeof Options>
 
 export const Entity = z.object({
+  extends: z
+    .union([
+      z.string(),
+      z.array(z.string())
+    ])
+    .describe('继承的实体标识。可引用本地实体或带 scope 的插件实体，例如 std/dev-reviewer。')
+    .optional(),
+  inherit: z
+    .union([
+      z.enum(['append', 'prepend', 'merge', 'replace', 'none']),
+      z.object({
+        default: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        prompt: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        tags: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        rules: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        skills: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        tools: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional(),
+        mcpServers: z.enum(['append', 'prepend', 'merge', 'replace', 'none']).optional()
+      })
+    ])
+    .describe('当前实体继承父实体组合结果时的字段策略。')
+    .optional(),
   prompt: z
     .string()
     .describe('实体的描述，简单介绍一下当前实体的作用。')

--- a/packages/types/src/definition.ts
+++ b/packages/types/src/definition.ts
@@ -54,11 +54,25 @@ export interface SkillSelection {
   list: string[]
 }
 
+export type EntityInheritanceMode = 'append' | 'prepend' | 'merge' | 'replace' | 'none'
+
+export interface EntityInheritance {
+  default?: EntityInheritanceMode
+  prompt?: EntityInheritanceMode
+  tags?: EntityInheritanceMode
+  rules?: EntityInheritanceMode
+  skills?: EntityInheritanceMode
+  tools?: EntityInheritanceMode
+  mcpServers?: EntityInheritanceMode
+}
+
 export interface Entity {
   name?: string
   always?: boolean
   description?: string
   tags?: string[]
+  extends?: string | string[]
+  inherit?: EntityInheritanceMode | EntityInheritance
   prompt?: string
   promptPath?: string
   rules?: RuleReference[]

--- a/packages/workspace-assets/__tests__/prompt-selection.spec.ts
+++ b/packages/workspace-assets/__tests__/prompt-selection.spec.ts
@@ -523,6 +523,225 @@ describe('resolvePromptAssetSelection', () => {
     expect(data.targetBody).toContain('## Memory\n\n记住上次评审指出过缺少验证。')
   })
 
+  it('inherits prompt, rules, and skills from scoped plugin entities', async () => {
+    const workspace = await createWorkspace()
+
+    await installPluginPackage(workspace, '@vibe-forge/plugin-standard-dev', {
+      'package.json': JSON.stringify(
+        {
+          name: '@vibe-forge/plugin-standard-dev',
+          version: '1.0.0'
+        },
+        null,
+        2
+      ),
+      'rules/base-review.md': '---\ndescription: 标准评审规则\n---\n父规则正文',
+      'skills/base-review/SKILL.md': '---\ndescription: 标准评审技能\n---\n父技能正文',
+      'entities/base-reviewer/README.md': [
+        '---',
+        'description: 标准评审实体',
+        'rules:',
+        '  - base-review',
+        'skills:',
+        '  - base-review',
+        'tools:',
+        '  include:',
+        '    - Read',
+        '---',
+        '父实体提示。'
+      ].join('\n')
+    })
+    await writeDocument(
+      join(workspace, '.ai/rules/base-review.md'),
+      '---\ndescription: 同名本地规则\n---\n同名本地规则正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/rules/frontend.md'),
+      '---\ndescription: 前端规则\n---\n子规则正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/skills/base-review/SKILL.md'),
+      '---\ndescription: 同名本地技能\n---\n同名本地技能正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/skills/frontend/SKILL.md'),
+      '---\ndescription: 前端技能\n---\n子技能正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/frontend-reviewer/README.md'),
+      [
+        '---',
+        'description: 前端评审实体',
+        'extends: std/base-reviewer',
+        'rules:',
+        '  - frontend',
+        'skills:',
+        '  - frontend',
+        'tools:',
+        '  include:',
+        '    - Grep',
+        '---',
+        '子实体提示。'
+      ].join('\n')
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      configs: [{
+        plugins: [
+          { id: 'standard-dev', scope: 'std' }
+        ]
+      }, undefined],
+      useDefaultVibeForgeMcpServer: false
+    })
+    const [data, options] = await resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'frontend-reviewer'
+    })
+    const parentEntityId = bundle.entities.find(asset => asset.displayName === 'std/base-reviewer')?.id
+    const childEntityId = bundle.entities.find(asset => asset.displayName === 'frontend-reviewer')?.id
+
+    expect(data.targetBody).toContain('父实体提示。\n\n子实体提示。')
+    expect(data.targetSkills.map(skill => skill.resolvedName)).toEqual(['std/base-review', 'frontend'])
+    expect(options.systemPrompt).toContain('> 父规则正文')
+    expect(options.systemPrompt).toContain('> 子规则正文')
+    expect(options.systemPrompt).not.toContain('> 同名本地规则正文')
+    expect(options.systemPrompt).not.toContain('<skill-content>\n同名本地技能正文\n</skill-content>')
+    expect(options.tools).toEqual({ include: ['Grep'] })
+    expect(options.promptAssetIds).toEqual(expect.arrayContaining([parentEntityId, childEntityId]))
+  })
+
+  it('composes multiple parent entities in extends order', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/entities/base-a.md'),
+      [
+        '---',
+        'description: 父实体 A',
+        'tools:',
+        '  include:',
+        '    - Read',
+        '---',
+        '父实体 A 提示。'
+      ].join('\n')
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/base-b.md'),
+      [
+        '---',
+        'description: 父实体 B',
+        'tools:',
+        '  include:',
+        '    - Bash',
+        '---',
+        '父实体 B 提示。'
+      ].join('\n')
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/child.md'),
+      [
+        '---',
+        'description: 子实体',
+        'extends:',
+        '  - base-a',
+        '  - base-b',
+        '---',
+        '子实体提示。'
+      ].join('\n')
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      useDefaultVibeForgeMcpServer: false
+    })
+    const [data, options] = await resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'child'
+    })
+
+    expect(data.targetBody).toContain('父实体 A 提示。\n\n父实体 B 提示。\n\n子实体提示。')
+    expect(options.tools).toEqual({ include: ['Bash'] })
+  })
+
+  it('lets the current entity replace inherited rules', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/rules/base.md'),
+      '---\ndescription: 父规则\n---\n父规则正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/rules/child.md'),
+      '---\ndescription: 子规则\n---\n子规则正文'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/base.md'),
+      [
+        '---',
+        'description: 父实体',
+        'rules:',
+        '  - base',
+        '---',
+        '父实体提示。'
+      ].join('\n')
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/child.md'),
+      [
+        '---',
+        'description: 子实体',
+        'extends: base',
+        'inherit:',
+        '  rules: replace',
+        'rules:',
+        '  - child',
+        '---',
+        '子实体提示。'
+      ].join('\n')
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      useDefaultVibeForgeMcpServer: false
+    })
+    const [, options] = await resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'child'
+    })
+
+    expect(options.systemPrompt).toContain('> 子规则正文')
+    expect(options.systemPrompt).toContain('> Use when: 父规则')
+    expect(options.systemPrompt).not.toContain('> 父规则正文')
+  })
+
+  it('rejects circular entity inheritance', async () => {
+    const workspace = await createWorkspace()
+
+    await writeDocument(
+      join(workspace, '.ai/entities/a.md'),
+      '---\ndescription: A\nextends: b\n---\nA'
+    )
+    await writeDocument(
+      join(workspace, '.ai/entities/b.md'),
+      '---\ndescription: B\nextends: a\n---\nB'
+    )
+
+    const bundle = await resolveWorkspaceAssetBundle({
+      cwd: workspace,
+      useDefaultVibeForgeMcpServer: false
+    })
+
+    await expect(resolvePromptAssetSelection({
+      bundle,
+      type: 'entity',
+      name: 'a'
+    })).rejects.toThrow('Circular entity inheritance detected: a -> b -> a')
+  })
+
   it('does not preload all skills when the target entity omits skill references', async () => {
     const workspace = await createWorkspace()
 

--- a/packages/workspace-assets/src/prompt-selection.ts
+++ b/packages/workspace-assets/src/prompt-selection.ts
@@ -1,11 +1,13 @@
 /* eslint-disable max-lines -- prompt asset selection coordinates routing, overlays, and dependency expansion */
 import type {
   Definition,
+  Entity,
   Filter,
   PluginOverlayConfig,
   Rule,
   RuleReference,
   SkillSelection,
+  Spec,
   WorkspaceAsset,
   WorkspaceAssetBundle,
   WorkspaceMcpSelection,
@@ -24,6 +26,7 @@ import {
 import {
   definitionWithResolvedName,
   pickDocumentAsset,
+  resolveEntityInheritance,
   resolveExcludedSkillRefs,
   resolveIncludedSkillRefs,
   resolveNamedAssets,
@@ -60,6 +63,8 @@ export async function resolvePromptAssetSelection(params: {
   let targetToolsFilter: Filter | undefined
   let targetMcpServersFilter: Filter | undefined
   let targetInstancePath: string | undefined
+  let targetAssetIds: string[] = []
+  let targetDefinition: Definition<Entity | Spec> | undefined
 
   if (params.type && params.name) {
     const baseTarget = params.type === 'spec'
@@ -80,9 +85,20 @@ export async function resolvePromptAssetSelection(params: {
     }
 
     pinnedTargetAsset = baseTarget
-    targetBody = baseTarget.payload.definition.body
-    targetToolsFilter = baseTarget.payload.definition.attributes.tools
-    targetMcpServersFilter = baseTarget.payload.definition.attributes.mcpServers
+    if (params.type === 'entity') {
+      const resolvedEntity = resolveEntityInheritance(
+        effectiveBundle,
+        baseTarget as Extract<WorkspaceAsset, { kind: 'entity' }>
+      )
+      targetDefinition = resolvedEntity.definition
+      targetAssetIds = resolvedEntity.assetIds
+    } else {
+      targetDefinition = baseTarget.payload.definition
+      targetAssetIds = [baseTarget.id]
+    }
+    targetBody = targetDefinition.body
+    targetToolsFilter = targetDefinition.attributes.tools
+    targetMcpServersFilter = targetDefinition.attributes.mcpServers
     targetInstancePath = baseTarget.instancePath
     options.assetBundle = effectiveBundle
   }
@@ -105,8 +121,8 @@ export async function resolvePromptAssetSelection(params: {
   const targetSkillsAssets: Array<Extract<WorkspaceAsset, { kind: 'skill' }>> = []
 
   if (pinnedTargetAsset != null) {
-    promptAssetIds.add(pinnedTargetAsset.id)
-    const attributes = pinnedTargetAsset.payload.definition.attributes
+    targetAssetIds.forEach(assetId => promptAssetIds.add(assetId))
+    const attributes = targetDefinition?.attributes ?? pinnedTargetAsset.payload.definition.attributes
 
     if (attributes.rules != null) {
       const selection = await resolveRuleSelection(

--- a/packages/workspace-assets/src/selection-internal.ts
+++ b/packages/workspace-assets/src/selection-internal.ts
@@ -1,5 +1,9 @@
 import type {
   Definition,
+  Entity,
+  EntityInheritance,
+  EntityInheritanceMode,
+  Filter,
   PluginConfig,
   PluginOverlayConfig,
   Rule,
@@ -30,8 +34,28 @@ type DocumentAsset<TDefinition> = Extract<WorkspaceAsset, { kind: DocumentAssetK
     definition: TDefinition & { path: string }
   }
 }
+type EntityAsset = Extract<WorkspaceAsset, { kind: 'entity' }>
+type EntityInheritanceField = Exclude<keyof EntityInheritance, 'default'>
 
 const ASSET_REFERENCE_PATH_SUFFIXES = ['.md', '.json', '.yaml', '.yml']
+const ENTITY_INHERITANCE_FIELDS = ['prompt', 'tags', 'rules', 'skills', 'tools', 'mcpServers'] as const
+const ENTITY_INHERITANCE_MODES = new Set<EntityInheritanceMode>(['append', 'prepend', 'merge', 'replace', 'none'])
+const DEFAULT_CHILD_ENTITY_INHERITANCE: Record<EntityInheritanceField, EntityInheritanceMode> = {
+  prompt: 'append',
+  tags: 'merge',
+  rules: 'merge',
+  skills: 'merge',
+  tools: 'replace',
+  mcpServers: 'replace'
+}
+const PARENT_ENTITY_INHERITANCE: Record<EntityInheritanceField, EntityInheritanceMode> = {
+  prompt: 'append',
+  tags: 'merge',
+  rules: 'merge',
+  skills: 'merge',
+  tools: 'replace',
+  mcpServers: 'replace'
+}
 
 export const definitionWithResolvedName = <TDefinition>(
   definition: Definition<TDefinition>,
@@ -121,6 +145,293 @@ export const resolveNamedAssets = <TAsset extends Extract<WorkspaceAsset, { kind
   }
 
   return selected
+}
+
+const normalizeEntityExtends = (value: Entity['extends']) => {
+  if (typeof value === 'string') return value.trim() !== '' ? [value.trim()] : []
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map(ref => ref.trim())
+    .filter(Boolean)
+}
+
+const parseEntityInheritanceMode = (
+  value: unknown,
+  label: string
+): EntityInheritanceMode | undefined => {
+  if (value == null) return undefined
+  if (typeof value !== 'string' || !ENTITY_INHERITANCE_MODES.has(value as EntityInheritanceMode)) {
+    throw new Error(`Invalid entity inherit mode for ${label}: ${String(value)}`)
+  }
+  return value as EntityInheritanceMode
+}
+
+const resolveEntityInheritanceModes = (
+  value: Entity['inherit'],
+  defaults: Record<EntityInheritanceField, EntityInheritanceMode>
+) => {
+  const modes = { ...defaults }
+  if (value == null) return modes
+
+  if (typeof value === 'string') {
+    const defaultMode = parseEntityInheritanceMode(value, 'inherit')
+    for (const field of ENTITY_INHERITANCE_FIELDS) {
+      modes[field] = defaultMode ?? modes[field]
+    }
+    return modes
+  }
+
+  const defaultMode = parseEntityInheritanceMode(value.default, 'inherit.default')
+  for (const field of ENTITY_INHERITANCE_FIELDS) {
+    modes[field] = parseEntityInheritanceMode(value[field], `inherit.${field}`) ?? defaultMode ?? modes[field]
+  }
+  return modes
+}
+
+const toUniqueStrings = (values: string[]) => Array.from(new Set(values))
+
+const toUniqueValues = <TValue>(values: TValue[], keyOf: (value: TValue) => string) => {
+  const seen = new Set<string>()
+  const result: TValue[] = []
+
+  for (const value of values) {
+    const key = keyOf(value)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(value)
+  }
+
+  return result
+}
+
+const keyRuleReference = (rule: RuleReference) => (
+  typeof rule === 'string' ? `string:${rule}` : `object:${JSON.stringify(rule)}`
+)
+
+const qualifyEntityReference = (
+  asset: EntityAsset,
+  ref: string
+) => {
+  const value = ref.trim()
+  if (value === '' || asset.scope == null) return value
+  if (parseScopedReference(value, { pathSuffixes: ASSET_REFERENCE_PATH_SUFFIXES }) != null) return value
+  if (
+    isPathLikeReference(value, {
+      pathSuffixes: ASSET_REFERENCE_PATH_SUFFIXES,
+      allowGlob: true
+    })
+  ) {
+    return value
+  }
+
+  return `${asset.scope}/${value}`
+}
+
+const qualifyEntityRuleReferences = (
+  asset: EntityAsset,
+  rules: Entity['rules']
+) => rules?.map(rule => typeof rule === 'string' ? qualifyEntityReference(asset, rule) : rule)
+
+const qualifyEntitySkillSelection = (
+  asset: EntityAsset,
+  selection: Entity['skills']
+): Entity['skills'] => {
+  if (selection == null) return undefined
+  if (Array.isArray(selection)) return selection.map(ref => qualifyEntityReference(asset, ref))
+
+  return {
+    ...selection,
+    list: selection.list.map(ref => qualifyEntityReference(asset, ref))
+  }
+}
+
+const qualifyEntityInternalReferences = (
+  asset: EntityAsset,
+  definition: Definition<Entity>
+): Definition<Entity> => ({
+  ...definition,
+  attributes: {
+    ...definition.attributes,
+    rules: qualifyEntityRuleReferences(asset, definition.attributes.rules),
+    skills: qualifyEntitySkillSelection(asset, definition.attributes.skills)
+  }
+})
+
+const selectInheritedValue = <TValue>(
+  parent: TValue | undefined,
+  child: TValue | undefined,
+  mode: EntityInheritanceMode,
+  merge: (left: TValue, right: TValue) => TValue
+) => {
+  if (mode === 'none') return child
+  if (mode === 'replace') return child ?? parent
+  if (parent == null) return child
+  if (child == null) return parent
+  return mode === 'prepend' ? merge(child, parent) : merge(parent, child)
+}
+
+const mergeEntityBody = (
+  parent: string,
+  child: string,
+  mode: EntityInheritanceMode
+) => {
+  if (mode === 'none' || mode === 'replace') return child
+
+  const values = mode === 'prepend' ? [child, parent] : [parent, child]
+  return values
+    .map(value => value.trim())
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+const getSkillIncludeRefs = (selection: Entity['skills']) => {
+  if (Array.isArray(selection)) return selection
+  return selection?.type === 'include' ? selection.list : undefined
+}
+
+const mergeSkillSelections = (
+  parent: Entity['skills'],
+  child: Entity['skills']
+): Entity['skills'] => {
+  const parentRefs = getSkillIncludeRefs(parent)
+  const childRefs = getSkillIncludeRefs(child)
+  if (parentRefs != null && childRefs != null) return toUniqueStrings([...parentRefs, ...childRefs])
+
+  return child ?? parent
+}
+
+const mergeFilters = (
+  parent: Filter,
+  child: Filter
+): Filter => {
+  const include = toUniqueStrings([
+    ...(parent.include ?? []),
+    ...(child.include ?? [])
+  ])
+  const exclude = toUniqueStrings([
+    ...(parent.exclude ?? []),
+    ...(child.exclude ?? [])
+  ])
+
+  return {
+    ...(include.length > 0 ? { include } : {}),
+    ...(exclude.length > 0 ? { exclude } : {})
+  }
+}
+
+const mergeEntityDefinitions = (
+  parent: Definition<Entity>,
+  child: Definition<Entity>,
+  modes: Record<EntityInheritanceField, EntityInheritanceMode>
+): Definition<Entity> => ({
+  ...child,
+  body: mergeEntityBody(parent.body, child.body, modes.prompt),
+  attributes: {
+    ...parent.attributes,
+    ...child.attributes,
+    name: child.attributes.name,
+    description: child.attributes.description ?? parent.attributes.description,
+    always: child.attributes.always ?? parent.attributes.always,
+    tags: selectInheritedValue(
+      parent.attributes.tags,
+      child.attributes.tags,
+      modes.tags,
+      (left, right) => toUniqueStrings([...left, ...right])
+    ),
+    rules: selectInheritedValue(
+      parent.attributes.rules,
+      child.attributes.rules,
+      modes.rules,
+      (left, right) => toUniqueValues([...left, ...right], keyRuleReference)
+    ),
+    skills: selectInheritedValue(parent.attributes.skills, child.attributes.skills, modes.skills, mergeSkillSelections),
+    tools: selectInheritedValue(parent.attributes.tools, child.attributes.tools, modes.tools, mergeFilters),
+    mcpServers: selectInheritedValue(
+      parent.attributes.mcpServers,
+      child.attributes.mcpServers,
+      modes.mcpServers,
+      mergeFilters
+    ),
+    plugins: child.attributes.plugins
+  }
+})
+
+const uniqueAssetIds = (values: string[]) => toUniqueValues(values, value => value)
+
+const formatEntityCycle = (stack: EntityAsset[], asset: EntityAsset) => (
+  [...stack.slice(stack.findIndex(item => item.id === asset.id)), asset]
+    .map(item => item.displayName)
+    .join(' -> ')
+)
+
+const createAvailableEntitiesMessage = (entities: EntityAsset[]) => (
+  entities
+    .map(asset => asset.displayName)
+    .sort((left, right) => left.localeCompare(right))
+    .join(', ')
+)
+
+export const resolveEntityInheritance = (
+  bundle: WorkspaceAssetBundle,
+  asset: EntityAsset
+): {
+  assetIds: string[]
+  definition: Definition<Entity>
+} => {
+  const resolveAsset = (
+    current: EntityAsset,
+    stack: EntityAsset[]
+  ): {
+    assetIds: string[]
+    definition: Definition<Entity>
+  } => {
+    if (stack.some(item => item.id === current.id)) {
+      throw new Error(`Circular entity inheritance detected: ${formatEntityCycle(stack, current)}`)
+    }
+
+    const currentDefinition = definitionWithResolvedName(
+      current.payload.definition,
+      current.displayName,
+      current.instancePath
+    )
+    const qualifiedCurrentDefinition = qualifyEntityInternalReferences(current, currentDefinition)
+    const parentRefs = normalizeEntityExtends(qualifiedCurrentDefinition.attributes.extends)
+    if (parentRefs.length === 0) {
+      return {
+        assetIds: [current.id],
+        definition: qualifiedCurrentDefinition
+      }
+    }
+
+    let inheritedBase: Definition<Entity> | undefined
+    const inheritedAssetIds: string[] = []
+    for (const ref of parentRefs) {
+      const parentAsset = findNamedAsset(bundle.entities, ref, current.instancePath)
+      if (parentAsset == null) {
+        throw new Error(
+          `Failed to resolve entity ${ref}. Available entities: ${createAvailableEntitiesMessage(bundle.entities)}`
+        )
+      }
+
+      const parent = resolveAsset(parentAsset, [...stack, current])
+      inheritedAssetIds.push(...parent.assetIds)
+      inheritedBase = inheritedBase == null
+        ? parent.definition
+        : mergeEntityDefinitions(inheritedBase, parent.definition, PARENT_ENTITY_INHERITANCE)
+    }
+
+    return {
+      assetIds: uniqueAssetIds([...inheritedAssetIds, current.id]),
+      definition: mergeEntityDefinitions(
+        inheritedBase ?? qualifiedCurrentDefinition,
+        qualifiedCurrentDefinition,
+        resolveEntityInheritanceModes(qualifiedCurrentDefinition.attributes.inherit, DEFAULT_CHILD_ENTITY_INHERITANCE)
+      )
+    }
+  }
+
+  return resolveAsset(asset, [])
 }
 
 const resolvePathMatchedRules = async (


### PR DESCRIPTION
## Summary
- add RFC 0002 for entity inheritance and link the follow-up advanced design issue
- add entity extends/inherit schema and shared types
- resolve inherited entity prompts, rules, skills, tools, MCP filters, and asset ids during prompt selection
- document entity inheritance usage

Closes #137
Refs #138

## Verification
- pnpm -C packages/workspace-assets test
- pnpm exec dprint check packages/workspace-assets/src/selection-internal.ts packages/workspace-assets/__tests__/prompt-selection.spec.ts .ai/rfcs/0002-entity-inheritance.md .ai/docs/usage/plugins/entity-inheritance.md .ai/docs/usage/plugins.md packages/types/src/definition.ts packages/task/src/schema.ts
- pnpm typecheck
- pnpm exec eslint .
- git diff --check