### PR TITLE
feat: add entity helper skills

### DIFF
--- a/.ai/docs/usage/skills.md
+++ b/.ai/docs/usage/skills.md
@@ -25,6 +25,15 @@ description: Build the app
 
 如果你修改过数据资产根目录，例如把 `.ai` 改成 `.vf`，skill 目录也会跟着变化。目录配置说明见 [数据资产目录配置](../asset-directories.md)。
 
+## CLI 内置 Skills
+
+`vf` CLI 默认会注入 `@vibe-forge/plugin-cli-skills`，提供一组不需要项目手动配置的通用说明型 skills。通常直接描述需求即可；只有需要强制指定某个 skill 时，才使用 `vf run --include-skill <name> "任务描述"`。
+
+- `vf-cli-quickstart`：说明 CLI 常用命令、配置命令和会话恢复方式。
+- `vf-cli-print-mode`：说明 print 模式、stdin 控制和权限确认。
+- `create-entity`：按用户需求创建新的 Vibe Forge entity。
+- `update-entity`：按用户需求更新已有 Vibe Forge entity，强调最小改动和维护引用关系。
+
 ## 声明依赖
 
 在 `SKILL.md` 的 frontmatter 里写 `dependencies`：

--- a/apps/cli/__tests__/run.spec.ts
+++ b/apps/cli/__tests__/run.spec.ts
@@ -5,6 +5,7 @@ import {
   createAdapterOption,
   createSessionExitController,
   getAdapterErrorMessage,
+  getCliDefaultSkillNames,
   getDisallowedResumeFlags,
   getPrintableAssistantText,
   handlePrintEvent,
@@ -19,6 +20,15 @@ import {
 } from '#~/commands/run.js'
 
 describe('run command print output', () => {
+  it('lists entity helpers as default CLI skills', () => {
+    expect(getCliDefaultSkillNames()).toEqual([
+      'vf-cli-quickstart',
+      'vf-cli-print-mode',
+      'create-entity',
+      'update-entity'
+    ])
+  })
+
   it('extracts printable assistant text from string content', () => {
     expect(getPrintableAssistantText({
       id: 'msg-1',

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -28,6 +28,7 @@ program
 Examples:
   vf "读取 README 并给出改进建议"
   vf run --include-skill vf-cli-quickstart "介绍 vf CLI 的常用命令"
+  vf "帮我创建一个前端评审实体"
   vf list
   vf list --view full
   vf config list

--- a/apps/cli/src/commands/run/command.ts
+++ b/apps/cli/src/commands/run/command.ts
@@ -106,6 +106,8 @@ Examples:
   vf run -A claude "读取 README 并总结"
   vf run --workspace billing "修复订单状态回滚问题"
   vf run --include-skill vf-cli-quickstart "介绍一下 vf CLI 怎么恢复会话"
+  vf "帮我创建一个前端评审实体"
+  vf "给 frontend-reviewer 加上移动端布局记忆"
   vf list --view default
   vf --resume <sessionId>
 

--- a/apps/cli/src/default-skill-plugin.ts
+++ b/apps/cli/src/default-skill-plugin.ts
@@ -4,7 +4,9 @@ const CLI_DEFAULT_SKILL_PLUGIN_ID = '@vibe-forge/plugin-cli-skills'
 
 const CLI_DEFAULT_SKILL_NAMES = [
   'vf-cli-quickstart',
-  'vf-cli-print-mode'
+  'vf-cli-print-mode',
+  'create-entity',
+  'update-entity'
 ] as const
 
 export const getCliDefaultSkillPluginConfig = (): PluginConfig => [

--- a/packages/plugins/cli-skills/README.md
+++ b/packages/plugins/cli-skills/README.md
@@ -6,12 +6,16 @@
 
 - `vf-cli-quickstart`
 - `vf-cli-print-mode`
+- `create-entity`
+- `update-entity`
 
 其中：
 
 - `vf-cli-quickstart` 负责解释 `vf run` / `vf list` / `vf --resume`，以及 `vf config list|get|set|unset` 的基本用法。
 - `vf config` 的读命令默认面向 merged config；文本模式输出 YAML。
 - `vf config get models` / `vf config list models` 在文本模式下会把 `modelServices` 和 `models` metadata 合成可读视图；`--json` 仍返回原始配置结构。
+- `create-entity` 负责按用户需求创建新的 Vibe Forge entity，覆盖文件布局、frontmatter、继承、规则和技能引用。
+- `update-entity` 负责按用户需求更新已有 Vibe Forge entity，强调最小改动、保留现有内容和维护引用关系。
 
 典型接入方式：
 

--- a/packages/plugins/cli-skills/skills/create-entity/SKILL.md
+++ b/packages/plugins/cli-skills/skills/create-entity/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: create-entity
+description: 根据用户需求创建新的 Vibe Forge entity，包含命名、文件布局、frontmatter、继承、规则和技能引用。
+---
+
+在用户要求“创建实体”“新增 agent/entity”“按某个角色沉淀实体”“把当前工作流变成实体”时使用这个 skill。
+
+如果用户要求修改已有实体，使用 `update-entity`。
+
+## 目标
+
+把用户的自然语言需求转成可运行、可维护的 Vibe Forge entity。完成后，项目里应该出现一个清晰命名的实体定义，必要时配套默认 prompt 文件、规则引用、技能引用和继承关系。
+
+## 信息收集
+
+开始前先收敛这些信息；如果用户已经给出，就不要重复询问：
+
+- 实体的职责：它负责什么问题、什么时候应该被选择。
+- 使用场景：开发、评审、验证、调研、文档、运维或项目特定流程。
+- 输出风格：汇报格式、语气、详略、是否优先列风险或结论。
+- 能力边界：它不该做什么，什么时候应该交还给用户或其他实体。
+- 可复用资产：是否应继承已有实体，是否需要引用已有 rules、skills、MCP server 或 tool filter。
+
+如果需求仍然模糊，先用一个保守实体落地，再在 final answer 里列出可继续补充的字段。
+
+## 资产检查
+
+创建前先检查当前项目已有资产：
+
+- 本地实体目录：避免实体名冲突，并观察本项目实体写法。
+- 本地 rules 目录：优先引用已有规则，不要重复复制规则正文。
+- 本地 skills 目录：优先引用已有技能，不要把大型操作流程塞进 entity prompt。
+- 插件实体：如果项目启用了插件并配置了 scope，继承时使用 `scope/name`，例如 `std/dev-reviewer`。
+
+不要凭空引用不存在的 rule 或 skill。确实需要新增配套资产时，先确认用户需求是否要求一起创建；否则在结果里说明缺口。
+
+## 实体目录定位
+
+不要硬编码 `.ai`。先解析本地资产根目录和实体目录，再创建文件：
+
+- `__VF_PROJECT_AI_BASE_DIR__=.vf` 时，本地资产根目录从 `.ai` 变成 `.vf`。
+- `__VF_PROJECT_AI_ENTITIES_DIR__=agents` 时，实体目录从 `<asset-root>/entities` 变成 `<asset-root>/agents`。
+- 如果不确定配置，先检查 `.env` 和现有实体目录；仍不确定时使用默认 `.ai/entities/`。
+- 后文的 `<entity-dir>` 指解析后的本地实体目录，不一定是 `.ai/entities`。
+
+新实体只能写入当前项目的本地实体目录。不要修改这些上游或受管理位置：
+
+- `node_modules/**`
+- `packages/plugins/**`
+- `<asset-root>/plugins/**/vibe-forge/**`
+- 任意插件包或 marketplace 同步下来的实体文件
+
+如果用户想“改某个插件实体”，创建一个本地派生实体，并用 `extends: scope/name` 继承插件实体。
+
+## 文件布局
+
+优先使用目录型实体：
+
+```text
+<entity-dir>/<entity-name>/README.md
+```
+
+当实体提示较长，或需要拆分身份、人格、记忆时，继续使用默认会被加载的文件：
+
+```text
+<entity-dir>/<entity-name>/INTRODUCTION.md
+<entity-dir>/<entity-name>/PERSONALITY.md
+<entity-dir>/<entity-name>/MEMORY.md
+```
+
+简单实体可以使用单文件：
+
+```text
+<entity-dir>/<entity-name>.md
+```
+
+命名使用 kebab-case，例如 `frontend-reviewer`、`release-coordinator`。名称应体现角色和场景，不要使用 `new-entity`、`agent1` 这类临时名。
+
+## Frontmatter 模板
+
+`README.md` 的 frontmatter 保持可读、最小够用：
+
+```yaml
+---
+name: frontend-reviewer
+description: 评审前端交互、样式、focus、主题和移动端布局风险的实体。
+tags:
+  - frontend
+  - review
+extends:
+  - std/dev-reviewer
+inherit:
+  prompt: append
+  rules: merge
+  skills: merge
+  tools: replace
+  mcpServers: replace
+rules:
+  - frontend-standard
+skills:
+  - frontend-review
+tools:
+  include:
+    - Read
+    - Grep
+---
+```
+
+字段使用原则：
+
+- `description` 必须能让路由提示判断什么时候选择这个实体。
+- `extends` 用于复用已有实体；插件实体用 `scope/name`。
+- `inherit` 只控制当前实体如何继承父实体组合结果；默认不需要显式写满，只有需要强调策略时再写。
+- `rules` 引用长期约束，适合稳定规范和边界。
+- `skills` 引用可复用流程，适合较长的操作方法或工具工作流。
+- `tools`、`mcpServers` 只在用户明确要求限制或开放能力时写。
+- `plugins` 只在当前实体确实需要任务级插件覆盖时写，不要为了继承父实体而写。
+
+## Prompt 写法
+
+实体正文聚焦角色行为，不写宣传语。建议结构：
+
+```markdown
+# 角色
+
+你是前端评审实体，负责发现交互、样式、focus、主题、可访问性和移动端布局风险。
+
+## 工作方式
+
+- 先读需求和改动范围，再检查用户可见行为。
+- 优先输出会导致真实用户受影响的问题。
+- 对每个问题给出证据、影响、建议修复方向。
+
+## 边界
+
+- 不替代实现实体直接改代码，除非用户明确要求。
+- 不复述父实体已经覆盖的通用评审规则。
+```
+
+写作要求：
+
+- 角色、职责、流程和边界要具体。
+- 避免泛化的“你是一个专业助手”。
+- 如果使用 `extends`，正文只写差异化补充，不要复制父实体内容。
+- 用户给出团队偏好、历史记忆或固定口吻时，放到 `MEMORY.md` 或 `PERSONALITY.md`，不要塞进规则文件。
+- 不写密钥、账号、个人隐私或一次性临时信息。
+
+## 继承设计
+
+当用户希望基于已有实体创建新实体时：
+
+- 需要复用已有能力、避免复制插件内容或避免改上游实体时，使用 `extends`。
+- 单父实体：`extends: std/dev-reviewer`。
+- 多父实体：按用户期望的基础能力顺序写成列表，后面的父实体覆盖前面父实体的保守字段。
+- 默认让 prompt 追加、rules/skills/tags 合并。
+- 如果用户明确说“只保留新实体自己的规则”，用 `inherit.rules: replace`。
+- 如果用户明确说“完全不要继承某字段”，用对应字段的 `none`。
+- 子实体正文只写差异化补充，不要复制父实体正文。
+- 插件实体引用必须使用已配置的 scope，例如 `std/dev-reviewer`；不要写插件包源码路径。
+
+不要为父实体之间的每个字段设计单独策略；这是高级继承设计，应留给后续方案。
+
+## 完成检查
+
+交付前检查：
+
+- 实体文件路径符合 `<entity-dir>/<name>/README.md` 或 `<entity-dir>/<name>.md`。
+- frontmatter YAML 可解析，`description` 清楚。
+- 引用的 `extends`、`rules`、`skills` 名称真实存在，或在结果里说明还需要补。
+- 如果创建了默认 prompt 文件，内容不会重复 `README.md`。
+- 没有覆盖用户已有实体，除非用户明确要求更新。
+- 没有修改插件包、managed plugin 或其他上游来源的实体文件。
+
+可运行验证时，优先执行与改动范围匹配的测试；只想手动冒烟时，可以用：
+
+```bash
+vf run --entity <entity-name> --print "说明这个实体的职责和边界"
+```

--- a/packages/plugins/cli-skills/skills/update-entity/SKILL.md
+++ b/packages/plugins/cli-skills/skills/update-entity/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: update-entity
+description: 根据用户需求更新已有 Vibe Forge entity，保持最小改动并维护 prompt、frontmatter、继承、规则和技能引用。
+---
+
+在用户要求“更新实体”“调整 entity/agent”“给某个实体加规则/技能/记忆”“把实体改成继承另一个实体”“重命名或拆分已有实体”时使用这个 skill。
+
+如果用户要求创建全新的实体，使用 `create-entity`。
+
+## 目标
+
+先读懂已有实体的职责和资产关系，再按用户需求做最小、可验证的更新。不要把更新任务当成重写任务；默认保留用户已有内容、命名、文件布局和引用关系。
+
+## 更新前检查
+
+先确认目标实体：
+
+- 不要硬编码 `.ai`。先定位本地资产根目录和实体目录。
+- 默认实体目录是 `.ai/entities/`；如果 `.env` 设置了 `__VF_PROJECT_AI_BASE_DIR__` 或 `__VF_PROJECT_AI_ENTITIES_DIR__`，按实际资产根目录和实体目录查找。
+- 在本地实体目录查找同名实体，包含 `<name>.md`、`<name>/README.md` 和 `<name>/index.json`。
+- 如果文件名和实体名不一致，继续看 frontmatter 或 JSON 里的 `name` 字段。
+- 如果用户只给了模糊名字，先看实体 `description`、目录名和路由名，找到最可能的目标。
+- 如果存在本地实体和插件实体同名，优先更新本地实体；插件实体不要直接修改，改用本地实体 `extends` 插件实体。
+- 如果用户要求更新插件实体，建议创建或更新本地派生实体，例如 `extends: std/dev-reviewer`。
+
+不要直接修改这些上游或受管理位置：
+
+- `node_modules/**`
+- `packages/plugins/**`
+- `<asset-root>/plugins/**/vibe-forge/**`
+- 任意插件包或 marketplace 同步下来的实体文件
+
+如果目标只存在于插件或上游来源，创建一个本地派生实体；如果本地已经有派生实体，就更新派生实体。
+
+继续检查关联资产：
+
+- `README.md` 或实体单文件：主体 prompt 和 frontmatter。
+- `INTRODUCTION.md`、`PERSONALITY.md`、`MEMORY.md`：目录型实体的默认加载文件。
+- `rules`：实体引用的长期约束。
+- `skills`：实体引用的可复用流程。
+- `extends` / `inherit`：实体继承关系。
+
+## 更新策略
+
+按用户真实意图选择最小变更：
+
+- 改职责：优先更新 `description` 和正文里的角色/边界。
+- 改行为风格：优先更新 `PERSONALITY.md`，没有该文件时再考虑正文。
+- 追加长期偏好或历史约定：优先更新 `MEMORY.md`。
+- 增加稳定规范：优先引用或新增 rule，不要把大段规则塞进 prompt。
+- 增加可复用操作流程：优先引用或新增 skill，不要把长流程塞进 entity。
+- 基于已有实体改造：优先加 `extends` 和少量差异化 prompt。
+- 不想继承某字段：使用 `inherit.<field>: replace` 或 `none`，不要复制父实体再删内容。
+- 如果目标是插件实体或共享上游实体，绝不直接编辑上游文件；用本地实体覆盖差异。
+
+只有用户明确要求“重写”“重构”“替换整个实体”时，才大幅改写 prompt。
+
+## Frontmatter 更新
+
+常见字段：
+
+```yaml
+---
+description: 更准确地描述这个实体何时应该被选择。
+extends:
+  - std/dev-reviewer
+inherit:
+  rules: replace
+rules:
+  - frontend-standard
+skills:
+  - frontend-review
+tools:
+  include:
+    - Read
+    - Grep
+---
+```
+
+维护原则：
+
+- `description` 要面向路由选择，说明使用场景和职责。
+- `extends` 引用插件实体时使用 `scope/name`，例如 `std/dev-reviewer`。
+- `inherit` 只写需要偏离默认行为的字段。
+- 添加 `rules` / `skills` 前先确认目标资产存在。
+- 不要因为要继承父实体而写 `plugins`。
+
+`extends` 设计原则：
+
+- 只是补充项目差异时，加或保留 `extends`，不要复制父实体正文。
+- 多父实体按列表顺序组合，顺序要反映能力优先级。
+- 当前实体的 `inherit` 只控制自己如何继承父实体组合结果。
+- 不要在更新任务里引入高级 per-parent 策略。
+
+## Prompt 更新
+
+更新正文时：
+
+- 保留原有有效结构，不为了统一模板重排整篇。
+- 新增内容放到最贴近的段落。
+- 删除内容前确认它和用户新需求冲突。
+- 如果已有父实体覆盖通用职责，子实体正文只写差异化补充。
+- 避免同时在 `README.md`、`INTRODUCTION.md`、`PERSONALITY.md`、`MEMORY.md` 重复同一句话。
+
+目录型实体推荐分工：
+
+- `README.md`：角色、职责、工作方式、边界。
+- `INTRODUCTION.md`：更详细的背景或接入说明。
+- `PERSONALITY.md`：表达风格、判断偏好、沟通顺序。
+- `MEMORY.md`：项目长期约定、用户偏好、历史经验。
+
+## 重命名或拆分
+
+用户要求重命名实体时：
+
+- 同步更新文件或目录名。
+- 如果 frontmatter 里有 `name`，同步更新。
+- 检查其他实体、spec、文档里是否引用旧名。
+- 在结果里明确旧名和新名。
+
+用户要求拆分实体时：
+
+- 先保留原实体的核心职责。
+- 新实体只承接被拆出去的职责。
+- 如需复用共同能力，考虑让两个实体继承同一个父实体。
+
+## 完成检查
+
+交付前检查：
+
+- 没有覆盖无关的用户内容。
+- frontmatter YAML 可解析。
+- `description` 仍然能准确触发路由选择。
+- `extends`、`rules`、`skills` 引用存在且不歧义。
+- 默认 prompt 文件之间没有明显重复。
+- 如果改了继承关系，确认没有形成循环。
+- 没有修改插件包、managed plugin 或其他上游来源的实体文件。
+
+可运行验证时，优先执行与改动范围匹配的测试；只想手动冒烟时，可以用：
+
+```bash
+vf run --entity <entity-name> --print "说明这个实体更新后的职责和边界"
+```

--- a/packages/plugins/cli-skills/skills/vf-cli-quickstart/SKILL.md
+++ b/packages/plugins/cli-skills/skills/vf-cli-quickstart/SKILL.md
@@ -31,10 +31,12 @@ description: 快速说明 Vibe Forge CLI 的常用命令、配置命令、会话
 ## 技能与资产
 
 - CLI 默认会注入 `@vibe-forge/plugin-cli-skills`。
-- 这组插件当前包含 `vf-cli-quickstart` 和 `vf-cli-print-mode` 两个 skill。
-- 需要显式加载某个 skill 时，使用 `--include-skill <name>`。
+- 这组插件当前包含 `vf-cli-quickstart`、`vf-cli-print-mode`、`create-entity` 和 `update-entity` 四个 skill。
+- 通常直接描述需求即可；需要强制指定某个 skill 时，使用 `--include-skill <name>`。
 - 需要排除某个 skill 时，使用 `--exclude-skill <name>`。
 - 例子：`vf run --include-skill vf-cli-quickstart "教我怎么恢复一个失败的会话"`
+- 例子：`vf "帮我创建一个前端评审实体"`
+- 例子：`vf "给 frontend-reviewer 加上移动端布局记忆"`
 
 ## 建议说明方式
 
@@ -42,3 +44,5 @@ description: 快速说明 Vibe Forge CLI 的常用命令、配置命令、会话
 - 再补 `list` / `resume` / `stop` 或 `config get` / `config set` 等排查命令。
 - 如果用户提到模型列表、`gpt-responses` 或 `models` section，优先说明 `modelServices` 才是服务模型来源，`models` 是 metadata；必要时补一句 CLI 文本模式会对 `models` 做展开展示。
 - 如果涉及 print 模式、权限确认或 stdin 控制，继续阅读 `vf-cli-print-mode`。
+- 如果涉及创建 entity，继续阅读 `create-entity`。
+- 如果涉及更新已有 entity，继续阅读 `update-entity`。


### PR DESCRIPTION
## Summary
- add default CLI skills for creating and updating Vibe Forge entities
- document entity-directory resolution so agents do not hard-code .ai when users customize asset paths
- clarify that plugin/upstream entities should not be edited directly; create or update local derived entities with extends instead
- update CLI help, quickstart docs, and default skill-list coverage

## Verification
- pnpm exec dprint check .ai/docs/usage/skills.md apps/cli/__tests__/run.spec.ts apps/cli/src/cli.ts apps/cli/src/commands/run/command.ts apps/cli/src/default-skill-plugin.ts packages/plugins/cli-skills/README.md packages/plugins/cli-skills/skills/vf-cli-quickstart/SKILL.md packages/plugins/cli-skills/skills/create-entity/SKILL.md packages/plugins/cli-skills/skills/update-entity/SKILL.md
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/cli/__tests__/run.spec.ts
- pnpm exec eslint .
- pnpm typecheck
- git diff --check