### PR TITLE
Manage adapter CLI installs in shared cache

### DIFF
--- a/.ai/docs/usage/runtime.md
+++ b/.ai/docs/usage/runtime.md
@@ -56,6 +56,7 @@ adapters:
     cli:
       source: managed
       version: 0.121.0
+      prepareOnInstall: true
   claude-code:
     cli:
       version: 2.1.114
@@ -75,6 +76,38 @@ adapters:
 - `path`：只使用 `cli.path` 指向的 binary
 
 把 `autoInstall` 设为 `false` 可以关闭首次使用时的自动安装。npm 托管 adapter 还支持 `cli.package`、`cli.npmPath`；Kimi 支持 `cli.package`、`cli.python`、`cli.uvPath`。
+
+如果希望提前把托管 CLI 下载到项目共享 cache，可以显式运行：
+
+```bash
+vf adapter prepare codex claude-code gemini
+vf adapter prepare claude-code.routerCli
+vf adapter prepare --all
+```
+
+不传 target 时，`vf adapter prepare` 只准备配置中声明了 `prepareOnInstall: true` 的 CLI：
+
+```json
+{
+  "adapters": {
+    "codex": {
+      "cli": {
+        "source": "managed",
+        "version": "0.121.0",
+        "prepareOnInstall": true
+      }
+    },
+    "claude-code": {
+      "routerCli": {
+        "version": "1.0.73",
+        "prepareOnInstall": true
+      }
+    }
+  }
+}
+```
+
+`@vibe-forge/cli` 的 package `postinstall` 也会读取项目根的 `.ai.config.json` 或 `infra/.ai.config.json`。只有发现上述 `prepareOnInstall: true` 时才会调用 `vf adapter prepare --from-postinstall`，否则不做网络下载。postinstall 默认跳过 `CI=true`；如需在 CI 里预热，设置 `VIBE_FORGE_POSTINSTALL_PREPARE=1`。如需跳过，设置 `VIBE_FORGE_SKIP_ADAPTER_PREPARE=1` 或 `VIBE_FORGE_SKIP_POSTINSTALL=1`。
 
 同样可以用环境变量临时覆盖，`<ADAPTER>` 使用大写下划线，例如 `CODEX`、`GEMINI`、`CLAUDE_CODE`、`CLAUDE_CODE_ROUTER`：
 

--- a/.ai/docs/usage/runtime.md
+++ b/.ai/docs/usage/runtime.md
@@ -25,7 +25,70 @@ wait
 - 如果没有显式设置 `__VF_PROJECT_WORKSPACE_FOLDER__`，`vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，并自动把项目根目录作为 workspace。
 - 项目配置默认也会跟随这个解析后的 workspace 根目录读取；如果需要单独改配置目录，可以显式设置 `__VF_PROJECT_CONFIG_DIR__`。
 - `__VF_PROJECT_AI_BASE_DIR__` 可选；默认是 `.ai`，也可以设成 `.vf` 或 `.config/vibe/ai-data` 之类的嵌套目录。
+- `__VF_PROJECT_AI_CACHE_DIR__` 可选；用于覆盖项目级共享 cache 目录。没有显式设置时，Vibe Forge 会把 adapter CLI、skill dependency 等可复用资源放到 workspace 的 `.ai/caches`。
+- worktree 场景下，项目级共享 cache 会优先跟随 `__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__`；没有这个环境变量时，会通过 Git worktree 的 common dir 反查主工作树。会话级 cache、mock home 和日志仍然留在当前 worktree。
 - `__VF_PROJECT_AI_ENTITIES_DIR__` 可选；默认是 `entities`，会基于 AI 基目录继续解析。
+
+## Adapter CLI 安装与版本
+
+Vibe Forge 不把各原生 CLI 作为 adapter 包的运行时依赖。第一次使用时，adapter 会优先找显式配置的 binary、项目共享 cache、系统 `PATH`，都不可用时再安装到项目级共享 cache：
+
+- npm 托管：`codex`、`gemini`、`copilot`、`opencode`、`claude-code.cli`、`claude-code.routerCli`
+- uv 托管：`kimi.cli`
+
+默认托管版本：
+
+| Adapter                 | 托管包                           | 默认版本  |
+| ----------------------- | -------------------------------- | --------- |
+| `codex`                 | `@openai/codex`                  | `0.121.0` |
+| `gemini`                | `@google/gemini-cli`             | `0.38.2`  |
+| `copilot`               | `@github/copilot`                | `1.0.32`  |
+| `opencode`              | `opencode-ai`                    | `1.14.18` |
+| `claude-code.cli`       | `@anthropic-ai/claude-code`      | `2.1.114` |
+| `claude-code.routerCli` | `@musistudio/claude-code-router` | `1.0.73`  |
+| `kimi.cli`              | `kimi-cli`                       | `1.36.0`  |
+
+可以在项目配置里固定来源和版本：
+
+```yaml
+adapters:
+  codex:
+    cli:
+      source: managed
+      version: 0.121.0
+  claude-code:
+    cli:
+      version: 2.1.114
+    routerCli:
+      version: 1.0.73
+  kimi:
+    cli:
+      package: kimi-cli
+      version: 1.36.0
+      python: "3.13"
+```
+
+`cli.source` 支持：
+
+- `managed`：使用项目共享 cache 中的托管 CLI；缺失时按 `autoInstall` 安装
+- `system`：优先使用系统 `PATH` 中的原生命令；缺失时仍可按 `autoInstall` 安装
+- `path`：只使用 `cli.path` 指向的 binary
+
+把 `autoInstall` 设为 `false` 可以关闭首次使用时的自动安装。npm 托管 adapter 还支持 `cli.package`、`cli.npmPath`；Kimi 支持 `cli.package`、`cli.python`、`cli.uvPath`。
+
+同样可以用环境变量临时覆盖，`<ADAPTER>` 使用大写下划线，例如 `CODEX`、`GEMINI`、`CLAUDE_CODE`、`CLAUDE_CODE_ROUTER`：
+
+```bash
+export __VF_PROJECT_AI_ADAPTER_CODEX_CLI_SOURCE__=managed
+export __VF_PROJECT_AI_ADAPTER_CODEX_INSTALL_VERSION__=0.121.0
+export __VF_PROJECT_AI_ADAPTER_CODEX_AUTO_INSTALL__=false
+export __VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__=/absolute/path/to/codex
+
+export __VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_VERSION__=1.36.0
+export __VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PYTHON__=3.13
+export __VF_PROJECT_AI_ADAPTER_KIMI_UV_PATH__=/absolute/path/to/uv
+```
+
 - Web UI 在 server 绑定到 `localhost`、`127.*`、`::1` 时默认不启用登录保护；绑定到 `0.0.0.0`、局域网 IP 或域名时默认启用。可以在项目配置中设置多个账号：
 
 ```yaml

--- a/.ai/rules/adapter-design/runtime-config.md
+++ b/.ai/rules/adapter-design/runtime-config.md
@@ -53,6 +53,15 @@ worktree 场景下，共享 CLI cache 必须通过 [`packages/utils/src/project-
 - Kimi：`adapters.kimi.cli.package`、`adapters.kimi.cli.version`、`adapters.kimi.cli.python`、`adapters.kimi.cli.uvPath`
 - 环境变量覆盖遵循 `__VF_PROJECT_AI_ADAPTER_<NAME>_INSTALL_PACKAGE__`、`__VF_PROJECT_AI_ADAPTER_<NAME>_INSTALL_VERSION__`、`__VF_PROJECT_AI_ADAPTER_<NAME>_AUTO_INSTALL__`
 
+预热入口：
+
+- `vf adapter prepare` 只准备配置里 `prepareOnInstall: true` 的 CLI
+- `vf adapter prepare --all` 准备所有已安装 adapter 暴露的 CLI target
+- `vf adapter prepare codex claude-code gemini` 按 adapter 名显式准备；`claude-code.routerCli` / `ccr` 可单独准备 Claude Code Router
+- `@vibe-forge/cli` 的 `postinstall` 只在项目根 `.ai.config.json` 或 `infra/.ai.config.json` 里发现 `adapters.<name>.cli.prepareOnInstall: true` / `routerCli.prepareOnInstall: true` 时触发同一套 prepare 逻辑
+- postinstall 默认不在 `CI=true` 时执行；可以用 `VIBE_FORGE_POSTINSTALL_PREPARE=1` 显式允许，或用 `VIBE_FORGE_SKIP_ADAPTER_PREPARE=1` / `VIBE_FORGE_SKIP_POSTINSTALL=1` 跳过
+- postinstall 失败默认只告警，不阻断依赖安装；需要严格失败时设置 `VIBE_FORGE_POSTINSTALL_STRICT=1`
+
 ## Claude Code
 
 - 实现入口：

--- a/.ai/rules/adapter-design/runtime-config.md
+++ b/.ai/rules/adapter-design/runtime-config.md
@@ -33,6 +33,26 @@
 
 因此同一份 workspace 配置会产生不同的原生结果。
 
+## 原生 CLI 托管
+
+原生 CLI 不作为 adapter package 的运行时依赖。npm 分发的 CLI 统一走 [`packages/utils/src/managed-npm-cli.ts`](../../../packages/utils/src/managed-npm-cli.ts)，Kimi 继续走 uv tool 安装；两者都必须把托管产物写到项目级共享 cache，而不是写进真实 home 或 adapter 依赖树。
+
+查找顺序：
+
+1. 显式 binary path：`adapters.<name>.cli.path` 或 `__VF_PROJECT_AI_ADAPTER_<NAME>_CLI_PATH__`
+2. primary workspace 的共享 cache：`<primary>/.ai/caches/adapter-<name>/cli`
+3. 系统 `PATH`
+4. `autoInstall !== false` 时安装到共享 cache
+
+worktree 场景下，共享 CLI cache 必须通过 [`packages/utils/src/project-cache-path.ts`](../../../packages/utils/src/project-cache-path.ts) 向主工作树归并。session share、mock home、日志仍然保持在当前 worktree，避免多个 worktree 互相污染会话状态。
+
+用户侧版本控制入口：
+
+- npm adapter：`adapters.<name>.cli.package`、`adapters.<name>.cli.version`、`adapters.<name>.cli.npmPath`
+- `claude-code` 有两套 CLI：`cli` 是 Claude Code，`routerCli` 是 Claude Code Router
+- Kimi：`adapters.kimi.cli.package`、`adapters.kimi.cli.version`、`adapters.kimi.cli.python`、`adapters.kimi.cli.uvPath`
+- 环境变量覆盖遵循 `__VF_PROJECT_AI_ADAPTER_<NAME>_INSTALL_PACKAGE__`、`__VF_PROJECT_AI_ADAPTER_<NAME>_INSTALL_VERSION__`、`__VF_PROJECT_AI_ADAPTER_<NAME>_AUTO_INSTALL__`
+
 ## Claude Code
 
 - 实现入口：

--- a/apps/cli/__tests__/adapter-prepare.spec.ts
+++ b/apps/cli/__tests__/adapter-prepare.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AdapterCliPreparer } from '@vibe-forge/types'
+
+import { normalizeCliArgs } from '#~/cli-argv.js'
+import { resolveAdapterPrepareRequests } from '#~/commands/adapter.js'
+
+const createPreparer = (
+  adapter: string,
+  targets: AdapterCliPreparer['targets']
+): AdapterCliPreparer => ({
+  adapter,
+  targets,
+  prepare: vi.fn()
+})
+
+const toRequestKeys = (requests: ReturnType<typeof resolveAdapterPrepareRequests>) => (
+  requests.map(request => `${request.adapter}.${request.target.key}`)
+)
+
+describe('adapter prepare command selection', () => {
+  const preparers = [
+    createPreparer('codex', [{
+      key: 'cli',
+      title: 'Codex CLI',
+      aliases: ['codex'],
+      configPath: ['cli']
+    }]),
+    createPreparer('claude-code', [
+      {
+        key: 'cli',
+        title: 'Claude Code CLI',
+        aliases: ['claude'],
+        configPath: ['cli']
+      },
+      {
+        key: 'routerCli',
+        title: 'Claude Code Router CLI',
+        aliases: ['ccr', 'router'],
+        configPath: ['routerCli']
+      }
+    ])
+  ]
+
+  it('selects only config entries opted into prepareOnInstall when no targets are passed', () => {
+    const requests = resolveAdapterPrepareRequests({
+      config: {
+        adapters: {
+          codex: {
+            cli: {
+              prepareOnInstall: true
+            }
+          },
+          'claude-code': {
+            cli: {
+              prepareOnInstall: false
+            },
+            routerCli: {
+              prepareOnInstall: true
+            }
+          }
+        }
+      },
+      preparers,
+      targets: []
+    })
+
+    expect(toRequestKeys(requests)).toEqual([
+      'codex.cli',
+      'claude-code.routerCli'
+    ])
+  })
+
+  it('expands adapter names and target aliases for explicit prepare requests', () => {
+    const requests = resolveAdapterPrepareRequests({
+      config: {},
+      preparers,
+      targets: ['claude', 'ccr', 'codex.cli']
+    })
+
+    expect(toRequestKeys(requests)).toEqual([
+      'claude-code.cli',
+      'claude-code.routerCli',
+      'codex.cli'
+    ])
+  })
+
+  it('selects every available prepare target with --all', () => {
+    const requests = resolveAdapterPrepareRequests({
+      all: true,
+      config: {},
+      preparers,
+      targets: []
+    })
+
+    expect(toRequestKeys(requests)).toEqual([
+      'codex.cli',
+      'claude-code.cli',
+      'claude-code.routerCli'
+    ])
+  })
+
+  it('rejects unknown explicit targets', () => {
+    expect(() =>
+      resolveAdapterPrepareRequests({
+        config: {},
+        preparers,
+        targets: ['missing']
+      })
+    ).toThrow('Unknown adapter CLI prepare target: missing')
+  })
+
+  it('keeps adapter as a root command instead of routing it through run', () => {
+    expect(normalizeCliArgs(['adapter', 'prepare'])).toEqual(['adapter', 'prepare'])
+  })
+})

--- a/apps/cli/__tests__/workspace.spec.ts
+++ b/apps/cli/__tests__/workspace.spec.ts
@@ -1,3 +1,4 @@
+import { execFileSync, spawnSync } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -46,6 +47,7 @@ vi.mock('@vibe-forge/hooks', () => ({
 
 const tempDirs: string[] = []
 const originalCwd = process.cwd()
+const hasGit = spawnSync('git', ['--version']).status === 0
 
 const createWorkspaceFixture = async () => {
   const cleanupDir = await fs.mkdtemp(path.join(tmpdir(), 'vf-cli-workspace-'))
@@ -61,11 +63,19 @@ const createWorkspaceFixture = async () => {
   }
 }
 
+const runGit = (cwd: string, args: string[]) => {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe'
+  })
+}
+
 afterEach(async () => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
   process.chdir(originalCwd)
   delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+  delete process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })))
 })
 
@@ -96,6 +106,50 @@ describe('cli workspace resolution', () => {
     expect(run).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: workspaceDir
+      }),
+      expect.any(Object)
+    )
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it.skipIf(!hasGit)('passes the primary git worktree folder into run command env', async () => {
+    const cleanupDir = await fs.mkdtemp(path.join(tmpdir(), 'vf-cli-worktree-'))
+    tempDirs.push(cleanupDir)
+    const primary = path.join(cleanupDir, 'primary')
+    const linked = path.join(cleanupDir, 'linked')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await fs.mkdir(primary, { recursive: true })
+    runGit(primary, ['init'])
+    await fs.writeFile(path.join(primary, 'README.md'), 'hello\n', 'utf8')
+    runGit(primary, ['add', 'README.md'])
+    runGit(primary, [
+      '-c',
+      'user.email=vf@example.test',
+      '-c',
+      'user.name=Vibe Forge',
+      'commit',
+      '-m',
+      'init'
+    ])
+    runGit(primary, ['worktree', 'add', '--detach', linked, 'HEAD'])
+
+    process.chdir(linked)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync(['run', '--print', 'smoke'], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: await fs.realpath(linked),
+        env: expect.objectContaining({
+          __VF_PROJECT_WORKSPACE_FOLDER__: await fs.realpath(linked),
+          __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: await fs.realpath(primary)
+        })
       }),
       expect.any(Object)
     )

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -27,6 +27,7 @@
     "vf": "./cli.js"
   },
   "scripts": {
+    "postinstall": "node postinstall.js",
     "test": "pnpm -C ../.. exec vitest run --workspace vitest.workspace.ts --project node apps/cli/__tests__"
   },
   "dependencies": {

--- a/apps/cli/postinstall.js
+++ b/apps/cli/postinstall.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const { existsSync, readFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+const process = require('node:process')
+
+const isFalseLike = value => ['0', 'false', 'no', 'off'].includes(String(value ?? '').trim().toLowerCase())
+const isTrueLike = value => ['1', 'true', 'yes', 'on'].includes(String(value ?? '').trim().toLowerCase())
+
+const shouldSkip = () => (
+  isTrueLike(process.env.VIBE_FORGE_SKIP_POSTINSTALL) ||
+  isTrueLike(process.env.VIBE_FORGE_SKIP_ADAPTER_PREPARE) ||
+  isTrueLike(process.env.VF_SKIP_ADAPTER_PREPARE) ||
+  process.env.VIBE_FORGE_ADAPTER_PREPARE_POSTINSTALL_ACTIVE === '1' ||
+  (
+    process.env.CI != null &&
+    !isFalseLike(process.env.CI) &&
+    !isTrueLike(process.env.VIBE_FORGE_POSTINSTALL_PREPARE)
+  )
+)
+
+const isPlainObject = value => value != null && typeof value === 'object' && !Array.isArray(value)
+
+const readJsonConfig = projectDir => {
+  for (const relativePath of ['.ai.config.json', 'infra/.ai.config.json']) {
+    const configPath = join(projectDir, relativePath)
+    if (!existsSync(configPath)) continue
+    try {
+      return JSON.parse(readFileSync(configPath, 'utf8'))
+    } catch (error) {
+      console.warn(`[vibe-forge] Skipping adapter CLI postinstall prepare: failed to read ${relativePath}.`)
+      console.warn(error instanceof Error ? error.message : String(error))
+      return undefined
+    }
+  }
+  return undefined
+}
+
+const hasPrepareOnInstallTarget = config => {
+  const adapters = isPlainObject(config?.adapters) ? config.adapters : undefined
+  if (adapters == null) return false
+
+  return Object.values(adapters).some(adapterConfig => {
+    if (!isPlainObject(adapterConfig)) return false
+    return ['cli', 'routerCli'].some(key => (
+      isPlainObject(adapterConfig[key]) && adapterConfig[key].prepareOnInstall === true
+    ))
+  })
+}
+
+if (!shouldSkip()) {
+  const projectDir = resolve(process.env.INIT_CWD || process.cwd())
+  const config = readJsonConfig(projectDir)
+  if (hasPrepareOnInstallTarget(config)) {
+    const result = spawnSync(
+      process.execPath,
+      [join(__dirname, 'cli.js'), 'adapter', 'prepare', '--from-postinstall'],
+      {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          VIBE_FORGE_ADAPTER_PREPARE_POSTINSTALL_ACTIVE: '1'
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    if (result.status !== 0) {
+      const strict = isTrueLike(process.env.VIBE_FORGE_POSTINSTALL_STRICT)
+      console.warn('[vibe-forge] Adapter CLI postinstall prepare failed.')
+      if (strict) {
+        process.exit(result.status ?? 1)
+      }
+    }
+  }
+}

--- a/apps/cli/src/cli-argv.ts
+++ b/apps/cli/src/cli-argv.ts
@@ -1,5 +1,6 @@
 const ROOT_ONLY_ARGS = new Set(['-h', '--help', '-V', '--version', 'help'])
 const ROOT_SUBCOMMANDS = new Set([
+  'adapter',
   'benchmark',
   'clear',
   'config',

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { program } from 'commander'
 import { getCliDescription, getCliVersion } from '#~/utils.js'
 
 import { normalizeCliArgs } from './cli-argv'
+import { registerAdapterCommand } from './commands/adapter'
 import { registerBenchmarkCommand } from './commands/benchmark'
 import { registerClearCommand } from './commands/clear'
 import { registerConfigCommand } from './commands/config'
@@ -37,6 +38,7 @@ Examples:
   )
 
 registerRunCommand(program)
+registerAdapterCommand(program)
 registerBenchmarkCommand(program)
 registerClearCommand(program)
 registerConfigCommand(program)

--- a/apps/cli/src/commands/adapter.ts
+++ b/apps/cli/src/commands/adapter.ts
@@ -1,0 +1,48 @@
+import process from 'node:process'
+
+import type { Command } from 'commander'
+import { Option } from 'commander'
+
+import type { AdapterPrepareCommandOptions } from './adapter/prepare'
+import { runAdapterPrepareCommand } from './adapter/prepare'
+
+const formatErrorMessage = (error: unknown) => error instanceof Error ? error.message : String(error)
+
+export { resolveAdapterPrepareRequests } from './adapter/prepare'
+
+export function registerAdapterCommand(program: Command) {
+  const adapterCommand = program
+    .command('adapter')
+    .description('Manage adapter runtime resources')
+
+  adapterCommand
+    .command('prepare [targets...]')
+    .description('Preinstall managed adapter CLI resources into the workspace cache')
+    .option('--all', 'Prepare all known adapter CLI resources', false)
+    .option('--json', 'Print JSON output', false)
+    .option('--quiet', 'Suppress non-error output', false)
+    .addOption(new Option('--from-postinstall', 'Mark this run as a package postinstall prewarm').hideHelp())
+    .addHelpText(
+      'after',
+      `
+Examples:
+  vf adapter prepare
+  vf adapter prepare --all
+  vf adapter prepare codex claude-code gemini
+  vf adapter prepare claude-code.routerCli
+`
+    )
+    .action(async (targets: string[], opts: AdapterPrepareCommandOptions) => {
+      try {
+        await runAdapterPrepareCommand(targets, opts)
+      } catch (error) {
+        const message = formatErrorMessage(error)
+        if (opts.json === true) {
+          console.error(JSON.stringify({ ok: false, error: message }, null, 2))
+        } else {
+          console.error(message)
+        }
+        process.exit(1)
+      }
+    })
+}

--- a/apps/cli/src/commands/adapter/prepare-selection.ts
+++ b/apps/cli/src/commands/adapter/prepare-selection.ts
@@ -1,0 +1,181 @@
+import { loadAdapterCliPreparer, normalizeAdapterPackageId } from '@vibe-forge/types'
+import type { AdapterCliPrepareTarget, AdapterCliPreparer, Config } from '@vibe-forge/types'
+
+const KNOWN_PREPARE_ADAPTERS = [
+  'codex',
+  'claude-code',
+  'gemini',
+  'copilot',
+  'opencode',
+  'kimi'
+]
+
+const SPECIAL_TARGET_ALIASES: Record<string, { adapter: string; target: string }> = {
+  ccr: {
+    adapter: 'claude-code',
+    target: 'routerCli'
+  },
+  'claude-code-router': {
+    adapter: 'claude-code',
+    target: 'routerCli'
+  }
+}
+
+interface AdapterPrepareRequest {
+  adapter: string
+  target: AdapterCliPrepareTarget
+  preparer: AdapterCliPreparer
+}
+
+type ParsedAdapterPrepareTarget =
+  | { all: true }
+  | { adapter: string; target?: string }
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => (
+  value != null && typeof value === 'object' && !Array.isArray(value)
+)
+
+const normalizeAdapterId = (value: string) => {
+  const normalized = normalizeAdapterPackageId(value)
+  return normalized.startsWith('adapter-') ? normalized.slice('adapter-'.length) : normalized
+}
+
+const readPath = (value: unknown, path: string[]) => {
+  let current = value
+  for (const segment of path) {
+    if (!isPlainRecord(current)) return undefined
+    current = current[segment]
+  }
+  return current
+}
+
+const isTargetPrepareOnInstallEnabled = (
+  config: Config,
+  adapter: string,
+  target: AdapterCliPrepareTarget
+) => {
+  const adapterConfig = (config.adapters as Record<string, unknown> | undefined)?.[adapter]
+  const cliConfig = readPath(adapterConfig, target.configPath ?? [target.key])
+  return isPlainRecord(cliConfig) && cliConfig.prepareOnInstall === true
+}
+
+const targetMatches = (target: AdapterCliPrepareTarget, value: string) => (
+  target.key === value || target.aliases?.includes(value) === true
+)
+
+export const parseAdapterPrepareTargetInput = (rawValue: string): ParsedAdapterPrepareTarget | undefined => {
+  const value = rawValue.trim()
+  if (value === '') return undefined
+  if (value === 'all') return { all: true as const }
+
+  const specialTarget = SPECIAL_TARGET_ALIASES[value]
+  if (specialTarget != null) return specialTarget
+
+  const [rawAdapter, rawTarget] = value.split('.', 2)
+  return {
+    adapter: normalizeAdapterId(rawAdapter),
+    target: rawTarget
+  }
+}
+
+const pushUniqueRequest = (
+  requests: AdapterPrepareRequest[],
+  request: AdapterPrepareRequest
+) => {
+  const key = `${request.adapter}.${request.target.key}`
+  if (requests.some(item => `${item.adapter}.${item.target.key}` === key)) return
+  requests.push(request)
+}
+
+export const resolveAdapterPrepareRequests = (params: {
+  all?: boolean
+  config: Config
+  preparers: AdapterCliPreparer[]
+  targets: string[]
+}): AdapterPrepareRequest[] => {
+  const requests: AdapterPrepareRequest[] = []
+
+  if (params.all === true) {
+    for (const preparer of params.preparers) {
+      for (const target of preparer.targets) {
+        pushUniqueRequest(requests, {
+          adapter: preparer.adapter,
+          preparer,
+          target
+        })
+      }
+    }
+    return requests
+  }
+
+  if (params.targets.length === 0) {
+    for (const preparer of params.preparers) {
+      for (const target of preparer.targets) {
+        if (!isTargetPrepareOnInstallEnabled(params.config, preparer.adapter, target)) continue
+        pushUniqueRequest(requests, {
+          adapter: preparer.adapter,
+          preparer,
+          target
+        })
+      }
+    }
+    return requests
+  }
+
+  for (const rawTarget of params.targets) {
+    const parsedTarget = parseAdapterPrepareTargetInput(rawTarget)
+    if (parsedTarget == null) continue
+    if ('all' in parsedTarget) {
+      return resolveAdapterPrepareRequests({
+        ...params,
+        all: true,
+        targets: []
+      })
+    }
+
+    const preparer = params.preparers.find(item => item.adapter === parsedTarget.adapter)
+    if (preparer == null) {
+      throw new Error(`Unknown adapter CLI prepare target: ${rawTarget}`)
+    }
+
+    const targets = parsedTarget.target == null
+      ? preparer.targets
+      : preparer.targets.filter(target => targetMatches(target, parsedTarget.target!))
+    if (targets.length === 0) {
+      throw new Error(`Unknown adapter CLI prepare target: ${rawTarget}`)
+    }
+
+    for (const target of targets) {
+      pushUniqueRequest(requests, {
+        adapter: preparer.adapter,
+        preparer,
+        target
+      })
+    }
+  }
+
+  return requests
+}
+
+export const loadAdapterPreparePreparers = async (params: {
+  config: Config
+  requiredTargets: string[]
+}) => {
+  const configuredAdapters = Object.keys(params.config.adapters ?? {})
+  const requestedAdapters = params.requiredTargets
+    .map(parseAdapterPrepareTargetInput)
+    .filter((value): value is { adapter: string; target?: string } => value != null && !('all' in value))
+    .map(value => value.adapter)
+  const adapterIds = Array.from(new Set([...KNOWN_PREPARE_ADAPTERS, ...configuredAdapters, ...requestedAdapters]))
+  const preparers: AdapterCliPreparer[] = []
+
+  for (const adapterId of adapterIds) {
+    try {
+      preparers.push(await loadAdapterCliPreparer(adapterId))
+    } catch (error) {
+      if (requestedAdapters.includes(adapterId)) throw error
+    }
+  }
+
+  return preparers
+}

--- a/apps/cli/src/commands/adapter/prepare.ts
+++ b/apps/cli/src/commands/adapter/prepare.ts
@@ -1,0 +1,103 @@
+import process from 'node:process'
+
+import { buildConfigJsonVariables, loadConfigState } from '@vibe-forge/config'
+import type { AdapterCliPrepareContext, AdapterCliPrepareResult } from '@vibe-forge/types'
+import {
+  PROJECT_PRIMARY_WORKSPACE_FOLDER_ENV,
+  resolveProjectPrimaryWorkspaceFolder
+} from '@vibe-forge/utils/project-cache-path'
+
+import { resolveCliWorkspaceCwd } from '#~/workspace.js'
+
+import { loadAdapterPreparePreparers, resolveAdapterPrepareRequests } from './prepare-selection'
+
+export interface AdapterPrepareCommandOptions {
+  all?: boolean
+  fromPostinstall?: boolean
+  json?: boolean
+  quiet?: boolean
+}
+
+const toPrepareEnv = (cwd: string) => {
+  const primaryWorkspaceFolder = resolveProjectPrimaryWorkspaceFolder(cwd, process.env) ?? cwd
+  return {
+    ...process.env,
+    __VF_PROJECT_WORKSPACE_FOLDER__: cwd,
+    [PROJECT_PRIMARY_WORKSPACE_FOLDER_ENV]: primaryWorkspaceFolder
+  }
+}
+
+const createPrepareContext = async (quiet: boolean | undefined): Promise<AdapterCliPrepareContext> => {
+  const cwd = resolveCliWorkspaceCwd()
+  const env = toPrepareEnv(cwd)
+  const configState = await loadConfigState({
+    cwd,
+    jsonVariables: buildConfigJsonVariables(cwd, env)
+  })
+  return {
+    cwd,
+    env,
+    configs: [configState.projectConfig, configState.userConfig],
+    configState,
+    logger: {
+      info: (...args: unknown[]) => {
+        if (quiet === true) return
+        console.error(args.map(arg => typeof arg === 'string' ? arg : JSON.stringify(arg)).join(' '))
+      }
+    }
+  }
+}
+
+const printPrepareResults = (
+  results: AdapterCliPrepareResult[],
+  options: AdapterPrepareCommandOptions
+) => {
+  if (options.json === true) {
+    console.log(JSON.stringify({ ok: true, prepared: results }, null, 2))
+    return
+  }
+
+  if (options.quiet === true) return
+  for (const result of results) {
+    console.log(`Prepared ${result.title}: ${result.binaryPath}`)
+  }
+}
+
+export const runAdapterPrepareCommand = async (
+  targets: string[],
+  options: AdapterPrepareCommandOptions
+) => {
+  const ctx = await createPrepareContext(options.quiet)
+  const preparers = await loadAdapterPreparePreparers({
+    config: ctx.configState?.mergedConfig ?? {},
+    requiredTargets: targets
+  })
+  const requests = resolveAdapterPrepareRequests({
+    all: options.all,
+    config: ctx.configState?.mergedConfig ?? {},
+    preparers,
+    targets
+  })
+
+  if (requests.length === 0) {
+    if (options.json === true) {
+      console.log(JSON.stringify({ ok: true, prepared: [] }, null, 2))
+    } else if (options.quiet !== true) {
+      console.log('No adapter CLI prepare targets selected.')
+      console.log('Set adapters.<adapter>.cli.prepareOnInstall: true, pass --all, or pass target names.')
+    }
+    return
+  }
+
+  const results: AdapterCliPrepareResult[] = []
+  for (const request of requests) {
+    results.push(
+      await request.preparer.prepare(ctx, {
+        target: request.target.key
+      })
+    )
+  }
+  printPrepareResults(results, options)
+}
+
+export { resolveAdapterPrepareRequests } from './prepare-selection'

--- a/apps/cli/src/commands/run/command.ts
+++ b/apps/cli/src/commands/run/command.ts
@@ -8,6 +8,7 @@ import { loadInjectDefaultSystemPromptValue, mergeSystemPrompts } from '@vibe-fo
 import { callHook } from '@vibe-forge/hooks'
 import type { AdapterInteractionRequest, AdapterOutputEvent, SessionInitInfo } from '@vibe-forge/types'
 import { getCache } from '@vibe-forge/utils/cache'
+import { resolveProjectPrimaryWorkspaceFolder } from '@vibe-forge/utils/project-cache-path'
 import { uuid } from '@vibe-forge/utils/uuid'
 
 import { getCliDefaultSkillNames, getCliDefaultSkillPluginConfig } from '#~/default-skill-plugin.js'
@@ -62,6 +63,11 @@ type PrintInputCapableSession = ExitControllableSession & {
   pid?: number
   respondInteraction?: (id: string, data: string | string[]) => void | Promise<void>
 }
+
+const resolveRunPrimaryWorkspaceFolder = (
+  workspaceFolder: string,
+  fallbackWorkspaceFolder: string
+) => resolveProjectPrimaryWorkspaceFolder(workspaceFolder, process.env) ?? fallbackWorkspaceFolder
 
 const configureRunCommand = (command: Command) => {
   command
@@ -274,7 +280,7 @@ Notes:
               ...process.env,
               __VF_PROJECT_AI_CTX_ID__: ctxId,
               __VF_PROJECT_WORKSPACE_FOLDER__: resolvedTaskCwd,
-              __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: cwd
+              __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: resolveRunPrimaryWorkspaceFolder(resolvedTaskCwd, cwd)
             }
             await callHook('GenerateSystemPrompt', {
               cwd: resolvedTaskCwd,
@@ -474,7 +480,10 @@ Notes:
           env: {
             ...process.env,
             __VF_PROJECT_WORKSPACE_FOLDER__: record.resume.taskOptions.cwd ?? record.resume.cwd,
-            __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: cwd
+            __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: resolveRunPrimaryWorkspaceFolder(
+              record.resume.taskOptions.cwd ?? record.resume.cwd,
+              cwd
+            )
           },
           plugins: getCliDefaultSkillPluginConfig()
         }, {

--- a/apps/server/src/services/session/index.ts
+++ b/apps/server/src/services/session/index.ts
@@ -20,6 +20,7 @@ import type {
   SessionInfo,
   SessionPromptType
 } from '@vibe-forge/types'
+import { resolveProjectPrimaryWorkspaceFolder } from '@vibe-forge/utils/project-cache-path'
 
 import { handleChannelSessionEvent, resolveChannelSessionMcpServers } from '#~/channels/index.js'
 import { getDb } from '#~/db/index.js'
@@ -426,8 +427,8 @@ export async function startAdapterSession(
         }
       )
       const adapterCwd = resolvedConfig.workspace?.cwd ?? promptCwd
-      const primaryWorkspaceFolder = processEnv.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__?.trim() ||
-        processEnv.__VF_PROJECT_WORKSPACE_FOLDER__?.trim() ||
+      const primaryWorkspaceFolder = resolveProjectPrimaryWorkspaceFolder(adapterCwd, processEnv) ??
+        processEnv.__VF_PROJECT_WORKSPACE_FOLDER__?.trim() ??
         promptCwd
       const env = {
         ...processEnv,

--- a/packages/adapters/claude-code/__tests__/paths.spec.ts
+++ b/packages/adapters/claude-code/__tests__/paths.spec.ts
@@ -1,0 +1,70 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveManagedNpmCliPaths } from '@vibe-forge/utils/managed-npm-cli'
+
+import {
+  CLAUDE_CODE_CLI_PACKAGE,
+  CLAUDE_CODE_CLI_VERSION,
+  CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+  CLAUDE_CODE_ROUTER_CLI_VERSION,
+  resolveAdapterCliPath,
+  resolveClaudeCliPath
+} from '../src/ccr/paths'
+
+describe('claude code CLI paths', () => {
+  it('uses a managed Claude binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-claude-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-claude-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'claude_code',
+        binaryName: 'claude',
+        cwd: worktree,
+        env,
+        packageName: CLAUDE_CODE_CLI_PACKAGE,
+        version: CLAUDE_CODE_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveClaudeCliPath(worktree, env)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
+  })
+
+  it('uses a managed Claude Code Router binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-ccr-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-ccr-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'claude_code_router',
+        binaryName: 'ccr',
+        cwd: worktree,
+        env,
+        packageName: CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+        version: CLAUDE_CODE_ROUTER_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveAdapterCliPath(worktree, env)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -69,8 +69,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.109",
-    "@musistudio/claude-code-router": "1.0.73",
     "@vibe-forge/config": "workspace:^",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -30,6 +30,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/claude-code/src/ccr/daemon.ts
+++ b/packages/adapters/claude-code/src/ccr/daemon.ts
@@ -270,7 +270,8 @@ export const ensureClaudeCodeRouterReady = async (
         env,
         logger: {
           info: () => undefined
-        }
+        },
+        versionArgs: ['version']
       })
       : await routerDeps.resolveCliPath()
     env.__VF_PROJECT_AI_ADAPTER_CLAUDE_CODE_ROUTER_CLI_PATH__ = cliPath

--- a/packages/adapters/claude-code/src/ccr/daemon.ts
+++ b/packages/adapters/claude-code/src/ccr/daemon.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import net from 'node:net'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
@@ -7,10 +7,16 @@ import { setTimeout as delay } from 'node:timers/promises'
 
 import type { AdapterCtx } from '@vibe-forge/types'
 import { resolveProjectAiPath } from '@vibe-forge/utils'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
 import { resolveClaudeCodeAdapterConfig } from '../runtime-config'
 import { generateDefaultCCRConfigJSON } from './config'
-import { resolveAdapterCliPath, resolveTransformerRuntimePreloadPath } from './paths'
+import {
+  CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+  CLAUDE_CODE_ROUTER_CLI_VERSION,
+  resolveAdapterCliPath,
+  resolveTransformerRuntimePreloadPath
+} from './paths'
 
 const DEFAULT_ROUTER_HOST = '127.0.0.1'
 const DEFAULT_ROUTER_PORT = 3456
@@ -28,7 +34,7 @@ export interface ClaudeCodeRouterConnection {
 
 export interface ClaudeCodeRouterDeps {
   isProcessAlive: (pid: number) => boolean
-  resolveCliPath: () => string
+  resolveCliPath: () => string | Promise<string>
   resolveRuntimePreloadPath: () => string | undefined
   spawnDetached: (params: {
     cliPath: string
@@ -252,8 +258,22 @@ export const ensureClaudeCodeRouterReady = async (
   }
 
   if (!isRunning) {
-    const cliPath = routerDeps.resolveCliPath()
-    await access(cliPath)
+    const cliPath = deps.resolveCliPath == null
+      ? await ensureManagedNpmCli({
+        adapterKey: 'claude_code_router',
+        binaryName: 'ccr',
+        bundledPath: resolveAdapterCliPath(cwd, env, adapterOptions.routerCli),
+        config: adapterOptions.routerCli,
+        cwd,
+        defaultPackageName: CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+        defaultVersion: CLAUDE_CODE_ROUTER_CLI_VERSION,
+        env,
+        logger: {
+          info: () => undefined
+        }
+      })
+      : await routerDeps.resolveCliPath()
+    env.__VF_PROJECT_AI_ADAPTER_CLAUDE_CODE_ROUTER_CLI_PATH__ = cliPath
     const spawnEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...env,

--- a/packages/adapters/claude-code/src/ccr/paths.ts
+++ b/packages/adapters/claude-code/src/ccr/paths.ts
@@ -1,8 +1,17 @@
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, extname, resolve } from 'node:path'
+import process from 'node:process'
+
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
+import { resolveManagedNpmCliBinaryPath } from '@vibe-forge/utils/managed-npm-cli'
 
 const require = createRequire(import.meta.url ?? __filename)
+
+export const CLAUDE_CODE_CLI_PACKAGE = '@anthropic-ai/claude-code'
+export const CLAUDE_CODE_CLI_VERSION = '2.1.114'
+export const CLAUDE_CODE_ROUTER_CLI_PACKAGE = '@musistudio/claude-code-router'
+export const CLAUDE_CODE_ROUTER_CLI_VERSION = '1.0.73'
 
 export const toRealPath = (targetPath: string) => {
   try {
@@ -40,20 +49,52 @@ const resolvePackageBinPath = (packageName: string, binName?: string) => {
   return toRealPath(resolve(packageDir, relativeBinPath))
 }
 
-/**
- * Resolve the CCR (claude-code-router) binary path.
- * Resolved from the adapter dependency package.json instead of PATH.
- */
-export const resolveAdapterCliPath = () => {
-  return resolvePackageBinPath('@musistudio/claude-code-router', 'ccr')
+const resolvePackageBinPathOrUndefined = (packageName: string, binName?: string) => {
+  try {
+    return resolvePackageBinPath(packageName, binName)
+  } catch {
+    return undefined
+  }
 }
 
 /**
- * Resolve the Claude Code binary path from the adapter dependency graph.
+ * Resolve the CCR (claude-code-router) binary path.
+ * Resolved from the managed shared cache before adapter dependency fallback.
  */
-export const resolveClaudeCliPath = () => {
-  return resolvePackageBinPath('@anthropic-ai/claude-code', 'claude')
-}
+export const resolveAdapterCliPath = (
+  cwd?: string,
+  env: Record<string, string | null | undefined> = process.env,
+  config?: ManagedNpmCliConfig
+) =>
+  resolveManagedNpmCliBinaryPath({
+    adapterKey: 'claude_code_router',
+    binaryName: 'ccr',
+    bundledPath: resolvePackageBinPathOrUndefined(CLAUDE_CODE_ROUTER_CLI_PACKAGE, 'ccr'),
+    config,
+    cwd,
+    defaultPackageName: CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+    defaultVersion: CLAUDE_CODE_ROUTER_CLI_VERSION,
+    env
+  })
+
+/**
+ * Resolve the Claude Code binary path from managed shared cache before adapter dependency fallback.
+ */
+export const resolveClaudeCliPath = (
+  cwd?: string,
+  env: Record<string, string | null | undefined> = process.env,
+  config?: ManagedNpmCliConfig
+) =>
+  resolveManagedNpmCliBinaryPath({
+    adapterKey: 'claude_code',
+    binaryName: 'claude',
+    bundledPath: resolvePackageBinPathOrUndefined(CLAUDE_CODE_CLI_PACKAGE, 'claude'),
+    config,
+    cwd,
+    defaultPackageName: CLAUDE_CODE_CLI_PACKAGE,
+    defaultVersion: CLAUDE_CODE_CLI_VERSION,
+    env
+  })
 
 const resolveTransformerCandidateNames = (name: string) => {
   const extension = extname(name)

--- a/packages/adapters/claude-code/src/claude/prepare.ts
+++ b/packages/adapters/claude-code/src/claude/prepare.ts
@@ -6,9 +6,10 @@ import { resolveConfigState } from '@vibe-forge/config'
 import { NATIVE_HOOK_BRIDGE_ADAPTER_ENV } from '@vibe-forge/hooks'
 import type { AdapterCtx, AdapterQueryOptions } from '@vibe-forge/types'
 import { resolveProjectAiPath } from '@vibe-forge/utils'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
 import { ensureClaudeCodeRouterReady } from '../ccr/daemon'
-import { resolveClaudeCliPath } from '../ccr/paths'
+import { CLAUDE_CODE_CLI_PACKAGE, CLAUDE_CODE_CLI_VERSION, resolveClaudeCliPath } from '../ccr/paths'
 import { resolveClaudeCodeAdapterConfig } from '../runtime-config'
 import { stageClaudePluginDirs } from './plugins'
 
@@ -291,8 +292,21 @@ export const prepareClaudeExecution = async (
       : {})
   }
 
+  const cliPath = await ensureManagedNpmCli({
+    adapterKey: 'claude_code',
+    binaryName: 'claude',
+    bundledPath: resolveClaudeCliPath(cwd, executionEnv, nativeConfig.cli),
+    config: nativeConfig.cli,
+    cwd,
+    defaultPackageName: CLAUDE_CODE_CLI_PACKAGE,
+    defaultVersion: CLAUDE_CODE_CLI_VERSION,
+    env: executionEnv,
+    logger: ctx.logger
+  })
+  ctx.env.__VF_PROJECT_AI_ADAPTER_CLAUDE_CODE_CLI_PATH__ = cliPath
+
   return {
-    cliPath: resolveClaudeCliPath(),
+    cliPath,
     args,
     env: executionEnv,
     cwd,

--- a/packages/adapters/claude-code/src/cli-prepare.ts
+++ b/packages/adapters/claude-code/src/cli-prepare.ts
@@ -1,0 +1,91 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
+
+import {
+  CLAUDE_CODE_CLI_PACKAGE,
+  CLAUDE_CODE_CLI_VERSION,
+  CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+  CLAUDE_CODE_ROUTER_CLI_VERSION,
+  resolveAdapterCliPath,
+  resolveClaudeCliPath
+} from './ccr/paths'
+import { resolveClaudeCodeAdapterConfig } from './runtime-config'
+
+const prepareClaudeCli = async (
+  ctx: Parameters<Parameters<typeof defineAdapterCliPreparer>[0]['prepare']>[0]
+) => {
+  const { native: adapterConfig } = resolveClaudeCodeAdapterConfig(ctx)
+  const binaryPath = await ensureManagedNpmCli({
+    adapterKey: 'claude_code',
+    binaryName: 'claude',
+    bundledPath: resolveClaudeCliPath(ctx.cwd, ctx.env, adapterConfig.cli),
+    config: {
+      ...adapterConfig.cli,
+      source: adapterConfig.cli?.source ?? 'managed'
+    },
+    cwd: ctx.cwd,
+    defaultPackageName: CLAUDE_CODE_CLI_PACKAGE,
+    defaultVersion: CLAUDE_CODE_CLI_VERSION,
+    env: ctx.env,
+    logger: ctx.logger
+  })
+
+  return {
+    adapter: 'claude-code',
+    target: 'cli',
+    title: 'Claude Code CLI',
+    binaryPath
+  }
+}
+
+const prepareRouterCli = async (
+  ctx: Parameters<Parameters<typeof defineAdapterCliPreparer>[0]['prepare']>[0]
+) => {
+  const { native: adapterConfig } = resolveClaudeCodeAdapterConfig(ctx)
+  const binaryPath = await ensureManagedNpmCli({
+    adapterKey: 'claude_code_router',
+    binaryName: 'ccr',
+    bundledPath: resolveAdapterCliPath(ctx.cwd, ctx.env, adapterConfig.routerCli),
+    config: {
+      ...adapterConfig.routerCli,
+      source: adapterConfig.routerCli?.source ?? 'managed'
+    },
+    cwd: ctx.cwd,
+    defaultPackageName: CLAUDE_CODE_ROUTER_CLI_PACKAGE,
+    defaultVersion: CLAUDE_CODE_ROUTER_CLI_VERSION,
+    env: ctx.env,
+    logger: ctx.logger,
+    versionArgs: ['version']
+  })
+
+  return {
+    adapter: 'claude-code',
+    target: 'routerCli',
+    title: 'Claude Code Router CLI',
+    binaryPath
+  }
+}
+
+export default defineAdapterCliPreparer({
+  adapter: 'claude-code',
+  title: 'Claude Code',
+  targets: [
+    {
+      key: 'cli',
+      title: 'Claude Code CLI',
+      aliases: ['claude'],
+      configPath: ['cli']
+    },
+    {
+      key: 'routerCli',
+      title: 'Claude Code Router CLI',
+      aliases: ['ccr', 'router', 'claude-code-router'],
+      configPath: ['routerCli']
+    }
+  ],
+  prepare: async (ctx, options) => {
+    if (options.target === 'cli') return prepareClaudeCli(ctx)
+    if (options.target === 'routerCli') return prepareRouterCli(ctx)
+    throw new Error(`Unknown Claude Code CLI prepare target: ${options.target}`)
+  }
+})

--- a/packages/adapters/claude-code/src/config-schema.ts
+++ b/packages/adapters/claude-code/src/config-schema.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod'
 
-import { defineAdapterConfigContribution, effortLevelSchema } from '@vibe-forge/core/config-schema'
+import {
+  adapterNativeCliConfigSchema,
+  defineAdapterConfigContribution,
+  effortLevelSchema
+} from '@vibe-forge/core/config-schema'
 
 export const claudeCodeAdapterConfigSchema = z.object({
+  cli: adapterNativeCliConfigSchema.optional().describe('Managed Claude Code CLI runtime'),
+  routerCli: adapterNativeCliConfigSchema.optional().describe('Managed Claude Code Router CLI runtime'),
   effort: effortLevelSchema.optional().describe('Reasoning effort level'),
   ccrOptions: z.object({
     LOG: z.boolean().optional().describe('Enable CCR logging'),
@@ -41,7 +47,9 @@ export const adapterConfigContribution = defineAdapterConfigContribution({
       'ccrTransformers',
       'modelFallbacks',
       'settingsContent',
-      'nativeEnv'
+      'nativeEnv',
+      'cli',
+      'routerCli'
     ] as const
   }
 })

--- a/packages/adapters/codex/__tests__/session.spec.ts
+++ b/packages/adapters/codex/__tests__/session.spec.ts
@@ -1,13 +1,14 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { AdapterOutputEvent } from '@vibe-forge/types'
+import { resolveManagedNpmCliPaths } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveCodexBinaryPath } from '#~/paths.js'
+import { CODEX_CLI_PACKAGE, CODEX_CLI_VERSION, resolveCodexBinaryPath } from '#~/paths.js'
 import { createCodexSession } from '#~/runtime/session.js'
 
 // ─── Availability check ───────────────────────────────────────────────────────
@@ -24,9 +25,13 @@ const codexAvailable = (() => {
 // ─── Path utilities ───────────────────────────────────────────────────────────
 
 describe('resolveCodexBinaryPath', () => {
-  it('resolves to the adapter bundled binary by default', () => {
+  const expectDefaultCodexBinary = (result: string) => {
+    expect(result === 'codex' || /node_modules\/\.bin\/codex$/.test(result)).toBe(true)
+  }
+
+  it('resolves to a usable default binary without requiring a bundled dependency', () => {
     const result = resolveCodexBinaryPath({})
-    expect(result).toMatch(/node_modules\/\.bin\/codex$/)
+    expectDefaultCodexBinary(result)
   })
 
   it('returns the env-specified path when set', () => {
@@ -35,11 +40,37 @@ describe('resolveCodexBinaryPath', () => {
     })).toBe('/usr/local/bin/codex')
   })
 
-  it('falls back to bundled binary when env value is empty string', () => {
+  it('falls back to the default binary when env value is empty string', () => {
     const result = resolveCodexBinaryPath({
       __VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__: ''
     })
-    expect(result).toMatch(/node_modules\/\.bin\/codex$/)
+    expectDefaultCodexBinary(result)
+  })
+
+  it('uses a managed binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-codex-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-codex-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'codex',
+        binaryName: 'codex',
+        cwd: worktree,
+        env,
+        packageName: CODEX_CLI_PACKAGE,
+        version: CODEX_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveCodexBinaryPath(env, worktree)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -71,7 +71,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@openai/codex": "0.120.0",
     "@vibe-forge/config": "workspace:^",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -41,6 +41,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/codex/src/cli-prepare.ts
+++ b/packages/adapters/codex/src/cli-prepare.ts
@@ -1,0 +1,40 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
+
+import { CODEX_CLI_PACKAGE, CODEX_CLI_VERSION, resolveCodexBinaryPath } from '#~/paths.js'
+import { resolveCodexAdapterConfig } from '#~/runtime/config.js'
+
+export default defineAdapterCliPreparer({
+  adapter: 'codex',
+  title: 'Codex',
+  targets: [{
+    key: 'cli',
+    title: 'Codex CLI',
+    aliases: ['codex'],
+    configPath: ['cli']
+  }],
+  prepare: async (ctx) => {
+    const { native: adapterConfig } = resolveCodexAdapterConfig(ctx)
+    const binaryPath = await ensureManagedNpmCli({
+      adapterKey: 'codex',
+      binaryName: 'codex',
+      bundledPath: resolveCodexBinaryPath(ctx.env, ctx.cwd),
+      config: {
+        ...adapterConfig.cli,
+        source: adapterConfig.cli?.source ?? 'managed'
+      },
+      cwd: ctx.cwd,
+      defaultPackageName: CODEX_CLI_PACKAGE,
+      defaultVersion: CODEX_CLI_VERSION,
+      env: ctx.env,
+      logger: ctx.logger
+    })
+
+    return {
+      adapter: 'codex',
+      target: 'cli',
+      title: 'Codex CLI',
+      binaryPath
+    }
+  }
+})

--- a/packages/adapters/codex/src/config-schema.ts
+++ b/packages/adapters/codex/src/config-schema.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod'
 
-import { defineAdapterConfigContribution, effortLevelSchema, jsonValueSchema } from '@vibe-forge/core/config-schema'
+import {
+  adapterNativeCliConfigSchema,
+  defineAdapterConfigContribution,
+  effortLevelSchema,
+  jsonValueSchema
+} from '@vibe-forge/core/config-schema'
 
 export const codexAdapterConfigSchema = z.object({
+  cli: adapterNativeCliConfigSchema.optional().describe('Managed Codex CLI runtime'),
   sandboxPolicy: z.object({
     type: z.enum(['readOnly', 'workspaceWrite', 'dangerFullAccess', 'externalSandbox'])
       .describe('Sandbox policy type'),
@@ -36,6 +42,6 @@ export const adapterConfigContribution = defineAdapterConfigContribution({
   schema: codexAdapterConfigSchema,
   configEntry: {
     extraCommonKeys: ['effort'] as const,
-    deepMergeKeys: ['sandboxPolicy', 'clientInfo', 'configOverrides', 'features'] as const
+    deepMergeKeys: ['cli', 'sandboxPolicy', 'clientInfo', 'configOverrides', 'features'] as const
   }
 })

--- a/packages/adapters/codex/src/paths.ts
+++ b/packages/adapters/codex/src/paths.ts
@@ -1,21 +1,36 @@
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { resolveManagedNpmCliBinaryPath } from '@vibe-forge/utils/managed-npm-cli'
 
 const require = createRequire(import.meta.url ?? __filename)
 const adapterPackageDir = dirname(require.resolve('@vibe-forge/adapter-codex/package.json'))
+const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/codex')
+
+export const CODEX_CLI_PACKAGE = '@openai/codex'
+export const CODEX_CLI_VERSION = '0.121.0'
 
 /**
  * Returns the path to the codex binary.
  *
  * Resolution order:
  *   1. `__VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__` env override
- *   2. `<adapterPackageDir>/node_modules/.bin/codex`  (bundled via @openai/codex dependency)
+ *   2. primary workspace managed CLI cache
+ *   3. `<adapterPackageDir>/node_modules/.bin/codex`  (bundled compatibility fallback)
+ *   4. `codex` on PATH
  */
-export const resolveCodexBinaryPath = (env: AdapterCtx['env']): string => {
-  const envPath = env.__VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__
-  return typeof envPath === 'string' && envPath !== ''
-    ? envPath
-    : resolve(adapterPackageDir, 'node_modules/.bin/codex')
-}
+export const resolveCodexBinaryPath = (
+  env: AdapterCtx['env'],
+  cwd?: string
+): string =>
+  resolveManagedNpmCliBinaryPath({
+    adapterKey: 'codex',
+    binaryName: 'codex',
+    bundledPath: existsSync(bundledPath) ? bundledPath : undefined,
+    cwd,
+    defaultPackageName: CODEX_CLI_PACKAGE,
+    defaultVersion: CODEX_CLI_VERSION,
+    env
+  })

--- a/packages/adapters/codex/src/runtime/init.ts
+++ b/packages/adapters/codex/src/runtime/init.ts
@@ -1,18 +1,16 @@
-import { execFile } from 'node:child_process'
 import { access, mkdir, readdir, rm } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
-import { promisify } from 'node:util'
 
 import { readJsonFileOrDefault, resolveMockHome, writeJsonFile } from '@vibe-forge/hooks'
 import type { AdapterCtx } from '@vibe-forge/types'
 import { resolveProjectAiPath, syncSymlinkTarget } from '@vibe-forge/utils'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveCodexBinaryPath } from '#~/paths.js'
-import { writeManagedCodexConfigFile } from './config'
+import { CODEX_CLI_PACKAGE, CODEX_CLI_VERSION, resolveCodexBinaryPath } from '#~/paths.js'
+import { resolveCodexAdapterConfig, writeManagedCodexConfigFile } from './config'
 import { ensureCodexNativeHooksInstalled } from './native-hooks'
 
-const execFileAsync = promisify(execFile)
 const CODEX_MANAGED_SKILLS_STATE_FILE = '.vibe-forge-managed-skills.json'
 
 const syncCodexMockHomeSymlink = async (params: {
@@ -177,18 +175,21 @@ async function writeManagedCodexConfig(
  */
 export const initCodexAdapter = async (ctx: AdapterCtx) => {
   const { env } = ctx
-
   const home = ctx.env.__VF_PROJECT_REAL_HOME__?.trim() || process.env.__VF_PROJECT_REAL_HOME__?.trim()
   const mockHome = resolveMockHome(ctx.cwd, ctx.env)
 
-  const binaryPath = resolveCodexBinaryPath(env)
-
-  try {
-    await execFileAsync(String(binaryPath), ['--version'])
-  } catch {
-    // Non-fatal: the binary might not be installed globally, or it might be
-    // installed but the --version flag might not exist in older builds.
-  }
+  const { native: adapterConfig } = resolveCodexAdapterConfig(ctx)
+  ctx.env.__VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__ = await ensureManagedNpmCli({
+    adapterKey: 'codex',
+    binaryName: 'codex',
+    bundledPath: resolveCodexBinaryPath(env, ctx.cwd),
+    config: adapterConfig.cli,
+    cwd: ctx.cwd,
+    defaultPackageName: CODEX_CLI_PACKAGE,
+    defaultVersion: CODEX_CLI_VERSION,
+    env,
+    logger: ctx.logger
+  })
 
   if (home != null && home !== '') {
     await linkAuthFile(home, mockHome)

--- a/packages/adapters/codex/src/runtime/session-common.ts
+++ b/packages/adapters/codex/src/runtime/session-common.ts
@@ -583,7 +583,7 @@ export async function resolveSessionBase(
   configOverrideArgs.push(...mcpConfigArgs)
   configFingerprintArgs.push(...mcpConfigArgs)
 
-  const binaryPath = resolveCodexBinaryPath(env)
+  const binaryPath = resolveCodexBinaryPath(env, cwd)
   const spawnEnv = buildSpawnEnv(env)
   await mkdir(resolve(spawnEnv.HOME ?? process.env.HOME!, '.codex'), { recursive: true })
 

--- a/packages/adapters/copilot/__tests__/paths.spec.ts
+++ b/packages/adapters/copilot/__tests__/paths.spec.ts
@@ -1,0 +1,43 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveManagedNpmCliPaths } from '@vibe-forge/utils/managed-npm-cli'
+
+import { COPILOT_CLI_PACKAGE, COPILOT_CLI_VERSION, resolveCopilotBinaryPath } from '#~/paths.js'
+
+describe('resolveCopilotBinaryPath', () => {
+  it('returns the env-specified path when set', () => {
+    expect(resolveCopilotBinaryPath({
+      __VF_PROJECT_AI_ADAPTER_COPILOT_CLI_PATH__: '/usr/local/bin/copilot'
+    })).toBe('/usr/local/bin/copilot')
+  })
+
+  it('uses a managed binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-copilot-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-copilot-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'copilot',
+        binaryName: 'copilot',
+        cwd: worktree,
+        env,
+        packageName: COPILOT_CLI_PACKAGE,
+        version: COPILOT_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveCopilotBinaryPath(env, undefined, worktree)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -41,6 +41,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -32,6 +32,15 @@
         "require": "./dist/schema.js"
       }
     },
+    "./config-schema": {
+      "__vibe-forge__": {
+        "default": "./src/config-schema.ts"
+      },
+      "default": {
+        "import": "./dist/config-schema.mjs",
+        "require": "./dist/config-schema.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"
@@ -53,8 +62,9 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@github/copilot": "1.0.27",
+    "@vibe-forge/core": "workspace:^",
     "@vibe-forge/types": "workspace:^",
-    "@vibe-forge/utils": "workspace:^"
+    "@vibe-forge/utils": "workspace:^",
+    "zod": "^3.24.1"
   }
 }

--- a/packages/adapters/copilot/src/adapter-config.ts
+++ b/packages/adapters/copilot/src/adapter-config.ts
@@ -1,3 +1,5 @@
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
+
 export {}
 
 declare module '@vibe-forge/types' {
@@ -10,6 +12,7 @@ declare module '@vibe-forge/types' {
 
   interface AdapterMap {
     copilot: {
+      cli?: ManagedNpmCliConfig
       cliPath?: string
       configDir?: string
       disableWorkspaceTrust?: boolean

--- a/packages/adapters/copilot/src/cli-prepare.ts
+++ b/packages/adapters/copilot/src/cli-prepare.ts
@@ -1,0 +1,41 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
+
+import { COPILOT_CLI_PACKAGE, COPILOT_CLI_VERSION, resolveCopilotBinaryPath } from '#~/paths.js'
+import { resolveAdapterConfig } from '#~/runtime/shared.js'
+
+export default defineAdapterCliPreparer({
+  adapter: 'copilot',
+  title: 'GitHub Copilot',
+  targets: [{
+    key: 'cli',
+    title: 'GitHub Copilot CLI',
+    aliases: ['copilot'],
+    configPath: ['cli']
+  }],
+  prepare: async (ctx) => {
+    const adapterConfig = resolveAdapterConfig(ctx as Parameters<typeof resolveAdapterConfig>[0])
+    const binaryPath = await ensureManagedNpmCli({
+      adapterKey: 'copilot',
+      binaryName: 'copilot',
+      bundledPath: resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath, ctx.cwd, adapterConfig.cli),
+      config: {
+        ...adapterConfig.cli,
+        source: adapterConfig.cli?.source ?? 'managed'
+      },
+      configuredPath: adapterConfig.cliPath,
+      cwd: ctx.cwd,
+      defaultPackageName: COPILOT_CLI_PACKAGE,
+      defaultVersion: COPILOT_CLI_VERSION,
+      env: ctx.env,
+      logger: ctx.logger
+    })
+
+    return {
+      adapter: 'copilot',
+      target: 'cli',
+      title: 'GitHub Copilot CLI',
+      binaryPath
+    }
+  }
+})

--- a/packages/adapters/copilot/src/config-schema.ts
+++ b/packages/adapters/copilot/src/config-schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+import { adapterNativeCliConfigSchema, defineAdapterConfigContribution } from '@vibe-forge/core/config-schema'
+
+export const copilotAdapterConfigSchema = z.object({
+  cli: adapterNativeCliConfigSchema.optional().describe('Managed GitHub Copilot CLI runtime'),
+  cliPath: z.string().optional().describe('Native Copilot CLI binary path'),
+  configDir: z.string().optional().describe('Copilot config directory'),
+  disableWorkspaceTrust: z.boolean().optional().describe('Disable workspace trust handling'),
+  logDir: z.string().optional().describe('Copilot log directory'),
+  logLevel: z.enum(['none', 'error', 'warning', 'info', 'debug', 'all']).optional().describe('Copilot log level'),
+  agent: z.string().optional().describe('Default agent name'),
+  stream: z.boolean().optional().describe('Enable stream mode'),
+  allowAll: z.boolean().optional().describe('Allow all permissions'),
+  allowAllTools: z.boolean().optional().describe('Allow all tools'),
+  allowAllPaths: z.boolean().optional().describe('Allow all paths'),
+  allowAllUrls: z.boolean().optional().describe('Allow all URLs'),
+  disableBuiltinMcps: z.boolean().optional().describe('Disable built-in MCP servers'),
+  disabledMcpServers: z.array(z.string()).optional().describe('Disabled MCP server names'),
+  enableAllGithubMcpTools: z.boolean().optional().describe('Enable all GitHub MCP tools'),
+  additionalGithubMcpToolsets: z.array(z.string()).optional().describe('Additional GitHub MCP toolsets'),
+  additionalGithubMcpTools: z.array(z.string()).optional().describe('Additional GitHub MCP tools'),
+  noCustomInstructions: z.boolean().optional().describe('Disable custom instructions'),
+  noAskUser: z.boolean().optional().describe('Disable AskUserQuestion')
+})
+
+export type CopilotAdapterConfigSchema = z.infer<typeof copilotAdapterConfigSchema>
+
+export const adapterConfigContribution = defineAdapterConfigContribution({
+  adapterKey: 'copilot',
+  title: 'GitHub Copilot',
+  description: 'GitHub Copilot adapter configuration',
+  schema: copilotAdapterConfigSchema,
+  configEntry: {
+    deepMergeKeys: ['cli'] as const
+  }
+})

--- a/packages/adapters/copilot/src/paths.ts
+++ b/packages/adapters/copilot/src/paths.ts
@@ -3,9 +3,15 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
+import { resolveManagedNpmCliBinaryPath } from '@vibe-forge/utils/managed-npm-cli'
 
 const require = createRequire(import.meta.url ?? __filename)
 const adapterPackageDir = dirname(require.resolve('@vibe-forge/adapter-copilot/package.json'))
+const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/copilot')
+
+export const COPILOT_CLI_PACKAGE = '@github/copilot'
+export const COPILOT_CLI_VERSION = '1.0.32'
 
 const toRealPath = (targetPath: string) => {
   try {
@@ -15,7 +21,12 @@ const toRealPath = (targetPath: string) => {
   }
 }
 
-export const resolveCopilotBinaryPath = (env: AdapterCtx['env'], configuredPath?: string): string => {
+export const resolveCopilotBinaryPath = (
+  env: AdapterCtx['env'],
+  configuredPath?: string,
+  cwd?: string,
+  config?: ManagedNpmCliConfig
+): string => {
   const envPath = env.__VF_PROJECT_AI_ADAPTER_COPILOT_CLI_PATH__
   if (typeof envPath === 'string' && envPath.trim() !== '') {
     return envPath
@@ -25,10 +36,15 @@ export const resolveCopilotBinaryPath = (env: AdapterCtx['env'], configuredPath?
     return configuredPath
   }
 
-  const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/copilot')
-  if (existsSync(bundledPath)) {
-    return toRealPath(bundledPath)
-  }
-
-  return 'copilot'
+  return resolveManagedNpmCliBinaryPath({
+    adapterKey: 'copilot',
+    binaryName: 'copilot',
+    bundledPath: existsSync(bundledPath) ? toRealPath(bundledPath) : undefined,
+    config,
+    configuredPath,
+    cwd,
+    defaultPackageName: COPILOT_CLI_PACKAGE,
+    defaultVersion: COPILOT_CLI_VERSION,
+    env
+  })
 }

--- a/packages/adapters/copilot/src/runtime/init.ts
+++ b/packages/adapters/copilot/src/runtime/init.ts
@@ -1,15 +1,12 @@
-import { execFile } from 'node:child_process'
 import { rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
-import { promisify } from 'node:util'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveCopilotBinaryPath } from '#~/paths.js'
-import { resolveAdapterConfig, syncCopilotManagedSymlink, toProcessEnv } from './shared'
-
-const execFileAsync = promisify(execFile)
+import { COPILOT_CLI_PACKAGE, COPILOT_CLI_VERSION, resolveCopilotBinaryPath } from '#~/paths.js'
+import { resolveAdapterConfig, syncCopilotManagedSymlink } from './shared'
 
 const resolveCopilotMockHome = (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => {
   const explicitHome = ctx.env.HOME?.trim() || process.env.HOME?.trim()
@@ -42,15 +39,18 @@ const syncCopilotMockHomeKeychains = async (ctx: Pick<AdapterCtx, 'cwd' | 'env'>
 
 export const initCopilotAdapter = async (ctx: AdapterCtx) => {
   const adapterConfig = resolveAdapterConfig(ctx)
-  const binaryPath = resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath)
+  ctx.env.__VF_PROJECT_AI_ADAPTER_COPILOT_CLI_PATH__ = await ensureManagedNpmCli({
+    adapterKey: 'copilot',
+    binaryName: 'copilot',
+    bundledPath: resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath, ctx.cwd, adapterConfig.cli),
+    config: adapterConfig.cli,
+    configuredPath: adapterConfig.cliPath,
+    cwd: ctx.cwd,
+    defaultPackageName: COPILOT_CLI_PACKAGE,
+    defaultVersion: COPILOT_CLI_VERSION,
+    env: ctx.env,
+    logger: ctx.logger
+  })
 
   await syncCopilotMockHomeKeychains(ctx)
-
-  try {
-    await execFileAsync(binaryPath, ['--version'], {
-      cwd: ctx.cwd,
-      env: toProcessEnv(ctx.env)
-    })
-  } catch {
-  }
 }

--- a/packages/adapters/copilot/src/runtime/session/direct.ts
+++ b/packages/adapters/copilot/src/runtime/session/direct.ts
@@ -18,7 +18,7 @@ export const createDirectCopilotSession = async (
   options: AdapterQueryOptions
 ): Promise<AdapterSession> => {
   const adapterConfig = resolveAdapterConfig(ctx)
-  const binaryPath = resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath)
+  const binaryPath = resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath, ctx.cwd, adapterConfig.cli)
   const prompt = options.description?.trim() !== '' ? options.description?.trim() : undefined
   const childEnv = await buildCopilotChildEnv(ctx, options, adapterConfig)
   const model = resolveCopilotModelConfig(ctx, options.model).cliModel ?? options.model ?? 'default'

--- a/packages/adapters/copilot/src/runtime/session/stream.ts
+++ b/packages/adapters/copilot/src/runtime/session/stream.ts
@@ -132,7 +132,7 @@ export const createStreamCopilotSession = async (
   options: AdapterQueryOptions
 ): Promise<AdapterSession> => {
   const adapterConfig = resolveAdapterConfig(ctx)
-  const binaryPath = resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath)
+  const binaryPath = resolveCopilotBinaryPath(ctx.env, adapterConfig.cliPath, ctx.cwd, adapterConfig.cli)
   const childEnv = await buildCopilotChildEnv(ctx, options, adapterConfig)
   const model = resolveCopilotModelConfig(ctx, options.model).cliModel ?? options.model ?? 'default'
 

--- a/packages/adapters/copilot/src/runtime/shared.ts
+++ b/packages/adapters/copilot/src/runtime/shared.ts
@@ -12,11 +12,13 @@ import type {
 } from '@vibe-forge/types'
 import { omitAdapterCommonConfig, syncSymlinkTarget } from '@vibe-forge/utils'
 import { createLogger } from '@vibe-forge/utils/create-logger'
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
 import { uuid } from '@vibe-forge/utils/uuid'
 
 import { registerCopilotProviderProxyRoute } from './provider-proxy'
 
 export interface CopilotAdapterConfig {
+  cli?: ManagedNpmCliConfig
   cliPath?: string
   configDir?: string
   disableWorkspaceTrust?: boolean

--- a/packages/adapters/gemini/__tests__/shared.spec.ts
+++ b/packages/adapters/gemini/__tests__/shared.spec.ts
@@ -1,9 +1,14 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { NATIVE_HOOK_BRIDGE_ADAPTER_ENV } from '@vibe-forge/hooks'
 import type { AdapterCtx, Config } from '@vibe-forge/types'
+import { resolveManagedNpmCliPaths } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveGeminiBinaryPath } from '#~/paths.js'
+import { GEMINI_CLI_PACKAGE, GEMINI_CLI_VERSION, resolveGeminiBinaryPath } from '#~/paths.js'
 import { buildGeminiNativeHooksSettings } from '#~/runtime/native-hooks.js'
 import {
   buildGeminiDirectArgs,
@@ -43,6 +48,32 @@ describe('resolveGeminiBinaryPath', () => {
     expect(resolveGeminiBinaryPath({
       __VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__: '/usr/local/bin/gemini'
     })).toBe('/usr/local/bin/gemini')
+  })
+
+  it('uses a managed binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-gemini-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-gemini-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'gemini',
+        binaryName: 'gemini',
+        cwd: worktree,
+        env,
+        packageName: GEMINI_CLI_PACKAGE,
+        version: GEMINI_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveGeminiBinaryPath(env, worktree)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/adapters/gemini/package.json
+++ b/packages/adapters/gemini/package.json
@@ -32,6 +32,15 @@
         "require": "./dist/schema.js"
       }
     },
+    "./config-schema": {
+      "__vibe-forge__": {
+        "default": "./src/config-schema.ts"
+      },
+      "default": {
+        "import": "./dist/config-schema.mjs",
+        "require": "./dist/config-schema.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"
@@ -62,10 +71,10 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@google/gemini-cli": "0.38.0",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
-    "@vibe-forge/utils": "workspace:^"
+    "@vibe-forge/utils": "workspace:^",
+    "zod": "^3.24.1"
   }
 }

--- a/packages/adapters/gemini/package.json
+++ b/packages/adapters/gemini/package.json
@@ -41,6 +41,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/gemini/src/adapter-config.ts
+++ b/packages/adapters/gemini/src/adapter-config.ts
@@ -1,3 +1,5 @@
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
+
 export {}
 
 declare module '@vibe-forge/types' {
@@ -9,6 +11,7 @@ declare module '@vibe-forge/types' {
 
   interface AdapterMap {
     gemini: {
+      cli?: ManagedNpmCliConfig
       disableExtensions?: boolean
       disableSubagents?: boolean
       disableAutoUpdate?: boolean

--- a/packages/adapters/gemini/src/cli-prepare.ts
+++ b/packages/adapters/gemini/src/cli-prepare.ts
@@ -1,0 +1,40 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
+
+import { GEMINI_CLI_PACKAGE, GEMINI_CLI_VERSION, resolveGeminiBinaryPath } from '#~/paths.js'
+import { resolveGeminiAdapterConfig } from '#~/runtime/shared.js'
+
+export default defineAdapterCliPreparer({
+  adapter: 'gemini',
+  title: 'Gemini',
+  targets: [{
+    key: 'cli',
+    title: 'Gemini CLI',
+    aliases: ['gemini'],
+    configPath: ['cli']
+  }],
+  prepare: async (ctx) => {
+    const adapterConfig = resolveGeminiAdapterConfig(ctx as Parameters<typeof resolveGeminiAdapterConfig>[0])
+    const binaryPath = await ensureManagedNpmCli({
+      adapterKey: 'gemini',
+      binaryName: 'gemini',
+      bundledPath: resolveGeminiBinaryPath(ctx.env, ctx.cwd),
+      config: {
+        ...adapterConfig.cli,
+        source: adapterConfig.cli?.source ?? 'managed'
+      },
+      cwd: ctx.cwd,
+      defaultPackageName: GEMINI_CLI_PACKAGE,
+      defaultVersion: GEMINI_CLI_VERSION,
+      env: ctx.env,
+      logger: ctx.logger
+    })
+
+    return {
+      adapter: 'gemini',
+      target: 'cli',
+      title: 'Gemini CLI',
+      binaryPath
+    }
+  }
+})

--- a/packages/adapters/gemini/src/config-schema.ts
+++ b/packages/adapters/gemini/src/config-schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+import { adapterNativeCliConfigSchema, defineAdapterConfigContribution } from '@vibe-forge/core/config-schema'
+
+export const geminiAdapterConfigSchema = z.object({
+  cli: adapterNativeCliConfigSchema.optional().describe('Managed Gemini CLI runtime'),
+  disableExtensions: z.boolean().optional().describe('Disable Gemini extensions'),
+  disableSubagents: z.boolean().optional().describe('Disable Gemini subagents'),
+  disableAutoUpdate: z.boolean().optional().describe('Disable Gemini auto update checks'),
+  telemetry: z.enum(['off', 'inherit']).optional().describe('Telemetry mode'),
+  nativePromptCommands: z.enum(['reject', 'allow']).optional().describe('Native prompt command behavior')
+})
+
+export type GeminiAdapterConfigSchema = z.infer<typeof geminiAdapterConfigSchema>
+
+export const adapterConfigContribution = defineAdapterConfigContribution({
+  adapterKey: 'gemini',
+  title: 'Gemini',
+  description: 'Gemini adapter configuration',
+  schema: geminiAdapterConfigSchema,
+  configEntry: {
+    deepMergeKeys: ['cli'] as const
+  }
+})

--- a/packages/adapters/gemini/src/paths.ts
+++ b/packages/adapters/gemini/src/paths.ts
@@ -3,9 +3,14 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { resolveManagedNpmCliBinaryPath } from '@vibe-forge/utils/managed-npm-cli'
 
 const require = createRequire(import.meta.url ?? __filename)
 const adapterPackageDir = dirname(require.resolve('@vibe-forge/adapter-gemini/package.json'))
+const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/gemini')
+
+export const GEMINI_CLI_PACKAGE = '@google/gemini-cli'
+export const GEMINI_CLI_VERSION = '0.38.2'
 
 const toRealPath = (targetPath: string) => {
   try {
@@ -15,16 +20,22 @@ const toRealPath = (targetPath: string) => {
   }
 }
 
-export const resolveGeminiBinaryPath = (env: AdapterCtx['env']) => {
+export const resolveGeminiBinaryPath = (
+  env: AdapterCtx['env'],
+  cwd?: string
+) => {
   const envPath = env.__VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__
   if (typeof envPath === 'string' && envPath.trim() !== '') {
     return envPath
   }
 
-  const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/gemini')
-  if (existsSync(bundledPath)) {
-    return toRealPath(bundledPath)
-  }
-
-  return 'gemini'
+  return resolveManagedNpmCliBinaryPath({
+    adapterKey: 'gemini',
+    binaryName: 'gemini',
+    bundledPath: existsSync(bundledPath) ? toRealPath(bundledPath) : undefined,
+    cwd,
+    defaultPackageName: GEMINI_CLI_PACKAGE,
+    defaultVersion: GEMINI_CLI_VERSION,
+    env
+  })
 }

--- a/packages/adapters/gemini/src/runtime/init.ts
+++ b/packages/adapters/gemini/src/runtime/init.ts
@@ -1,16 +1,13 @@
-import { execFile } from 'node:child_process'
 import { mkdir, rm } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
-import { promisify } from 'node:util'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveGeminiBinaryPath } from '#~/paths.js'
+import { GEMINI_CLI_PACKAGE, GEMINI_CLI_VERSION, resolveGeminiBinaryPath } from '#~/paths.js'
 
 import { prepareGeminiNativeHooks } from './native-hooks'
-import { resolveGeminiMockHome, syncGeminiMockHomeSymlink } from './shared'
-
-const execFileAsync = promisify(execFile)
+import { resolveGeminiAdapterConfig, resolveGeminiMockHome, syncGeminiMockHomeSymlink } from './shared'
 
 const syncGeminiMockHomeSkills = async (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => {
   const mockHome = resolveGeminiMockHome(ctx)
@@ -53,12 +50,18 @@ const syncGeminiMockHomeSkillEntries = async (ctx: Pick<AdapterCtx, 'assets' | '
 export const initGeminiAdapter = async (ctx: AdapterCtx) => {
   prepareGeminiNativeHooks(ctx)
 
-  const binaryPath = resolveGeminiBinaryPath(ctx.env)
-
-  try {
-    await execFileAsync(binaryPath, ['--version'])
-  } catch {
-  }
+  const adapterConfig = resolveGeminiAdapterConfig(ctx)
+  ctx.env.__VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__ = await ensureManagedNpmCli({
+    adapterKey: 'gemini',
+    binaryName: 'gemini',
+    bundledPath: resolveGeminiBinaryPath(ctx.env, ctx.cwd),
+    config: adapterConfig.cli,
+    cwd: ctx.cwd,
+    defaultPackageName: GEMINI_CLI_PACKAGE,
+    defaultVersion: GEMINI_CLI_VERSION,
+    env: ctx.env,
+    logger: ctx.logger
+  })
 
   await mkdir(resolve(resolveGeminiMockHome(ctx), '.gemini'), { recursive: true })
   await syncGeminiMockHomeSkillEntries(ctx)

--- a/packages/adapters/gemini/src/runtime/session/direct.ts
+++ b/packages/adapters/gemini/src/runtime/session/direct.ts
@@ -31,7 +31,7 @@ export const createDirectGeminiSession = async (
     ctx,
     model: options.model
   })
-  const binaryPath = resolveGeminiBinaryPath(ctx.env)
+  const binaryPath = resolveGeminiBinaryPath(ctx.env, ctx.cwd)
   const approvalMode = resolveGeminiApprovalMode(options.permissionMode)
   const promptFiles = await ensureGeminiPromptFiles(ctx, options)
   const proxyRoute = resolvedModel.routedService == null

--- a/packages/adapters/gemini/src/runtime/session/stream.ts
+++ b/packages/adapters/gemini/src/runtime/session/stream.ts
@@ -45,7 +45,7 @@ export const createStreamGeminiSession = async (
     ctx,
     model: options.model
   })
-  const binaryPath = resolveGeminiBinaryPath(ctx.env)
+  const binaryPath = resolveGeminiBinaryPath(ctx.env, ctx.cwd)
   const approvalMode = resolveGeminiApprovalMode(options.permissionMode)
   const promptFiles = await ensureGeminiPromptFiles(ctx, options)
   const proxyRoute = resolvedModel.routedService == null

--- a/packages/adapters/gemini/src/runtime/shared.ts
+++ b/packages/adapters/gemini/src/runtime/shared.ts
@@ -15,11 +15,13 @@ import type {
   ModelServiceConfig
 } from '@vibe-forge/types'
 import { omitAdapterCommonConfig, parseServiceModelSelector, syncSymlinkTarget } from '@vibe-forge/utils'
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
 
 import type { GeminiNativeHooksSettings } from './native-hooks'
 import { resolveGeminiModelServiceRoute } from './proxy'
 
 export interface GeminiAdapterConfig {
+  cli?: ManagedNpmCliConfig
   disableExtensions?: boolean
   disableSubagents?: boolean
   disableAutoUpdate?: boolean

--- a/packages/adapters/kimi/.ai/rules/runtime.md
+++ b/packages/adapters/kimi/.ai/rules/runtime.md
@@ -52,10 +52,33 @@ kimi \
 
 Kimi CLI 定位优先级：
 
-1. `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__`
-2. workspace 托管 binary：`.ai/caches/adapter-kimi/cli/bin/kimi`
+1. `adapters.kimi.cli.path` 或 `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__`
+2. primary workspace 共享托管 binary：`<primary>/.ai/caches/adapter-kimi/cli/bin/kimi`
 3. 系统 `PATH` 里的 `kimi`
 4. `autoInstall !== false` 且 `uv` 可用时，执行 `uv tool install --python 3.13 kimi-cli`
+
+用户可通过 `adapters.kimi.cli` 固定版本和安装器：
+
+```yaml
+adapters:
+  kimi:
+    cli:
+      source: managed
+      package: kimi-cli
+      version: 1.36.0
+      python: "3.13"
+      uvPath: uv
+```
+
+旧字段 `autoInstall`、`installPackage`、`installPython`、`uvPath` 继续兼容；新配置优先用 `cli.*`。环境变量覆盖包括：
+
+- `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_SOURCE__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_AUTO_INSTALL__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PACKAGE__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_VERSION__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PYTHON__`
+- `__VF_PROJECT_AI_ADAPTER_KIMI_UV_PATH__`
 
 官方安装脚本适合提示用户手动执行：
 
@@ -63,7 +86,9 @@ Kimi CLI 定位优先级：
 curl -LsSf https://code.kimi.com/install.sh | bash
 ```
 
-adapter 内部不直接执行官方脚本，因为它会修改用户级环境和 PATH。自动安装必须保持在 `.ai/caches/adapter-kimi/cli`，避免污染真实 home。
+adapter 内部不直接执行官方脚本，因为它会修改用户级环境和 PATH。自动安装必须保持在共享 cache 的 `adapter-kimi/cli` 下，避免污染真实 home。
+
+worktree 场景下，CLI 安装 cache 跟随 primary workspace：优先使用 `__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__`，没有 env hint 时通过 `git rev-parse --git-common-dir` 反查主工作树。session share dir 仍然留在当前 worktree 的 `.ai/caches/<ctxId>/<sessionId>/adapter-kimi/share`，不要和 CLI cache 混用。
 
 没有 `kimi` 或 `uv` 时，错误信息要继续包含：
 

--- a/packages/adapters/kimi/__tests__/runtime-config.spec.ts
+++ b/packages/adapters/kimi/__tests__/runtime-config.spec.ts
@@ -129,7 +129,28 @@ describe('kimi runtime helpers', () => {
     }
   })
 
-  it('builds workspace-local uv tool install options for managed Kimi CLI installs', async () => {
+  it('uses the primary workspace shared cache for managed Kimi CLI paths', async () => {
+    const { ctx, cleanup } = await createCtx()
+    const primary = await mkdtemp(join(tmpdir(), 'vf-kimi-primary-'))
+    try {
+      ctx.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__ = primary
+      const paths = resolveKimiManagedToolPaths(ctx.cwd, ctx.env)
+      const binaryPath = paths.binaryCandidates[0]
+
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(binaryPath, '#!/bin/sh\n')
+      await chmod(binaryPath, 0o755)
+
+      expect(paths.rootDir).toBe(join(primary, '.ai', 'caches', 'adapter-kimi', 'cli'))
+      expect(resolveKimiBinaryPath(ctx.env, ctx.cwd)).toBe(await realpath(binaryPath))
+      expect(buildKimiCliInstallEnv(ctx).UV_TOOL_DIR).toBe(paths.toolDir)
+    } finally {
+      await cleanup()
+      await rm(primary, { recursive: true, force: true })
+    }
+  })
+
+  it('builds shared-cache uv tool install options for managed Kimi CLI installs', async () => {
     const { ctx, cleanup } = await createCtx()
     try {
       const options = resolveKimiCliInstallOptions({
@@ -148,8 +169,10 @@ describe('kimi runtime helpers', () => {
 
       expect(options).toEqual({
         autoInstall: false,
+        binaryPath: undefined,
         packageName: 'kimi-cli==1.2.3',
         python: '3.14',
+        source: undefined,
         uvPath: '/opt/bin/uv'
       })
       expect(buildKimiCliInstallArgs(options)).toEqual([
@@ -168,6 +191,31 @@ describe('kimi runtime helpers', () => {
     } finally {
       await cleanup()
     }
+  })
+
+  it('accepts nested Kimi CLI config for managed package version control', () => {
+    expect(resolveKimiCliInstallOptions({}, {
+      cli: {
+        autoInstall: false,
+        package: 'kimi-cli',
+        path: '/opt/kimi/bin/kimi',
+        python: '3.14',
+        source: 'path',
+        uvPath: '/opt/bin/uv',
+        version: '1.2.3'
+      },
+      autoInstall: true,
+      installPackage: 'ignored',
+      installPython: '3.13',
+      uvPath: 'ignored'
+    })).toEqual({
+      autoInstall: false,
+      binaryPath: '/opt/kimi/bin/kimi',
+      packageName: 'kimi-cli==1.2.3',
+      python: '3.14',
+      source: 'path',
+      uvPath: '/opt/bin/uv'
+    })
   })
 
   it('renders actionable install instructions when Kimi CLI or uv is missing', async () => {

--- a/packages/adapters/kimi/package.json
+++ b/packages/adapters/kimi/package.json
@@ -32,6 +32,15 @@
         "require": "./dist/schema.js"
       }
     },
+    "./config-schema": {
+      "__vibe-forge__": {
+        "default": "./src/config-schema.ts"
+      },
+      "default": {
+        "import": "./dist/config-schema.mjs",
+        "require": "./dist/config-schema.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"
@@ -56,6 +65,7 @@
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
-    "@vibe-forge/utils": "workspace:^"
+    "@vibe-forge/utils": "workspace:^",
+    "zod": "^3.24.1"
   }
 }

--- a/packages/adapters/kimi/package.json
+++ b/packages/adapters/kimi/package.json
@@ -41,6 +41,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/kimi/src/adapter-config.ts
+++ b/packages/adapters/kimi/src/adapter-config.ts
@@ -1,19 +1,9 @@
+import type { KimiAdapterConfig } from './config-schema.js'
+
 export {}
 
 declare module '@vibe-forge/types' {
   interface AdapterMap {
-    kimi: {
-      agent?: 'default' | 'okabe' | (string & {})
-      thinking?: boolean
-      showThinkingStream?: boolean
-      maxStepsPerTurn?: number
-      maxRetriesPerStep?: number
-      maxRalphIterations?: number
-      autoInstall?: boolean
-      installPackage?: string
-      installPython?: string
-      uvPath?: string
-      configContent?: Record<string, unknown>
-    }
+    kimi: KimiAdapterConfig
   }
 }

--- a/packages/adapters/kimi/src/cli-prepare.ts
+++ b/packages/adapters/kimi/src/cli-prepare.ts
@@ -1,0 +1,25 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+
+import { ensureKimiCli } from '#~/runtime/init.js'
+
+export default defineAdapterCliPreparer({
+  adapter: 'kimi',
+  title: 'Kimi',
+  targets: [{
+    key: 'cli',
+    title: 'Kimi CLI',
+    aliases: ['kimi'],
+    configPath: ['cli']
+  }],
+  prepare: async (ctx) => {
+    const binaryPath = await ensureKimiCli(ctx as Parameters<typeof ensureKimiCli>[0], {
+      defaultSource: 'managed'
+    })
+    return {
+      adapter: 'kimi',
+      target: 'cli',
+      title: 'Kimi CLI',
+      binaryPath
+    }
+  }
+})

--- a/packages/adapters/kimi/src/config-schema.ts
+++ b/packages/adapters/kimi/src/config-schema.ts
@@ -9,6 +9,7 @@ const kimiCliConfigSchema = z.object({
   version: z.string().optional().describe('Managed uv package version'),
   python: z.string().optional().describe('Python version used by uv tool install'),
   autoInstall: z.boolean().optional().describe('Install Kimi CLI when no usable binary is found'),
+  prepareOnInstall: z.boolean().optional().describe('Preinstall Kimi CLI during Vibe Forge package install'),
   uvPath: z.string().optional().describe('uv binary used for managed installs')
 })
 

--- a/packages/adapters/kimi/src/config-schema.ts
+++ b/packages/adapters/kimi/src/config-schema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+import { defineAdapterConfigContribution, effortLevelSchema, jsonValueSchema } from '@vibe-forge/core/config-schema'
+
+const kimiCliConfigSchema = z.object({
+  source: z.enum(['managed', 'system', 'path']).optional().describe('Kimi CLI source'),
+  path: z.string().optional().describe('Kimi CLI binary path when source is path'),
+  package: z.string().optional().describe('Managed uv package name'),
+  version: z.string().optional().describe('Managed uv package version'),
+  python: z.string().optional().describe('Python version used by uv tool install'),
+  autoInstall: z.boolean().optional().describe('Install Kimi CLI when no usable binary is found'),
+  uvPath: z.string().optional().describe('uv binary used for managed installs')
+})
+
+export const kimiAdapterConfigSchema = z.object({
+  cli: kimiCliConfigSchema.optional().describe('Managed Kimi CLI runtime'),
+  agent: z.union([z.literal('default'), z.literal('okabe'), z.string()]).optional().describe('Kimi agent name'),
+  thinking: z.boolean().optional().describe('Enable Kimi thinking mode'),
+  showThinkingStream: z.boolean().optional().describe('Show thinking stream'),
+  maxStepsPerTurn: z.number().int().positive().optional().describe('Maximum tool steps per turn'),
+  maxRetriesPerStep: z.number().int().nonnegative().optional().describe('Maximum retries per tool step'),
+  maxRalphIterations: z.number().int().positive().optional().describe('Maximum Ralph iterations'),
+  autoInstall: z.boolean().optional().describe('Legacy shortcut for cli.autoInstall'),
+  installPackage: z.string().optional().describe('Legacy shortcut for cli.package, including optional version spec'),
+  installPython: z.string().optional().describe('Legacy shortcut for cli.python'),
+  uvPath: z.string().optional().describe('Legacy shortcut for cli.uvPath'),
+  configContent: z.record(z.string(), jsonValueSchema).optional().describe('Raw Kimi config override'),
+  effort: effortLevelSchema.optional().describe('Reasoning effort level')
+})
+
+export type KimiAdapterConfig = z.infer<typeof kimiAdapterConfigSchema>
+export type KimiCommonAdapterConfigKey = 'effort'
+export type KimiNativeAdapterConfig = KimiAdapterConfig
+
+export const adapterConfigContribution = defineAdapterConfigContribution({
+  adapterKey: 'kimi',
+  title: 'Kimi',
+  description: 'Kimi CLI adapter configuration',
+  schema: kimiAdapterConfigSchema,
+  configEntry: {
+    extraCommonKeys: ['effort'] as const,
+    deepMergeKeys: ['cli', 'configContent'] as const
+  }
+})

--- a/packages/adapters/kimi/src/paths.ts
+++ b/packages/adapters/kimi/src/paths.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { resolveProjectSharedCachePath } from '@vibe-forge/utils/project-cache-path'
 
 const KIMI_BINARY_NAMES = process.platform === 'win32'
   ? ['kimi.exe', 'kimi.cmd', 'kimi']
@@ -16,8 +17,11 @@ const toRealPath = (targetPath: string) => {
   }
 }
 
-export const resolveKimiManagedToolPaths = (cwd: string) => {
-  const rootDir = resolve(cwd, '.ai', 'caches', 'adapter-kimi', 'cli')
+export const resolveKimiManagedToolPaths = (
+  cwd: string,
+  env: AdapterCtx['env'] = process.env
+) => {
+  const rootDir = resolveProjectSharedCachePath(cwd, env, 'adapter-kimi', 'cli')
   const binDir = resolve(rootDir, 'bin')
   return {
     rootDir,
@@ -30,9 +34,12 @@ export const resolveKimiManagedToolPaths = (cwd: string) => {
   }
 }
 
-export const resolveKimiManagedBinaryPath = (cwd?: string) => {
+export const resolveKimiManagedBinaryPath = (
+  cwd?: string,
+  env: AdapterCtx['env'] = process.env
+) => {
   if (cwd == null || cwd.trim() === '') return undefined
-  return resolveKimiManagedToolPaths(cwd).binaryCandidates
+  return resolveKimiManagedToolPaths(cwd, env).binaryCandidates
     .find(candidate => existsSync(candidate))
 }
 
@@ -42,7 +49,7 @@ export const resolveKimiBinaryPath = (env: AdapterCtx['env'], cwd?: string) => {
     return envPath
   }
 
-  const managedPath = resolveKimiManagedBinaryPath(cwd)
+  const managedPath = resolveKimiManagedBinaryPath(cwd, env)
   if (managedPath != null) {
     return toRealPath(managedPath)
   }

--- a/packages/adapters/kimi/src/runtime/common.ts
+++ b/packages/adapters/kimi/src/runtime/common.ts
@@ -4,6 +4,10 @@ import type { ChatMessageContent } from '@vibe-forge/core'
 import type { AdapterCtx, AdapterQueryOptions } from '@vibe-forge/types'
 import { omitAdapterCommonConfig } from '@vibe-forge/utils'
 
+import type { KimiAdapterConfig } from '../config-schema'
+
+export type { KimiAdapterConfig } from '../config-schema'
+
 export type KimiProviderType =
   | 'kimi'
   | 'openai_legacy'
@@ -11,20 +15,6 @@ export type KimiProviderType =
   | 'anthropic'
   | 'gemini'
   | 'vertexai'
-
-export interface KimiAdapterConfig {
-  agent?: 'default' | 'okabe' | (string & {})
-  thinking?: boolean
-  showThinkingStream?: boolean
-  maxStepsPerTurn?: number
-  maxRetriesPerStep?: number
-  maxRalphIterations?: number
-  autoInstall?: boolean
-  installPackage?: string
-  installPython?: string
-  uvPath?: string
-  configContent?: Record<string, unknown>
-}
 
 export const DEFAULT_KIMI_TOOL_REFS = [
   'kimi_cli.tools.agent:Agent',

--- a/packages/adapters/kimi/src/runtime/init.ts
+++ b/packages/adapters/kimi/src/runtime/init.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Kimi CLI bootstrap keeps install helpers and init flow together. */
 import { execFile } from 'node:child_process'
 import { mkdir } from 'node:fs/promises'
 import process from 'node:process'
@@ -13,6 +14,7 @@ import { prepareKimiNativeHooks } from './native-hooks'
 const execFileAsync = promisify(execFile)
 
 const DEFAULT_KIMI_INSTALL_PACKAGE = 'kimi-cli'
+const DEFAULT_KIMI_INSTALL_VERSION = '1.36.0'
 const DEFAULT_KIMI_INSTALL_PYTHON = '3.13'
 const COMMAND_CHECK_TIMEOUT_MS = 15000
 
@@ -22,22 +24,43 @@ const normalizeNonEmptyString = (value: unknown) => (
 
 const isFalseLike = (value: string) => ['0', 'false', 'no', 'off'].includes(value.trim().toLowerCase())
 
+const normalizeSource = (value: unknown) => (
+  value === 'managed' || value === 'system' || value === 'path' ? value : undefined
+)
+
+const hasUvVersionSpec = (packageName: string) => /[<>=!~@]/u.test(packageName)
+
+const toUvPackageSpec = (packageName: string, version?: string) => (
+  version != null && !hasUvVersionSpec(packageName) ? `${packageName}==${version}` : packageName
+)
+
 export const resolveKimiCliInstallOptions = (
   env: AdapterCtx['env'],
   adapterConfig: KimiAdapterConfig = {}
 ) => {
   const rawAutoInstall = normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_AUTO_INSTALL__)
+  const packageName = normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PACKAGE__) ??
+    normalizeNonEmptyString(adapterConfig.cli?.package) ??
+    normalizeNonEmptyString(adapterConfig.installPackage) ??
+    DEFAULT_KIMI_INSTALL_PACKAGE
+  const version = normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_VERSION__) ??
+    normalizeNonEmptyString(adapterConfig.cli?.version) ??
+    DEFAULT_KIMI_INSTALL_VERSION
   return {
     autoInstall: rawAutoInstall == null
-      ? adapterConfig.autoInstall !== false
+      ? (adapterConfig.cli?.autoInstall ?? adapterConfig.autoInstall) !== false
       : !isFalseLike(rawAutoInstall),
-    packageName: normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PACKAGE__) ??
-      normalizeNonEmptyString(adapterConfig.installPackage) ??
-      DEFAULT_KIMI_INSTALL_PACKAGE,
+    binaryPath: normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__) ??
+      normalizeNonEmptyString(adapterConfig.cli?.path),
+    packageName: toUvPackageSpec(packageName, version),
     python: normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_INSTALL_PYTHON__) ??
+      normalizeNonEmptyString(adapterConfig.cli?.python) ??
       normalizeNonEmptyString(adapterConfig.installPython) ??
       DEFAULT_KIMI_INSTALL_PYTHON,
+    source: normalizeSource(env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_SOURCE__) ??
+      normalizeSource(adapterConfig.cli?.source),
     uvPath: normalizeNonEmptyString(env.__VF_PROJECT_AI_ADAPTER_KIMI_UV_PATH__) ??
+      normalizeNonEmptyString(adapterConfig.cli?.uvPath) ??
       normalizeNonEmptyString(adapterConfig.uvPath) ??
       'uv'
   }
@@ -46,7 +69,7 @@ export const resolveKimiCliInstallOptions = (
 export const buildKimiCliInstallEnv = (
   ctx: Pick<AdapterCtx, 'cwd' | 'env'>
 ) => {
-  const paths = resolveKimiManagedToolPaths(ctx.cwd)
+  const paths = resolveKimiManagedToolPaths(ctx.cwd, ctx.env)
   return toProcessEnv({
     ...process.env,
     ...ctx.env,
@@ -70,10 +93,10 @@ export const buildKimiCliInstallArgs = (
 ]
 
 export const buildKimiCliInstallInstructions = (
-  ctx: Pick<AdapterCtx, 'cwd'>,
+  ctx: Pick<AdapterCtx, 'cwd' | 'env'>,
   options: ReturnType<typeof resolveKimiCliInstallOptions>
 ) => {
-  const paths = resolveKimiManagedToolPaths(ctx.cwd)
+  const paths = resolveKimiManagedToolPaths(ctx.cwd, ctx.env)
   const manualInstallCommand = `${options.uvPath} tool install --python ${options.python} ${options.packageName}`
   return [
     'Install Kimi CLI with one of these options:',
@@ -110,8 +133,8 @@ const canRunCommand = async (binaryPath: string, args: string[], env?: NodeJS.Pr
 const canRunKimiBinary = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
 const canRunUvBinary = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
 
-const ensureManagedDirs = async (ctx: Pick<AdapterCtx, 'cwd'>) => {
-  const paths = resolveKimiManagedToolPaths(ctx.cwd)
+const ensureManagedDirs = async (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => {
+  const paths = resolveKimiManagedToolPaths(ctx.cwd, ctx.env)
   await mkdir(paths.binDir, { recursive: true })
   await mkdir(paths.toolDir, { recursive: true })
   await mkdir(paths.cacheDir, { recursive: true })
@@ -124,24 +147,32 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
 
   const adapterConfig = resolveAdapterConfig(ctx)
   const installOptions = resolveKimiCliInstallOptions(ctx.env, adapterConfig)
-  const explicitBinaryPath = normalizeNonEmptyString(ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__)
   const probeEnv = toProcessEnv({
     ...process.env,
     ...ctx.env
   })
 
-  if (explicitBinaryPath != null) {
-    if (await canRunKimiBinary(explicitBinaryPath, probeEnv)) return
-    throw new Error(`Configured Kimi CLI path is not executable: ${explicitBinaryPath}`)
+  if (installOptions.binaryPath != null) {
+    if (await canRunKimiBinary(installOptions.binaryPath, probeEnv)) {
+      ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = installOptions.binaryPath
+      return
+    }
+    throw new Error(`Configured Kimi CLI path is not executable: ${installOptions.binaryPath}`)
   }
 
-  const managedBinaryPath = resolveKimiManagedBinaryPath(ctx.cwd)
-  if (managedBinaryPath != null && await canRunKimiBinary(managedBinaryPath, probeEnv)) {
-    ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = managedBinaryPath
-    return
+  if (installOptions.source === 'path') {
+    throw new Error('Kimi CLI source is set to path, but no Kimi CLI path is configured.')
   }
 
-  if (await canRunKimiBinary('kimi', probeEnv)) {
+  if (installOptions.source !== 'system') {
+    const managedBinaryPath = resolveKimiManagedBinaryPath(ctx.cwd, ctx.env)
+    if (managedBinaryPath != null && await canRunKimiBinary(managedBinaryPath, probeEnv)) {
+      ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = managedBinaryPath
+      return
+    }
+  }
+
+  if (installOptions.source !== 'managed' && await canRunKimiBinary('kimi', probeEnv)) {
     ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = 'kimi'
     return
   }
@@ -164,7 +195,7 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
 
   await ensureManagedDirs(ctx)
   const installEnv = buildKimiCliInstallEnv(ctx)
-  ctx.logger.info(`Installing Kimi CLI into ${resolveKimiManagedToolPaths(ctx.cwd).binDir}`)
+  ctx.logger.info(`Installing Kimi CLI into ${resolveKimiManagedToolPaths(ctx.cwd, ctx.env).binDir}`)
   await execFileAsync(
     installOptions.uvPath,
     buildKimiCliInstallArgs(installOptions),
@@ -175,7 +206,7 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
     }
   )
 
-  const installedBinaryPath = resolveKimiManagedBinaryPath(ctx.cwd)
+  const installedBinaryPath = resolveKimiManagedBinaryPath(ctx.cwd, ctx.env)
   if (installedBinaryPath == null || !await canRunKimiBinary(installedBinaryPath, installEnv)) {
     throw new Error(
       `Kimi CLI installation completed, but the managed kimi binary could not be executed.\n\n${

--- a/packages/adapters/kimi/src/runtime/init.ts
+++ b/packages/adapters/kimi/src/runtime/init.ts
@@ -142,11 +142,16 @@ const ensureManagedDirs = async (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => {
   await mkdir(paths.pythonBinDir, { recursive: true })
 }
 
-export const initKimiAdapter = async (ctx: AdapterCtx) => {
-  prepareKimiNativeHooks(ctx)
-
+export const ensureKimiCli = async (
+  ctx: AdapterCtx,
+  options: { defaultSource?: 'managed' | 'system' | 'path' } = {}
+) => {
   const adapterConfig = resolveAdapterConfig(ctx)
-  const installOptions = resolveKimiCliInstallOptions(ctx.env, adapterConfig)
+  const resolvedInstallOptions = resolveKimiCliInstallOptions(ctx.env, adapterConfig)
+  const installOptions = {
+    ...resolvedInstallOptions,
+    source: resolvedInstallOptions.source ?? options.defaultSource
+  }
   const probeEnv = toProcessEnv({
     ...process.env,
     ...ctx.env
@@ -155,7 +160,7 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
   if (installOptions.binaryPath != null) {
     if (await canRunKimiBinary(installOptions.binaryPath, probeEnv)) {
       ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = installOptions.binaryPath
-      return
+      return installOptions.binaryPath
     }
     throw new Error(`Configured Kimi CLI path is not executable: ${installOptions.binaryPath}`)
   }
@@ -168,13 +173,13 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
     const managedBinaryPath = resolveKimiManagedBinaryPath(ctx.cwd, ctx.env)
     if (managedBinaryPath != null && await canRunKimiBinary(managedBinaryPath, probeEnv)) {
       ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = managedBinaryPath
-      return
+      return managedBinaryPath
     }
   }
 
   if (installOptions.source !== 'managed' && await canRunKimiBinary('kimi', probeEnv)) {
     ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = 'kimi'
-    return
+    return 'kimi'
   }
 
   if (!installOptions.autoInstall) {
@@ -216,4 +221,10 @@ export const initKimiAdapter = async (ctx: AdapterCtx) => {
   }
 
   ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_CLI_PATH__ = installedBinaryPath
+  return installedBinaryPath
+}
+
+export const initKimiAdapter = async (ctx: AdapterCtx) => {
+  prepareKimiNativeHooks(ctx)
+  await ensureKimiCli(ctx)
 }

--- a/packages/adapters/opencode/__tests__/runtime-common.spec.ts
+++ b/packages/adapters/opencode/__tests__/runtime-common.spec.ts
@@ -1,6 +1,12 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
-import { resolveOpenCodeBinaryPath } from '#~/paths.js'
+import { resolveManagedNpmCliPaths } from '@vibe-forge/utils/managed-npm-cli'
+
+import { OPENCODE_CLI_PACKAGE, OPENCODE_CLI_VERSION, resolveOpenCodeBinaryPath } from '#~/paths.js'
 import {
   buildOpenCodeRunArgs,
   buildOpenCodeSessionTitle,
@@ -12,14 +18,41 @@ import {
 } from '#~/runtime/common.js'
 
 describe('resolveOpenCodeBinaryPath', () => {
-  it('resolves to the adapter bundled binary by default', () => {
-    expect(resolveOpenCodeBinaryPath({})).toMatch(/node_modules\/\.bin\/opencode$/)
+  it('resolves to a usable default binary without requiring a bundled dependency', () => {
+    const result = resolveOpenCodeBinaryPath({})
+    expect(result === 'opencode' || /node_modules\/\.bin\/opencode$/.test(result)).toBe(true)
   })
 
   it('returns the env-specified path when set', () => {
     expect(resolveOpenCodeBinaryPath({
       __VF_PROJECT_AI_ADAPTER_OPENCODE_CLI_PATH__: '/usr/local/bin/opencode'
     })).toBe('/usr/local/bin/opencode')
+  })
+
+  it('uses a managed binary from the primary workspace shared cache', async () => {
+    const primary = await mkdtemp(join(tmpdir(), 'vf-opencode-primary-'))
+    const worktree = await mkdtemp(join(tmpdir(), 'vf-opencode-worktree-'))
+    try {
+      const env = {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+      }
+      const paths = resolveManagedNpmCliPaths({
+        adapterKey: 'opencode',
+        binaryName: 'opencode',
+        cwd: worktree,
+        env,
+        packageName: OPENCODE_CLI_PACKAGE,
+        version: OPENCODE_CLI_VERSION
+      })
+      await mkdir(paths.binDir, { recursive: true })
+      await writeFile(paths.binaryPath, '#!/bin/sh\n')
+      await chmod(paths.binaryPath, 0o755)
+
+      expect(resolveOpenCodeBinaryPath(env, worktree)).toBe(await realpath(paths.binaryPath))
+    } finally {
+      await rm(primary, { recursive: true, force: true })
+      await rm(worktree, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -68,7 +68,6 @@
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",
-    "opencode-ai": "1.3.2",
     "zod": "^3.24.1"
   }
 }

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -41,6 +41,15 @@
         "require": "./dist/config-schema.js"
       }
     },
+    "./cli-prepare": {
+      "__vibe-forge__": {
+        "default": "./src/cli-prepare.ts"
+      },
+      "default": {
+        "import": "./dist/cli-prepare.mjs",
+        "require": "./dist/cli-prepare.js"
+      }
+    },
     "./models": {
       "__vibe-forge__": {
         "default": "./src/models.ts"

--- a/packages/adapters/opencode/src/cli-prepare.ts
+++ b/packages/adapters/opencode/src/cli-prepare.ts
@@ -1,0 +1,40 @@
+import { defineAdapterCliPreparer } from '@vibe-forge/types'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
+
+import { OPENCODE_CLI_PACKAGE, OPENCODE_CLI_VERSION, resolveOpenCodeBinaryPath } from '#~/paths.js'
+import { resolveAdapterConfig } from '#~/runtime/session/shared.js'
+
+export default defineAdapterCliPreparer({
+  adapter: 'opencode',
+  title: 'OpenCode',
+  targets: [{
+    key: 'cli',
+    title: 'OpenCode CLI',
+    aliases: ['opencode'],
+    configPath: ['cli']
+  }],
+  prepare: async (ctx) => {
+    const adapterConfig = resolveAdapterConfig(ctx as Parameters<typeof resolveAdapterConfig>[0])
+    const binaryPath = await ensureManagedNpmCli({
+      adapterKey: 'opencode',
+      binaryName: 'opencode',
+      bundledPath: resolveOpenCodeBinaryPath(ctx.env, ctx.cwd, adapterConfig.native.cli),
+      config: {
+        ...adapterConfig.native.cli,
+        source: adapterConfig.native.cli?.source ?? 'managed'
+      },
+      cwd: ctx.cwd,
+      defaultPackageName: OPENCODE_CLI_PACKAGE,
+      defaultVersion: OPENCODE_CLI_VERSION,
+      env: ctx.env,
+      logger: ctx.logger
+    })
+
+    return {
+      adapter: 'opencode',
+      target: 'cli',
+      title: 'OpenCode CLI',
+      binaryPath
+    }
+  }
+})

--- a/packages/adapters/opencode/src/config-schema.ts
+++ b/packages/adapters/opencode/src/config-schema.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod'
 
-import { defineAdapterConfigContribution, effortLevelSchema, jsonValueSchema } from '@vibe-forge/core/config-schema'
+import {
+  adapterNativeCliConfigSchema,
+  defineAdapterConfigContribution,
+  effortLevelSchema,
+  jsonValueSchema
+} from '@vibe-forge/core/config-schema'
 
 export const openCodeAdapterConfigSchema = z.object({
+  cli: adapterNativeCliConfigSchema.optional().describe('Managed OpenCode CLI runtime'),
   effort: effortLevelSchema.optional().describe('Reasoning effort level'),
   agent: z.string().optional().describe('Default agent name'),
   planAgent: z.union([z.string(), z.literal(false)]).optional().describe('Plan agent override'),
@@ -23,6 +29,6 @@ export const adapterConfigContribution = defineAdapterConfigContribution({
   schema: openCodeAdapterConfigSchema,
   configEntry: {
     extraCommonKeys: ['effort'] as const,
-    deepMergeKeys: ['configContent'] as const
+    deepMergeKeys: ['cli', 'configContent'] as const
   }
 })

--- a/packages/adapters/opencode/src/paths.ts
+++ b/packages/adapters/opencode/src/paths.ts
@@ -3,9 +3,15 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import type { ManagedNpmCliConfig } from '@vibe-forge/utils/managed-npm-cli'
+import { resolveManagedNpmCliBinaryPath } from '@vibe-forge/utils/managed-npm-cli'
 
 const require = createRequire(import.meta.url ?? __filename)
 const adapterPackageDir = dirname(require.resolve('@vibe-forge/adapter-opencode/package.json'))
+const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/opencode')
+
+export const OPENCODE_CLI_PACKAGE = 'opencode-ai'
+export const OPENCODE_CLI_VERSION = '1.14.18'
 
 export const toRealPath = (targetPath: string) => {
   try {
@@ -15,16 +21,24 @@ export const toRealPath = (targetPath: string) => {
   }
 }
 
-export const resolveOpenCodeBinaryPath = (env: AdapterCtx['env']): string => {
+export const resolveOpenCodeBinaryPath = (
+  env: AdapterCtx['env'],
+  cwd?: string,
+  config?: ManagedNpmCliConfig
+): string => {
   const envPath = env.__VF_PROJECT_AI_ADAPTER_OPENCODE_CLI_PATH__
   if (typeof envPath === 'string' && envPath.trim() !== '') {
     return envPath
   }
 
-  const bundledPath = resolve(adapterPackageDir, 'node_modules/.bin/opencode')
-  if (existsSync(bundledPath)) {
-    return toRealPath(bundledPath)
-  }
-
-  return 'opencode'
+  return resolveManagedNpmCliBinaryPath({
+    adapterKey: 'opencode',
+    binaryName: 'opencode',
+    bundledPath: existsSync(bundledPath) ? toRealPath(bundledPath) : undefined,
+    config,
+    cwd,
+    defaultPackageName: OPENCODE_CLI_PACKAGE,
+    defaultVersion: OPENCODE_CLI_VERSION,
+    env
+  })
 }

--- a/packages/adapters/opencode/src/runtime/init.ts
+++ b/packages/adapters/opencode/src/runtime/init.ts
@@ -1,15 +1,13 @@
-import { execFile } from 'node:child_process'
 import { join } from 'node:path'
 import process from 'node:process'
-import { promisify } from 'node:util'
 
 import type { AdapterCtx } from '@vibe-forge/types'
 import { syncSymlinkTarget } from '@vibe-forge/utils'
+import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
-import { resolveOpenCodeBinaryPath } from '#~/paths.js'
+import { OPENCODE_CLI_PACKAGE, OPENCODE_CLI_VERSION, resolveOpenCodeBinaryPath } from '#~/paths.js'
 import { ensureOpenCodeNativeHooksInstalled } from './native-hooks'
-
-const execFileAsync = promisify(execFile)
+import { resolveAdapterConfig } from './session/shared'
 
 const ensureSymlink = async (sourcePath: string, targetPath: string) => {
   await syncSymlinkTarget({
@@ -19,12 +17,18 @@ const ensureSymlink = async (sourcePath: string, targetPath: string) => {
 }
 
 export const initOpenCodeAdapter = async (ctx: AdapterCtx) => {
-  const binaryPath = resolveOpenCodeBinaryPath(ctx.env)
-
-  try {
-    await execFileAsync(binaryPath, ['--version'])
-  } catch {
-  }
+  const adapterConfig = resolveAdapterConfig(ctx)
+  ctx.env.__VF_PROJECT_AI_ADAPTER_OPENCODE_CLI_PATH__ = await ensureManagedNpmCli({
+    adapterKey: 'opencode',
+    binaryName: 'opencode',
+    bundledPath: resolveOpenCodeBinaryPath(ctx.env, ctx.cwd, adapterConfig.native.cli),
+    config: adapterConfig.native.cli,
+    cwd: ctx.cwd,
+    defaultPackageName: OPENCODE_CLI_PACKAGE,
+    defaultVersion: OPENCODE_CLI_VERSION,
+    env: ctx.env,
+    logger: ctx.logger
+  })
 
   const realHome = process.env.__VF_PROJECT_REAL_HOME__
   const aiHome = process.env.HOME

--- a/packages/adapters/opencode/src/runtime/session/direct.ts
+++ b/packages/adapters/opencode/src/runtime/session/direct.ts
@@ -23,7 +23,7 @@ export const createDirectOpenCodeSession = async (
     planAgent: adapterConfig.native.planAgent,
     permissionMode: options.permissionMode
   })
-  const binaryPath = resolveOpenCodeBinaryPath(ctx.env)
+  const binaryPath = resolveOpenCodeBinaryPath(ctx.env, ctx.cwd, adapterConfig.native.cli)
   const title = buildOpenCodeSessionTitle(options.sessionId, adapterConfig.native.titlePrefix)
   const cachedSession = options.type === 'resume' ? await ctx.cache.get('adapter.opencode.session') : undefined
   const systemPromptFile = await ensureSystemPromptFile(ctx, options)

--- a/packages/adapters/opencode/src/runtime/session/stream.ts
+++ b/packages/adapters/opencode/src/runtime/session/stream.ts
@@ -37,7 +37,7 @@ export const createStreamOpenCodeSession = async (
     planAgent: adapterConfig.native.planAgent,
     permissionMode: options.permissionMode
   })
-  const binaryPath = resolveOpenCodeBinaryPath(ctx.env)
+  const binaryPath = resolveOpenCodeBinaryPath(ctx.env, ctx.cwd, adapterConfig.native.cli)
   const title = buildOpenCodeSessionTitle(options.sessionId, adapterConfig.native.titlePrefix)
   const systemPromptFile = await ensureSystemPromptFile(ctx, options)
   const childEnv = await buildChildEnv({ ctx, options, adapterConfig, systemPromptFile })

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -66,6 +66,7 @@ export const adapterNativeCliConfigSchema = z.object({
   package: z.string().optional().describe('Managed npm package name'),
   version: z.string().optional().describe('Managed npm package version'),
   autoInstall: z.boolean().optional().describe('Install the managed CLI when no usable binary is found'),
+  prepareOnInstall: z.boolean().optional().describe('Preinstall this managed CLI during Vibe Forge package install'),
   npmPath: z.string().optional().describe('npm binary used for managed installs')
 })
 

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -60,6 +60,15 @@ export const adapterConfigCommonSchema = z.object({
   excludeModels: z.array(z.string()).optional().describe('Blocked model IDs for this adapter')
 })
 
+export const adapterNativeCliConfigSchema = z.object({
+  source: z.enum(['managed', 'system', 'path']).optional().describe('Native CLI source'),
+  path: z.string().optional().describe('Native CLI binary path when source is path'),
+  package: z.string().optional().describe('Managed npm package name'),
+  version: z.string().optional().describe('Managed npm package version'),
+  autoInstall: z.boolean().optional().describe('Install the managed CLI when no usable binary is found'),
+  npmPath: z.string().optional().describe('npm binary used for managed installs')
+})
+
 export const modelServiceConfigSchema = z.object({
   title: z.string().optional().describe('Display title'),
   description: z.string().optional().describe('Display description'),

--- a/packages/types/src/adapter-cli-prepare.ts
+++ b/packages/types/src/adapter-cli-prepare.ts
@@ -1,0 +1,39 @@
+import type { AdapterConfigState, AdapterCtx } from './adapter'
+
+export interface AdapterCliPrepareTarget {
+  key: string
+  title: string
+  aliases?: string[]
+  configPath?: string[]
+}
+
+export interface AdapterCliPrepareContext {
+  cwd: string
+  env: AdapterCtx['env']
+  configs: AdapterCtx['configs']
+  configState?: AdapterConfigState
+  logger: Pick<AdapterCtx['logger'], 'info'>
+}
+
+export interface AdapterCliPrepareOptions {
+  target: string
+}
+
+export interface AdapterCliPrepareResult {
+  adapter: string
+  target: string
+  title: string
+  binaryPath: string
+}
+
+export interface AdapterCliPreparer {
+  adapter: string
+  title?: string
+  targets: AdapterCliPrepareTarget[]
+  prepare: (
+    ctx: AdapterCliPrepareContext,
+    options: AdapterCliPrepareOptions
+  ) => Promise<AdapterCliPrepareResult>
+}
+
+export const defineAdapterCliPreparer = <T extends AdapterCliPreparer>(preparer: T) => preparer

--- a/packages/types/src/adapter-package.ts
+++ b/packages/types/src/adapter-package.ts
@@ -1,10 +1,12 @@
 import { dirname, join } from 'node:path'
 
 import type { Adapter } from './adapter'
+import type { AdapterCliPreparer } from './adapter-cli-prepare'
 import type { AdapterPluginInstaller } from './native-plugin'
 
 const ADAPTER_SCOPE = '@vibe-forge'
 const ADAPTER_PREFIX = 'adapter-'
+const ADAPTER_CLI_PREPARE_EXPORT = '/cli-prepare'
 const ADAPTER_PLUGIN_EXPORT = '/plugins'
 
 const loadWorkspacePackageExport = (params: {
@@ -81,6 +83,34 @@ export const loadAdapterPluginInstaller = async (type: string) => {
         packageName,
         sourcePath: 'src/plugins/index.ts'
       }).default as AdapterPluginInstaller
+    }
+    throw error
+  }
+}
+
+export const loadAdapterCliPreparer = async (type: string) => {
+  const packageName = resolveAdapterPackageName(type)
+  const exportName = `${packageName}${ADAPTER_CLI_PREPARE_EXPORT}`
+
+  try {
+    return (
+      // eslint-disable-next-line ts/no-require-imports
+      require(exportName)
+    ).default as AdapterCliPreparer
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code
+    const message = error instanceof Error ? error.message : String(error)
+    if (
+      code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' ||
+      (code === 'MODULE_NOT_FOUND' && message.includes(exportName))
+    ) {
+      throw new Error(`Adapter ${type} does not support CLI preparation.`)
+    }
+    if (code === 'MODULE_NOT_FOUND' && message.includes('/dist/')) {
+      return loadWorkspacePackageExport({
+        packageName,
+        sourcePath: 'src/cli-prepare.ts'
+      }).default as AdapterCliPreparer
     }
     throw error
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapter'
+export * from './adapter-cli-prepare'
 export * from './adapter-package'
 export * from './benchmark'
 export * from './cache'

--- a/packages/utils/__tests__/managed-npm-cli.spec.ts
+++ b/packages/utils/__tests__/managed-npm-cli.spec.ts
@@ -1,6 +1,11 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
+  ensureManagedNpmCli,
   resolveManagedNpmCliBinaryPath,
   resolveManagedNpmCliInstallOptions,
   resolveManagedNpmCliPaths
@@ -58,5 +63,63 @@ describe('managed npm cli utils', () => {
     })).toBe(
       '/tmp/primary/.ai/caches/adapter-opencode/cli/npm/opencode-ai/1.14.18/node_modules/.bin/opencode'
     )
+  })
+
+  it('supports CLIs that use custom version arguments for managed install validation', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'vf-managed-npm-cli-'))
+    const npmPath = join(workspace, 'npm')
+    await writeFile(
+      npmPath,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "10.0.0"
+  exit 0
+fi
+
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    shift
+    prefix="$1"
+  fi
+  shift
+done
+
+if [ -z "$prefix" ]; then
+  exit 2
+fi
+
+mkdir -p "$prefix/node_modules/.bin"
+tool="$prefix/node_modules/.bin/tool"
+{
+  printf '%s\\n' '#!/bin/sh'
+  printf '%s\\n' 'if [ "$1" = "version" ]; then echo "tool 1.0.0"; exit 0; fi'
+  printf '%s\\n' 'exit 42'
+} > "$tool"
+chmod +x "$tool"
+`
+    )
+    await chmod(npmPath, 0o755)
+
+    try {
+      const binaryPath = await ensureManagedNpmCli({
+        adapterKey: 'custom_tool',
+        binaryName: 'tool',
+        cwd: workspace,
+        defaultPackageName: '@example/tool',
+        defaultVersion: '1.0.0',
+        env: {
+          __VF_PROJECT_AI_ADAPTER_CUSTOM_TOOL_NPM_PATH__: npmPath
+        },
+        logger: {
+          info: () => undefined
+        },
+        versionArgs: ['version']
+      })
+
+      expect(binaryPath.endsWith('/node_modules/.bin/tool')).toBe(true)
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/utils/__tests__/managed-npm-cli.spec.ts
+++ b/packages/utils/__tests__/managed-npm-cli.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveManagedNpmCliBinaryPath,
+  resolveManagedNpmCliInstallOptions,
+  resolveManagedNpmCliPaths
+} from '#~/managed-npm-cli.js'
+
+describe('managed npm cli utils', () => {
+  it('resolves managed CLI paths from the primary workspace shared cache', () => {
+    const paths = resolveManagedNpmCliPaths({
+      adapterKey: 'codex',
+      binaryName: 'codex',
+      cwd: '/tmp/worktree',
+      env: {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: '/tmp/primary'
+      },
+      packageName: '@openai/codex',
+      version: '0.121.0'
+    })
+
+    expect(paths.binaryPath).toBe(
+      '/tmp/primary/.ai/caches/adapter-codex/cli/npm/openai-codex/0.121.0/node_modules/.bin/codex'
+    )
+  })
+
+  it('uses env version and package overrides when building install options', () => {
+    expect(resolveManagedNpmCliInstallOptions({
+      adapterKey: 'gemini',
+      defaultPackageName: '@google/gemini-cli',
+      defaultVersion: '0.38.2',
+      env: {
+        __VF_PROJECT_AI_ADAPTER_GEMINI_INSTALL_PACKAGE__: '@example/gemini',
+        __VF_PROJECT_AI_ADAPTER_GEMINI_INSTALL_VERSION__: '1.2.3',
+        __VF_PROJECT_AI_ADAPTER_GEMINI_CLI_SOURCE__: 'managed',
+        __VF_PROJECT_AI_ADAPTER_GEMINI_NPM_PATH__: '/opt/npm'
+      }
+    })).toMatchObject({
+      npmPath: '/opt/npm',
+      packageName: '@example/gemini',
+      packageSpec: '@example/gemini@1.2.3',
+      source: 'managed',
+      version: '1.2.3'
+    })
+  })
+
+  it('returns the managed candidate path when source is forced to managed', () => {
+    expect(resolveManagedNpmCliBinaryPath({
+      adapterKey: 'opencode',
+      binaryName: 'opencode',
+      cwd: '/tmp/worktree',
+      defaultPackageName: 'opencode-ai',
+      defaultVersion: '1.14.18',
+      env: {
+        __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: '/tmp/primary',
+        __VF_PROJECT_AI_ADAPTER_OPENCODE_CLI_SOURCE__: 'managed'
+      }
+    })).toBe(
+      '/tmp/primary/.ai/caches/adapter-opencode/cli/npm/opencode-ai/1.14.18/node_modules/.bin/opencode'
+    )
+  })
+})

--- a/packages/utils/__tests__/project-cache-path.spec.ts
+++ b/packages/utils/__tests__/project-cache-path.spec.ts
@@ -1,0 +1,85 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { resolveProjectAiPath } from '#~/ai-path.js'
+import {
+  resolveProjectSharedCacheDir,
+  resolveProjectSharedCachePath,
+  resolveProjectSharedWorkspaceFolder
+} from '#~/project-cache-path.js'
+
+const tempDirs: string[] = []
+const hasGit = spawnSync('git', ['--version']).status === 0
+
+const createTempDir = async (prefix: string) => {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+const runGit = (cwd: string, args: string[]) => {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe'
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('project shared cache path utils', () => {
+  it('uses the explicit primary workspace for shared cache paths', async () => {
+    const primary = await createTempDir('vf-cache-primary-')
+    const worktree = await createTempDir('vf-cache-worktree-')
+    const env = {
+      __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary
+    }
+
+    expect(resolveProjectSharedWorkspaceFolder(worktree, env)).toBe(primary)
+    expect(resolveProjectSharedCacheDir(worktree, env)).toBe(join(primary, '.ai', 'caches'))
+    expect(resolveProjectSharedCachePath(worktree, env, 'adapter-kimi', 'cli'))
+      .toBe(join(primary, '.ai', 'caches', 'adapter-kimi', 'cli'))
+    expect(resolveProjectAiPath(worktree, {}, 'caches')).toBe(join(worktree, '.ai', 'caches'))
+  })
+
+  it('lets an explicit shared cache dir override primary workspace resolution', async () => {
+    const primary = await createTempDir('vf-cache-primary-')
+    const worktree = await createTempDir('vf-cache-worktree-')
+    const env = {
+      __VF_PROJECT_LAUNCH_CWD__: worktree,
+      __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primary,
+      __VF_PROJECT_AI_CACHE_DIR__: 'shared-cache'
+    }
+
+    expect(resolveProjectSharedCacheDir(worktree, env)).toBe(join(worktree, 'shared-cache'))
+  })
+
+  it.skipIf(!hasGit)('detects a git worktree primary workspace without env hints', async () => {
+    const primary = await createTempDir('vf-cache-git-primary-')
+    const worktreeRoot = await createTempDir('vf-cache-git-worktrees-')
+    const worktree = join(worktreeRoot, 'repo-worktree')
+
+    runGit(primary, ['init'])
+    await writeFile(join(primary, 'README.md'), 'hello\n', 'utf8')
+    runGit(primary, ['add', 'README.md'])
+    runGit(primary, [
+      '-c',
+      'user.email=vf@example.test',
+      '-c',
+      'user.name=Vibe Forge',
+      'commit',
+      '-m',
+      'init'
+    ])
+    runGit(primary, ['worktree', 'add', '--detach', worktree, 'HEAD'])
+
+    const realPrimary = await realpath(primary)
+    expect(resolveProjectSharedWorkspaceFolder(worktree, {})).toBe(realPrimary)
+    expect(resolveProjectSharedCacheDir(worktree, {})).toBe(join(realPrimary, '.ai', 'caches'))
+  })
+})

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -86,6 +86,15 @@
         "require": "./dist/model-selection.js"
       }
     },
+    "./managed-npm-cli": {
+      "__vibe-forge__": {
+        "default": "./src/managed-npm-cli.ts"
+      },
+      "default": {
+        "import": "./dist/managed-npm-cli.mjs",
+        "require": "./dist/managed-npm-cli.js"
+      }
+    },
     "./plugin-resolver": {
       "__vibe-forge__": {
         "default": "./src/plugin-resolver.ts"
@@ -93,6 +102,15 @@
       "default": {
         "import": "./dist/plugin-resolver.mjs",
         "require": "./dist/plugin-resolver.js"
+      }
+    },
+    "./project-cache-path": {
+      "__vibe-forge__": {
+        "default": "./src/project-cache-path.ts"
+      },
+      "default": {
+        "import": "./dist/project-cache-path.mjs",
+        "require": "./dist/project-cache-path.js"
       }
     },
     "./string-transform": {

--- a/packages/utils/src/managed-npm-cli.ts
+++ b/packages/utils/src/managed-npm-cli.ts
@@ -16,6 +16,7 @@ export interface ManagedNpmCliConfig {
   package?: string
   version?: string
   autoInstall?: boolean
+  prepareOnInstall?: boolean
   npmPath?: string
 }
 

--- a/packages/utils/src/managed-npm-cli.ts
+++ b/packages/utils/src/managed-npm-cli.ts
@@ -1,0 +1,333 @@
+/* eslint-disable max-lines -- shared managed CLI resolver intentionally centralizes install policy. */
+import { execFile } from 'node:child_process'
+import { existsSync, realpathSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import process from 'node:process'
+import { promisify } from 'node:util'
+
+import type { Logger } from '@vibe-forge/types'
+
+import { resolveProjectSharedCachePath } from './project-cache-path'
+
+export interface ManagedNpmCliConfig {
+  source?: 'managed' | 'system' | 'path'
+  path?: string
+  package?: string
+  version?: string
+  autoInstall?: boolean
+  npmPath?: string
+}
+
+export interface ManagedNpmCliInstallOptions {
+  autoInstall: boolean
+  npmPath: string
+  packageName: string
+  packageSpec: string
+  source?: 'managed' | 'system' | 'path'
+  version: string
+}
+
+export interface ManagedNpmCliPaths {
+  rootDir: string
+  installDir: string
+  cacheDir: string
+  binDir: string
+  binaryPath: string
+}
+
+interface ResolveManagedNpmCliOptionsParams {
+  adapterKey: string
+  defaultPackageName: string
+  defaultVersion: string
+  env: Record<string, string | null | undefined>
+  config?: ManagedNpmCliConfig
+}
+
+interface ResolveManagedNpmCliPathParams extends ResolveManagedNpmCliOptionsParams {
+  binaryName: string
+  bundledPath?: string
+  cwd?: string
+  configuredPath?: string
+}
+
+interface EnsureManagedNpmCliParams extends ResolveManagedNpmCliPathParams {
+  cwd: string
+  logger: Pick<Logger, 'info'>
+}
+
+const execFileAsync = promisify(execFile)
+const COMMAND_CHECK_TIMEOUT_MS = 15000
+
+const normalizeNonEmptyString = (value: unknown) => (
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+)
+
+const isFalseLike = (value: string) => ['0', 'false', 'no', 'off'].includes(value.trim().toLowerCase())
+
+const normalizeAdapterEnvPrefix = (adapterKey: string) => (
+  `__VF_PROJECT_AI_ADAPTER_${adapterKey.replace(/[^a-z0-9]+/giu, '_').toUpperCase()}`
+)
+
+const normalizeSource = (value: unknown): ManagedNpmCliInstallOptions['source'] => (
+  value === 'managed' || value === 'system' || value === 'path' ? value : undefined
+)
+
+const toCacheSegment = (value: string) => (
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'cli'
+)
+
+const hasExplicitPackageVersion = (packageName: string) => {
+  const lastAt = packageName.lastIndexOf('@')
+  if (!packageName.startsWith('@')) return lastAt > 0
+  const slash = packageName.indexOf('/')
+  return slash > 0 && lastAt > slash
+}
+
+const toPackageSpec = (packageName: string, version: string) => (
+  hasExplicitPackageVersion(packageName) ? packageName : `${packageName}@${version}`
+)
+
+const toRealPath = (targetPath: string) => {
+  try {
+    return realpathSync(targetPath)
+  } catch {
+    return targetPath
+  }
+}
+
+const canRunCommand = async (binaryPath: string, args: string[], env?: NodeJS.ProcessEnv) => {
+  try {
+    await execFileAsync(binaryPath, args, { env, timeout: COMMAND_CHECK_TIMEOUT_MS })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const canRunBinary = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
+const canRunNpm = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
+
+export const resolveManagedNpmCliInstallOptions = (
+  params: ResolveManagedNpmCliOptionsParams
+): ManagedNpmCliInstallOptions => {
+  const envPrefix = normalizeAdapterEnvPrefix(params.adapterKey)
+  const rawAutoInstall = normalizeNonEmptyString(params.env[`${envPrefix}_AUTO_INSTALL__`])
+  const packageName = normalizeNonEmptyString(params.env[`${envPrefix}_INSTALL_PACKAGE__`]) ??
+    normalizeNonEmptyString(params.config?.package) ??
+    params.defaultPackageName
+  const version = normalizeNonEmptyString(params.env[`${envPrefix}_INSTALL_VERSION__`]) ??
+    normalizeNonEmptyString(params.config?.version) ??
+    params.defaultVersion
+
+  return {
+    autoInstall: rawAutoInstall == null
+      ? params.config?.autoInstall !== false
+      : !isFalseLike(rawAutoInstall),
+    npmPath: normalizeNonEmptyString(params.env[`${envPrefix}_NPM_PATH__`]) ??
+      normalizeNonEmptyString(params.config?.npmPath) ??
+      'npm',
+    packageName,
+    packageSpec: toPackageSpec(packageName, version),
+    source: normalizeSource(params.env[`${envPrefix}_CLI_SOURCE__`]) ?? normalizeSource(params.config?.source),
+    version
+  }
+}
+
+export const resolveManagedNpmCliPaths = (params: {
+  adapterKey: string
+  binaryName: string
+  cwd: string
+  env: Record<string, string | null | undefined>
+  packageName: string
+  version: string
+}): ManagedNpmCliPaths => {
+  const rootDir = resolveProjectSharedCachePath(params.cwd, params.env, `adapter-${params.adapterKey}`, 'cli', 'npm')
+  const installDir = resolve(rootDir, toCacheSegment(params.packageName), toCacheSegment(params.version))
+  const binDir = resolve(installDir, 'node_modules', '.bin')
+  return {
+    rootDir,
+    installDir,
+    cacheDir: resolve(rootDir, '.npm-cache'),
+    binDir,
+    binaryPath: resolve(binDir, params.binaryName)
+  }
+}
+
+export const resolveManagedNpmCliBinaryPath = (params: ResolveManagedNpmCliPathParams) => {
+  const envPrefix = normalizeAdapterEnvPrefix(params.adapterKey)
+  const installOptions = resolveManagedNpmCliInstallOptions(params)
+  const explicitPath = normalizeNonEmptyString(params.env[`${envPrefix}_CLI_PATH__`]) ??
+    normalizeNonEmptyString(params.configuredPath) ??
+    normalizeNonEmptyString(params.config?.path)
+
+  if (explicitPath != null) return explicitPath
+  if (installOptions.source === 'system') return params.binaryName
+
+  if (params.cwd != null && params.cwd.trim() !== '') {
+    const paths = resolveManagedNpmCliPaths({
+      adapterKey: params.adapterKey,
+      binaryName: params.binaryName,
+      cwd: params.cwd,
+      env: params.env,
+      packageName: installOptions.packageName,
+      version: installOptions.version
+    })
+    if (existsSync(paths.binaryPath) || installOptions.source === 'managed') {
+      return toRealPath(paths.binaryPath)
+    }
+  }
+
+  if (installOptions.source !== 'managed' && params.bundledPath != null && existsSync(params.bundledPath)) {
+    return toRealPath(params.bundledPath)
+  }
+
+  return params.binaryName
+}
+
+export const buildManagedNpmCliInstallEnv = (params: {
+  cwd: string
+  env: Record<string, string | null | undefined>
+  paths: ManagedNpmCliPaths
+}) => ({
+  ...process.env,
+  ...Object.fromEntries(
+    Object.entries(params.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  ),
+  npm_config_cache: params.paths.cacheDir
+})
+
+export const buildManagedNpmCliInstallInstructions = (params: {
+  adapterKey: string
+  binaryName: string
+  options: ManagedNpmCliInstallOptions
+  paths: ManagedNpmCliPaths
+}) =>
+  [
+    `Install ${params.binaryName} CLI with one of these options:`,
+    '',
+    '1. Let Vibe Forge install the managed CLI into the workspace cache:',
+    `   ${params.options.npmPath} install --prefix ${params.paths.installDir} --no-save ${params.options.packageSpec}`,
+    '',
+    '2. Install it yourself and point Vibe Forge at the binary:',
+    `   __VF_PROJECT_AI_ADAPTER_${
+      params.adapterKey.replace(/[^a-z0-9]+/giu, '_').toUpperCase()
+    }_CLI_PATH__=/absolute/path/to/${params.binaryName}`,
+    '',
+    `Managed ${params.binaryName} bin dir: ${params.paths.binDir}`
+  ].join('\n')
+
+export const ensureManagedNpmCli = async (params: EnsureManagedNpmCliParams) => {
+  const installOptions = resolveManagedNpmCliInstallOptions(params)
+  const paths = resolveManagedNpmCliPaths({
+    adapterKey: params.adapterKey,
+    binaryName: params.binaryName,
+    cwd: params.cwd,
+    env: params.env,
+    packageName: installOptions.packageName,
+    version: installOptions.version
+  })
+  const probeEnv = {
+    ...process.env,
+    ...Object.fromEntries(
+      Object.entries(params.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    )
+  }
+  const explicitPath = resolveManagedNpmCliBinaryPath({
+    ...params,
+    config: {
+      ...params.config,
+      source: params.config?.source === 'path' ? 'path' : undefined
+    }
+  })
+
+  if (explicitPath !== params.binaryName && explicitPath !== toRealPath(paths.binaryPath)) {
+    return explicitPath
+  }
+
+  if (existsSync(paths.binaryPath) && await canRunBinary(paths.binaryPath, probeEnv)) {
+    return toRealPath(paths.binaryPath)
+  }
+
+  if (
+    installOptions.source !== 'managed' && params.bundledPath != null &&
+    await canRunBinary(params.bundledPath, probeEnv)
+  ) {
+    return toRealPath(params.bundledPath)
+  }
+
+  if (installOptions.source !== 'managed' && await canRunBinary(params.binaryName, probeEnv)) {
+    return params.binaryName
+  }
+
+  if (!installOptions.autoInstall) {
+    throw new Error(
+      `${params.binaryName} CLI was not found and automatic install is disabled.\n\n${
+        buildManagedNpmCliInstallInstructions({
+          adapterKey: params.adapterKey,
+          binaryName: params.binaryName,
+          options: installOptions,
+          paths
+        })
+      }`
+    )
+  }
+
+  if (!await canRunNpm(installOptions.npmPath, probeEnv)) {
+    throw new Error(
+      `${params.binaryName} CLI was not found, and npm is required for automatic install.\n\n${
+        buildManagedNpmCliInstallInstructions({
+          adapterKey: params.adapterKey,
+          binaryName: params.binaryName,
+          options: installOptions,
+          paths
+        })
+      }`
+    )
+  }
+
+  await mkdir(paths.installDir, { recursive: true })
+  await mkdir(paths.cacheDir, { recursive: true })
+  const installEnv = buildManagedNpmCliInstallEnv({
+    cwd: params.cwd,
+    env: params.env,
+    paths
+  })
+  params.logger.info(`Installing ${params.binaryName} CLI into ${paths.installDir}`)
+  await execFileAsync(
+    installOptions.npmPath,
+    [
+      'install',
+      '--prefix',
+      paths.installDir,
+      '--no-save',
+      '--no-audit',
+      '--no-fund',
+      installOptions.packageSpec
+    ],
+    {
+      cwd: params.cwd,
+      env: installEnv,
+      maxBuffer: 1024 * 1024 * 10
+    }
+  )
+
+  if (!await canRunBinary(paths.binaryPath, installEnv)) {
+    throw new Error(
+      `${params.binaryName} CLI installation completed, but the managed binary could not be executed.\n\n${
+        buildManagedNpmCliInstallInstructions({
+          adapterKey: params.adapterKey,
+          binaryName: params.binaryName,
+          options: installOptions,
+          paths
+        })
+      }`
+    )
+  }
+
+  return toRealPath(paths.binaryPath)
+}

--- a/packages/utils/src/managed-npm-cli.ts
+++ b/packages/utils/src/managed-npm-cli.ts
@@ -49,6 +49,7 @@ interface ResolveManagedNpmCliPathParams extends ResolveManagedNpmCliOptionsPara
   bundledPath?: string
   cwd?: string
   configuredPath?: string
+  versionArgs?: string[]
 }
 
 interface EnsureManagedNpmCliParams extends ResolveManagedNpmCliPathParams {
@@ -109,7 +110,12 @@ const canRunCommand = async (binaryPath: string, args: string[], env?: NodeJS.Pr
   }
 }
 
-const canRunBinary = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
+const normalizeVersionArgs = (versionArgs: string[] | undefined) => (
+  versionArgs == null || versionArgs.length === 0 ? ['--version'] : versionArgs
+)
+
+const canRunBinary = (binaryPath: string, versionArgs: string[] | undefined, env?: NodeJS.ProcessEnv) =>
+  canRunCommand(binaryPath, normalizeVersionArgs(versionArgs), env)
 const canRunNpm = (binaryPath: string, env?: NodeJS.ProcessEnv) => canRunCommand(binaryPath, ['--version'], env)
 
 export const resolveManagedNpmCliInstallOptions = (
@@ -249,18 +255,18 @@ export const ensureManagedNpmCli = async (params: EnsureManagedNpmCliParams) => 
     return explicitPath
   }
 
-  if (existsSync(paths.binaryPath) && await canRunBinary(paths.binaryPath, probeEnv)) {
+  if (existsSync(paths.binaryPath) && await canRunBinary(paths.binaryPath, params.versionArgs, probeEnv)) {
     return toRealPath(paths.binaryPath)
   }
 
   if (
     installOptions.source !== 'managed' && params.bundledPath != null &&
-    await canRunBinary(params.bundledPath, probeEnv)
+    await canRunBinary(params.bundledPath, params.versionArgs, probeEnv)
   ) {
     return toRealPath(params.bundledPath)
   }
 
-  if (installOptions.source !== 'managed' && await canRunBinary(params.binaryName, probeEnv)) {
+  if (installOptions.source !== 'managed' && await canRunBinary(params.binaryName, params.versionArgs, probeEnv)) {
     return params.binaryName
   }
 
@@ -316,7 +322,7 @@ export const ensureManagedNpmCli = async (params: EnsureManagedNpmCliParams) => 
     }
   )
 
-  if (!await canRunBinary(paths.binaryPath, installEnv)) {
+  if (!await canRunBinary(paths.binaryPath, params.versionArgs, installEnv)) {
     throw new Error(
       `${params.binaryName} CLI installation completed, but the managed binary could not be executed.\n\n${
         buildManagedNpmCliInstallInstructions({

--- a/packages/utils/src/project-cache-path.ts
+++ b/packages/utils/src/project-cache-path.ts
@@ -36,10 +36,17 @@ const resolvePathFromBase = (
 }
 
 const resolveGitPrimaryWorkspaceFolder = (cwd: string) => {
-  const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
-    cwd,
-    encoding: 'utf8'
-  })
+  const result = (() => {
+    try {
+      return spawnSync('git', ['rev-parse', '--git-common-dir'], {
+        cwd,
+        encoding: 'utf8'
+      })
+    } catch {
+      return undefined
+    }
+  })()
+  if (result == null) return undefined
   if (result.status !== 0) return undefined
 
   const gitCommonDir = result.stdout?.trim()

--- a/packages/utils/src/project-cache-path.ts
+++ b/packages/utils/src/project-cache-path.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, isAbsolute, resolve } from 'node:path'
+import process from 'node:process'
+
+import {
+  PROJECT_LAUNCH_CWD_ENV,
+  PROJECT_WORKSPACE_FOLDER_ENV,
+  resolveProjectAiBaseDir,
+  resolveProjectLaunchCwd,
+  resolveProjectWorkspaceFolder
+} from './ai-path'
+
+export const PROJECT_PRIMARY_WORKSPACE_FOLDER_ENV = '__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__'
+export const PROJECT_AI_CACHE_DIR_ENV = '__VF_PROJECT_AI_CACHE_DIR__'
+
+const normalizeDirPath = (value: string | null | undefined) => {
+  const trimmed = value?.trim()
+  if (trimmed == null || trimmed === '') return undefined
+  return trimmed.replace(/[\\/]+$/, '')
+}
+
+const resolvePathFromBase = (
+  baseDir: string,
+  value: string | null | undefined
+) => {
+  const normalizedValue = normalizeDirPath(value)
+  if (normalizedValue == null) {
+    return undefined
+  }
+
+  if (isAbsolute(normalizedValue)) {
+    return resolve(normalizedValue)
+  }
+
+  return resolve(baseDir, normalizedValue)
+}
+
+const resolveGitPrimaryWorkspaceFolder = (cwd: string) => {
+  const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
+    cwd,
+    encoding: 'utf8'
+  })
+  if (result.status !== 0) return undefined
+
+  const gitCommonDir = result.stdout?.trim()
+  if (gitCommonDir == null || gitCommonDir === '') return undefined
+
+  const workspaceFolder = resolve(cwd)
+  const primaryWorkspaceFolder = dirname(resolve(cwd, gitCommonDir))
+  return primaryWorkspaceFolder === workspaceFolder ? undefined : primaryWorkspaceFolder
+}
+
+export const resolveProjectPrimaryWorkspaceFolder = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => {
+  const explicitPrimaryWorkspaceFolder = resolvePathFromBase(
+    resolveProjectLaunchCwd(cwd, env),
+    env[PROJECT_PRIMARY_WORKSPACE_FOLDER_ENV]
+  )
+  if (explicitPrimaryWorkspaceFolder != null) {
+    return explicitPrimaryWorkspaceFolder
+  }
+
+  return resolveGitPrimaryWorkspaceFolder(resolveProjectWorkspaceFolder(cwd, env))
+}
+
+export const resolveProjectSharedWorkspaceFolder = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => (
+  resolveProjectPrimaryWorkspaceFolder(cwd, env) ?? resolveProjectWorkspaceFolder(cwd, env)
+)
+
+export const resolveProjectSharedAiBaseDir = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => {
+  const sharedWorkspaceFolder = resolveProjectSharedWorkspaceFolder(cwd, env)
+  const sharedEnv = {
+    ...env,
+    [PROJECT_LAUNCH_CWD_ENV]: sharedWorkspaceFolder,
+    [PROJECT_WORKSPACE_FOLDER_ENV]: sharedWorkspaceFolder
+  }
+
+  return resolveProjectAiBaseDir(sharedWorkspaceFolder, sharedEnv)
+}
+
+export const resolveProjectSharedCacheDir = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => (
+  resolvePathFromBase(resolveProjectLaunchCwd(cwd, env), env[PROJECT_AI_CACHE_DIR_ENV]) ??
+    resolve(resolveProjectSharedAiBaseDir(cwd, env), 'caches')
+)
+
+export const resolveProjectSharedCachePath = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env,
+  ...segments: string[]
+) => resolve(resolveProjectSharedCacheDir(cwd, env), ...segments)

--- a/packages/workspace-assets/__tests__/bundle.spec.ts
+++ b/packages/workspace-assets/__tests__/bundle.spec.ts
@@ -202,6 +202,83 @@ describe('resolveWorkspaceAssetBundle', () => {
     )
   })
 
+  it('installs skill dependencies into the primary workspace shared cache', async () => {
+    const primary = await createWorkspace()
+    const worktree = await createWorkspace()
+    const previousPrimaryWorkspace = process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://registry.example.test/api/search?q=frontend-design&limit=10') {
+        return new Response(JSON.stringify({
+          skills: [{
+            id: 'anthropics/skills/frontend-design',
+            skillId: 'frontend-design',
+            name: 'frontend-design',
+            source: 'anthropics/skills'
+          }]
+        }))
+      }
+      if (url === 'https://registry.example.test/api/download/anthropics/skills/frontend-design') {
+        return new Response(JSON.stringify({
+          files: [{
+            path: 'SKILL.md',
+            contents: '---\nname: frontend-design\ndescription: UI design guidance\n---\nUse primary cache.\n'
+          }]
+        }))
+      }
+      return new Response('not found', { status: 404 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__ = primary
+      await writeDocument(
+        join(worktree, '.ai/skills/app-builder/SKILL.md'),
+        [
+          '---',
+          'name: app-builder',
+          'description: Build apps',
+          'dependencies:',
+          '  - frontend-design',
+          '---',
+          'Build the app.'
+        ].join('\n')
+      )
+
+      const bundle = await resolveWorkspaceAssetBundle({
+        cwd: worktree,
+        configs: [{
+          skills: {
+            registry: 'https://registry.example.test'
+          }
+        }, undefined],
+        useDefaultVibeForgeMcpServer: false
+      })
+
+      await buildAdapterAssetPlan({
+        adapter: 'opencode',
+        bundle,
+        options: {
+          skills: {
+            include: ['app-builder']
+          }
+        }
+      })
+
+      const dependency = bundle.skills.find(asset => asset.name === 'frontend-design')
+      expect(dependency?.sourcePath).toContain(join(
+        primary,
+        '.ai/caches/skill-dependencies/registry.example.test/'
+      ))
+      expect(dependency?.sourcePath).not.toContain(join(worktree, '.ai/caches'))
+    } finally {
+      if (previousPrimaryWorkspace == null) {
+        delete process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__
+      } else {
+        process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__ = previousPrimaryWorkspace
+      }
+    }
+  })
+
   it('reuses complete skill dependency caches without deleting or downloading them again', async () => {
     const workspace = await createWorkspace()
     const fetchMock = vi.fn(async () => new Response('not found', { status: 404 }))

--- a/packages/workspace-assets/src/skill-registry.ts
+++ b/packages/workspace-assets/src/skill-registry.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 import { setTimeout as delay } from 'node:timers/promises'
 
 import type { Config } from '@vibe-forge/types'
-import { resolveProjectAiPath } from '@vibe-forge/utils'
+import { resolveProjectSharedCachePath } from '@vibe-forge/utils/project-cache-path'
 
 import type { NormalizedSkillDependency } from './skill-dependencies'
 
@@ -238,10 +238,9 @@ const buildInstallDir = (params: {
   } catch {
   }
 
-  return resolveProjectAiPath(
+  return resolveProjectSharedCachePath(
     params.cwd,
     process.env,
-    'caches',
     'skill-dependencies',
     toCacheSegment(registryKey),
     ...params.source.split('/').map(toCacheSegment),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,12 +355,6 @@ importers:
 
   packages/adapters/claude-code:
     dependencies:
-      '@anthropic-ai/claude-code':
-        specifier: 2.1.109
-        version: 2.1.109
-      '@musistudio/claude-code-router':
-        specifier: 1.0.73
-        version: 1.0.73(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
       '@vibe-forge/config':
         specifier: workspace:^
         version: link:../../config
@@ -382,9 +376,6 @@ importers:
 
   packages/adapters/codex:
     dependencies:
-      '@openai/codex':
-        specifier: 0.120.0
-        version: 0.120.0
       '@vibe-forge/config':
         specifier: workspace:^
         version: link:../../config
@@ -406,21 +397,21 @@ importers:
 
   packages/adapters/copilot:
     dependencies:
-      '@github/copilot':
-        specifier: 1.0.27
-        version: 1.0.27
+      '@vibe-forge/core':
+        specifier: workspace:^
+        version: link:../../core
       '@vibe-forge/types':
         specifier: workspace:^
         version: link:../../types
       '@vibe-forge/utils':
         specifier: workspace:^
         version: link:../../utils
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
 
   packages/adapters/gemini:
     dependencies:
-      '@google/gemini-cli':
-        specifier: 0.38.0
-        version: 0.38.0
       '@vibe-forge/core':
         specifier: workspace:^
         version: link:../../core
@@ -433,6 +424,9 @@ importers:
       '@vibe-forge/utils':
         specifier: workspace:^
         version: link:../../utils
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
 
   packages/adapters/kimi:
     dependencies:
@@ -448,6 +442,9 @@ importers:
       '@vibe-forge/utils':
         specifier: workspace:^
         version: link:../../utils
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
 
   packages/adapters/opencode:
     dependencies:
@@ -469,9 +466,6 @@ importers:
       '@vibe-forge/utils':
         specifier: workspace:^
         version: link:../../utils
-      opencode-ai:
-        specifier: 1.3.2
-        version: 1.3.2
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -863,15 +857,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==, tarball: https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz}
-
-  '@anthropic-ai/claude-code@2.1.109':
-    resolution: {integrity: sha512-jVy1TcNWzFP/PFbrVfKYNSWoxXe4HJw7wjnZxR72S+X/kSG4Q1d1gVrUsr4Ej7udHBSaCiStqkOI0vGiy9aKlg==, tarball: https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.109.tgz}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  '@anthropic-ai/sdk@0.54.0':
-    resolution: {integrity: sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==, tarball: https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz}
-    hasBin: true
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==, tarball: https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz}
@@ -1405,90 +1390,6 @@ packages:
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==, tarball: https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fastify/accept-negotiator@2.0.1':
-    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==, tarball: https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz}
-
-  '@fastify/ajv-compiler@4.0.5':
-    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==, tarball: https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz}
-
-  '@fastify/cors@11.2.0':
-    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==, tarball: https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz}
-
-  '@fastify/error@4.2.0':
-    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==, tarball: https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz}
-
-  '@fastify/fast-json-stringify-compiler@5.0.3':
-    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==, tarball: https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz}
-
-  '@fastify/forwarded@3.0.1':
-    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==, tarball: https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz}
-
-  '@fastify/merge-json-schemas@0.2.1':
-    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==, tarball: https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz}
-
-  '@fastify/proxy-addr@5.1.0':
-    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==, tarball: https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz}
-
-  '@fastify/send@4.1.0':
-    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==, tarball: https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz}
-
-  '@fastify/static@8.3.0':
-    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==, tarball: https://registry.npmjs.org/@fastify/static/-/static-8.3.0.tgz}
-
-  '@github/copilot-darwin-arm64@1.0.27':
-    resolution: {integrity: sha512-F0mzfLTGngGugSfTuDtG4MMsAK4U8u+Okcb2ftrn9ObHakz/Fzr3DOMld2T8GyzQIbhOnmOYwOk2UvOAZTq/Vg==, tarball: https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.27.tgz}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@github/copilot-darwin-x64@1.0.27':
-    resolution: {integrity: sha512-Nn1KME4kZDsve+HOMbwvO0XfCznyZN9mzh+DRL+Q5e2CF0PIxIcJC7zP9t1/dBux/CUOyDppniUd5OVTuqbWVQ==, tarball: https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.27.tgz}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@github/copilot-linux-arm64@1.0.27':
-    resolution: {integrity: sha512-tg91mQQIChPDdSZCJ2e6iNIvjaOhBAT78o0jkxjF2Hn9bmNt8Iu/ywDUorugtPM+0t82PZY8AwUPkyMmuYokTQ==, tarball: https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.27.tgz}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@github/copilot-linux-x64@1.0.27':
-    resolution: {integrity: sha512-E2cJLoiT5hWtuLPbVS04fxTM5F7yJL2Xazlf44PLXWPzbp5LQvQ+0SDSxnaAkRVT/DqtrtKitYMCxuDQpkdH7Q==, tarball: https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.27.tgz}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
-  '@github/copilot-win32-arm64@1.0.27':
-    resolution: {integrity: sha512-/V530uFEHf3Pl6itJX4nJjx5fX9RAEIejDiqCDoKvuL8prFHGvx2CoKEz00+1QGpQHN0Z2PA0spN9a8V8o+/KA==, tarball: https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.27.tgz}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
-
-  '@github/copilot-win32-x64@1.0.27':
-    resolution: {integrity: sha512-ifRG64DAWG09AV6TIvkd5X08DaVMdyvrBC0Iavr75XVA1B9dKldocJAfVtQzhZTkjo/PLHRFTaAaPMNhGTfziA==, tarball: https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.27.tgz}
-    cpu: [x64]
-    os: [win32]
-    hasBin: true
-
-  '@github/copilot@1.0.27':
-    resolution: {integrity: sha512-f9rlylQWzXRWyK+KkCOmC/wCKXbqQUwfwRkgT8p5JqHlTBvmJ6CS8M9aPo4ycv0aJjtbasLlkYHdrfITMA1cjg==, tarball: https://registry.npmjs.org/@github/copilot/-/copilot-1.0.27.tgz}
-    hasBin: true
-
-  '@google/gemini-cli@0.38.0':
-    resolution: {integrity: sha512-tPGKOY9OGkMEzDOpMbxRPmXBDlcGjXLBU38gLSPCLtkke40HZfXtpiH8R50A5FnW5mEJutflxwt5JPX6R3/YgA==, tarball: https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.38.0.tgz}
-    engines: {node: '>=20'}
-    hasBin: true
-
-  '@google/genai@1.47.0':
-    resolution: {integrity: sha512-0VV7AaXm5rQu3oRHNZNEubRAOL2lv5u+YA72eWnDwcOx3B1jFRbvtgL4drRHlocRHOnludvr3xmbQGbR+/RQAQ==, tarball: https://registry.npmjs.org/@google/genai/-/genai-1.47.0.tgz}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
   '@hapi/bourne@3.0.0':
     resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==, tarball: https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz}
 
@@ -1514,165 +1415,6 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==, tarball: https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz}
     engines: {node: '>=18.18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==, tarball: https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==, tarball: https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==, tarball: https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==, tarball: https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==, tarball: https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@inquirer/checkbox@2.5.0':
-    resolution: {integrity: sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==, tarball: https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/confirm@3.2.0':
-    resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==, tarball: https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/core@9.2.1':
-    resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==, tarball: https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/editor@2.2.0':
-    resolution: {integrity: sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==, tarball: https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/expand@2.3.0':
-    resolution: {integrity: sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==, tarball: https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==, tarball: https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/input@2.3.0':
-    resolution: {integrity: sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==, tarball: https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/number@1.1.0':
-    resolution: {integrity: sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==, tarball: https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/password@2.2.0':
-    resolution: {integrity: sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==, tarball: https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/prompts@5.5.0':
-    resolution: {integrity: sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==, tarball: https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/rawlist@2.3.0':
-    resolution: {integrity: sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==, tarball: https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/search@1.1.0':
-    resolution: {integrity: sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==, tarball: https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/select@2.5.0':
-    resolution: {integrity: sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==, tarball: https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/type@1.5.5':
-    resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==, tarball: https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz}
-    engines: {node: '>=18'}
-
-  '@inquirer/type@2.0.0':
-    resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==, tarball: https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz}
-    engines: {node: '>=18'}
-
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==, tarball: https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz}
     engines: {node: 20 || >=22}
@@ -1684,10 +1426,6 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==, tarball: https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz}
     engines: {node: '>=12'}
-
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==, tarball: https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz}
-    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==, tarball: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz}
@@ -1717,43 +1455,6 @@ packages:
   '@larksuiteoapi/node-sdk@1.60.0':
     resolution: {integrity: sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==, tarball: https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.60.0.tgz}
 
-  '@lukeed/ms@2.0.2':
-    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==, tarball: https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz}
-    engines: {node: '>=8'}
-
-  '@lydell/node-pty-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==, tarball: https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.1.0.tgz}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@lydell/node-pty-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==, tarball: https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.1.0.tgz}
-    cpu: [x64]
-    os: [darwin]
-
-  '@lydell/node-pty-linux-arm64@1.1.0':
-    resolution: {integrity: sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==, tarball: https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.1.0.tgz}
-    cpu: [arm64]
-    os: [linux]
-
-  '@lydell/node-pty-linux-x64@1.1.0':
-    resolution: {integrity: sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==, tarball: https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.1.0.tgz}
-    cpu: [x64]
-    os: [linux]
-
-  '@lydell/node-pty-win32-arm64@1.1.0':
-    resolution: {integrity: sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==, tarball: https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.1.0.tgz}
-    cpu: [arm64]
-    os: [win32]
-
-  '@lydell/node-pty-win32-x64@1.1.0':
-    resolution: {integrity: sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==, tarball: https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.1.0.tgz}
-    cpu: [x64]
-    os: [win32]
-
-  '@lydell/node-pty@1.1.0':
-    resolution: {integrity: sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==, tarball: https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.1.0.tgz}
-
   '@mizchi/lsmcp@0.10.0':
     resolution: {integrity: sha512-hjqBxRy7W4q+UJtPp4W4geyeHXAjNEAtRB9jG+V2hPhCGTd/ot4HpguNoBgP1EFsTfvzNrp7/rxomXYdF1xWzg==, tarball: https://registry.npmjs.org/@mizchi/lsmcp/-/lsmcp-0.10.0.tgz}
     engines: {node: '>=22.0.0'}
@@ -1779,13 +1480,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@musistudio/claude-code-router@1.0.73':
-    resolution: {integrity: sha512-t6O5tbBA4BYWuLLTGi0E2Dijk3IZfQxm6t/x64b6Bs8xucDR5+RzketJxvXqbyOgIqRGMq5dd6fGDOTkRnhzFQ==, tarball: https://registry.npmjs.org/@musistudio/claude-code-router/-/claude-code-router-1.0.73.tgz}
-    hasBin: true
-
-  '@musistudio/llms@1.0.53':
-    resolution: {integrity: sha512-EfSMGHAdqJfvCeRww6pHtQjtP7HoshdwAzYPRLcAS11zHs57xChuHqig+Yjtu/CmgHiLHVWsTqwwoqipzmS99w==, tarball: https://registry.npmjs.org/@musistudio/llms/-/llms-1.0.53.tgz}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==, tarball: https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz}
     engines: {node: '>= 8'}
@@ -1801,47 +1495,6 @@ packages:
   '@nolyfill/function-bind@1.0.21':
     resolution: {integrity: sha512-0Jsaoxp/9HJqCa3GzEzJcoi4+VfupD/o+1pBG0qJ0X3d+sKbbfSej2Faiyp0fTHH36mhsdAKi2TahEx9JV08ZA==, tarball: https://registry.npmjs.org/@nolyfill/function-bind/-/function-bind-1.0.21.tgz}
     engines: {node: '>=12.4.0'}
-
-  '@openai/codex@0.120.0':
-    resolution: {integrity: sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0.tgz}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  '@openai/codex@0.120.0-darwin-arm64':
-    resolution: {integrity: sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-arm64.tgz}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@openai/codex@0.120.0-darwin-x64':
-    resolution: {integrity: sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-x64.tgz}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@openai/codex@0.120.0-linux-arm64':
-    resolution: {integrity: sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-arm64.tgz}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@openai/codex@0.120.0-linux-x64':
-    resolution: {integrity: sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-x64.tgz}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@openai/codex@0.120.0-win32-arm64':
-    resolution: {integrity: sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-arm64.tgz}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@openai/codex@0.120.0-win32-x64':
-    resolution: {integrity: sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==, tarball: https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-x64.tgz}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
 
   '@parcel/watcher-android-arm64@2.5.4':
     resolution: {integrity: sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==, tarball: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.4.tgz}
@@ -2280,9 +1933,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==, tarball: https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz}
 
-  '@types/mute-stream@0.0.4':
-    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==, tarball: https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz}
-
   '@types/node-notifier@8.0.5':
     resolution: {integrity: sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==, tarball: https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz}
 
@@ -2309,9 +1959,6 @@ packages:
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==, tarball: https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz}
 
-  '@types/retry@0.12.0':
-    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==, tarball: https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz}
-
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==, tarball: https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz}
 
@@ -2329,9 +1976,6 @@ packages:
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==, tarball: https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz}
-
-  '@types/wrap-ansi@3.0.0':
-    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==, tarball: https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz}
@@ -2535,9 +2179,6 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==, tarball: https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz}
 
-  abstract-logging@2.0.1:
-    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==, tarball: https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz}
-
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==, tarball: https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz}
     engines: {node: '>= 0.6'}
@@ -2556,10 +2197,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==, tarball: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz}
-    engines: {node: '>= 14'}
-
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
     peerDependencies:
@@ -2573,13 +2210,6 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz}
-
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz}
-
-  ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==, tarball: https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz}
-    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==, tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz}
@@ -2628,9 +2258,6 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==, tarball: https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz}
     engines: {node: '>=8.0.0'}
 
-  avvio@9.2.0:
-    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==, tarball: https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz}
-
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==, tarball: https://registry.npmjs.org/axios/-/axios-1.13.6.tgz}
 
@@ -2640,23 +2267,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz}
-    engines: {node: 18 || 20 || >=22}
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==, tarball: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz}
-
   baseline-browser-mapping@2.10.13:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==, tarball: https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==, tarball: https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==, tarball: https://registry.npmjs.org/bl/-/bl-4.1.0.tgz}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==, tarball: https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz}
@@ -2671,10 +2285,6 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz}
-    engines: {node: 18 || 20 || >=22}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==, tarball: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz}
     engines: {node: '>=8'}
@@ -2683,12 +2293,6 @@ packages:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==, tarball: https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==, tarball: https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==, tarball: https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz}
 
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==, tarball: https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz}
@@ -2747,9 +2351,6 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==, tarball: https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz}
 
-  chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==, tarball: https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz}
-
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==, tarball: https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz}
     engines: {node: '>= 16'}
@@ -2757,9 +2358,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==, tarball: https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz}
     engines: {node: '>= 14.16.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==, tarball: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz}
 
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==, tarball: https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz}
@@ -2771,10 +2369,6 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==, tarball: https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz}
     engines: {node: '>=4'}
-
-  cli-width@4.1.0:
-    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==, tarball: https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz}
-    engines: {node: '>= 12'}
 
   co-body@6.2.0:
     resolution: {integrity: sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==, tarball: https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz}
@@ -2804,10 +2398,6 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==, tarball: https://registry.npmjs.org/commander/-/commander-12.1.0.tgz}
     engines: {node: '>=18'}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==, tarball: https://registry.npmjs.org/commander/-/commander-14.0.3.tgz}
-    engines: {node: '>=20'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==, tarball: https://registry.npmjs.org/commander/-/commander-7.2.0.tgz}
@@ -3047,10 +2637,6 @@ packages:
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==, tarball: https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==, tarball: https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz}
-    engines: {node: '>= 12'}
-
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==, tarball: https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz}
 
@@ -3069,20 +2655,12 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==, tarball: https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==, tarball: https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz}
-    engines: {node: '>=10'}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==, tarball: https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz}
     engines: {node: '>=6'}
 
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==, tarball: https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==, tarball: https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz}
-    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==, tarball: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz}
@@ -3151,9 +2729,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==, tarball: https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==, tarball: https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==, tarball: https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz}
@@ -3466,10 +3041,6 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==, tarball: https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz}
     engines: {node: '>=18.0.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==, tarball: https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz}
-    engines: {node: '>=6'}
-
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==, tarball: https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz}
     engines: {node: '>=12.0.0'}
@@ -3490,15 +3061,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==, tarball: https://registry.npmjs.org/extend/-/extend-3.0.2.tgz}
 
-  external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==, tarball: https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz}
-    engines: {node: '>=4'}
-
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==, tarball: https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz}
-
-  fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==, tarball: https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==, tarball: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz}
@@ -3510,14 +3074,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==, tarball: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz}
 
-  fast-json-stringify@6.3.0:
-    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==, tarball: https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz}
-
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==, tarball: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
-
-  fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==, tarball: https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==, tarball: https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz}
@@ -3525,17 +3083,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz}
 
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==, tarball: https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz}
-
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==, tarball: https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz}
-
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==, tarball: https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==, tarball: https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==, tarball: https://registry.npmjs.org/fault/-/fault-2.0.1.tgz}
@@ -3549,10 +3098,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==, tarball: https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz}
-    engines: {node: ^12.20 || >= 14.13}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==, tarball: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz}
     engines: {node: '>=16.0.0'}
@@ -3564,14 +3109,6 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==, tarball: https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz}
     engines: {node: '>= 18.0.0'}
-
-  find-my-way@9.5.0:
-    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==, tarball: https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz}
-    engines: {node: '>=20'}
-
-  find-process@2.1.1:
-    resolution: {integrity: sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==, tarball: https://registry.npmjs.org/find-process/-/find-process-2.1.1.tgz}
-    hasBin: true
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==, tarball: https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz}
@@ -3609,10 +3146,6 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==, tarball: https://registry.npmjs.org/format/-/format-0.2.2.tgz}
     engines: {node: '>=0.4.x'}
 
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==, tarball: https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz}
-    engines: {node: '>=12.20.0'}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==, tarball: https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz}
     engines: {node: '>= 0.6'}
@@ -3628,21 +3161,10 @@ packages:
   front-matter@4.0.2:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==, tarball: https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz}
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==, tarball: https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  gaxios@7.1.4:
-    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==, tarball: https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz}
-    engines: {node: '>=18'}
-
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==, tarball: https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz}
-    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==, tarball: https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz}
@@ -3662,9 +3184,6 @@ packages:
   gitaware-glob@0.2.0:
     resolution: {integrity: sha512-86QjEcbFxPBsmi9hv0wPnQRgv5aXx8yHl40AkEZk1OBLSp42GUEz6jzDoADh7B/YH6/5dAumHDJH2WM0nYPMig==, tarball: https://registry.npmjs.org/gitaware-glob/-/gitaware-glob-0.2.0.tgz}
 
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==, tarball: https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz}
-
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==, tarball: https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz}
 
@@ -3678,12 +3197,6 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==, tarball: https://registry.npmjs.org/glob/-/glob-10.5.0.tgz}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==, tarball: https://registry.npmjs.org/glob/-/glob-11.1.0.tgz}
-    engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
@@ -3701,14 +3214,6 @@ packages:
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==, tarball: https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz}
-
-  google-auth-library@10.6.2:
-    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==, tarball: https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz}
-    engines: {node: '>=18'}
-
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==, tarball: https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz}
-    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==, tarball: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz}
@@ -3780,10 +3285,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==, tarball: https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz}
     engines: {node: '>= 0.8'}
 
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==, tarball: https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz}
-    engines: {node: '>= 14'}
-
   i18next-browser-languagedetector@8.2.0:
     resolution: {integrity: sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==, tarball: https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz}
 
@@ -3806,9 +3307,6 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==, tarball: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz}
     engines: {node: '>=0.10.0'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==, tarball: https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==, tarball: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz}
@@ -3843,9 +3341,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz}
 
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==, tarball: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz}
-
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==, tarball: https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz}
 
@@ -3859,10 +3354,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==, tarball: https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.3.0:
-    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==, tarball: https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz}
-    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==, tarball: https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz}
@@ -3921,10 +3412,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==, tarball: https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==, tarball: https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz}
-    engines: {node: 20 || >=22}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==, tarball: https://registry.npmjs.org/jose/-/jose-6.1.3.tgz}
@@ -3987,14 +3474,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==, tarball: https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz}
-
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==, tarball: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz}
-
-  json-schema-ref-resolver@3.0.0:
-    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==, tarball: https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
@@ -4020,16 +3501,6 @@ packages:
     resolution: {integrity: sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==, tarball: https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  jsonrepair@3.13.3:
-    resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==, tarball: https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.3.tgz}
-    hasBin: true
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==, tarball: https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==, tarball: https://registry.npmjs.org/jws/-/jws-4.0.1.tgz}
-
   katex@0.16.28:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==, tarball: https://registry.npmjs.org/katex/-/katex-0.16.28.tgz}
     hasBin: true
@@ -4038,9 +3509,6 @@ packages:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==, tarball: https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz}
     engines: {node: '>= 0.6'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  keytar@7.9.0:
-    resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==, tarball: https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==, tarball: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz}
@@ -4078,9 +3546,6 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==, tarball: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz}
     engines: {node: '>= 0.8.0'}
 
-  light-my-request@6.6.0:
-    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==, tarball: https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz}
-
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==, tarball: https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz}
     engines: {node: '>=14'}
@@ -4104,10 +3569,6 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz}
 
-  loglevel@1.9.2:
-    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==, tarball: https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz}
-    engines: {node: '>= 0.6.0'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==, tarball: https://registry.npmjs.org/long/-/long-5.3.2.tgz}
 
@@ -4123,10 +3584,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz}
-
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz}
-    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz}
@@ -4400,22 +3857,9 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==, tarball: https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz}
     engines: {node: '>=18'}
 
-  mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==, tarball: https://registry.npmjs.org/mime/-/mime-3.0.0.tgz}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==, tarball: https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz}
-    engines: {node: '>=10'}
-
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==, tarball: https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz}
     engines: {node: 20 || >=22}
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==, tarball: https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==, tarball: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz}
@@ -4431,13 +3875,6 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==, tarball: https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==, tarball: https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==, tarball: https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz}
-
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==, tarball: https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz}
 
@@ -4451,17 +3888,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
 
-  mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==, tarball: https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==, tarball: https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==, tarball: https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==, tarball: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz}
@@ -4478,24 +3908,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==, tarball: https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz}
     engines: {node: '>= 0.6'}
 
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==, tarball: https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz}
-    engines: {node: '>=10'}
-
-  node-addon-api@4.3.0:
-    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==, tarball: https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz}
-
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==, tarball: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz}
-
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==, tarball: https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==, tarball: https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==, tarball: https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz}
@@ -4543,92 +3957,9 @@ packages:
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==, tarball: https://registry.npmjs.org/only/-/only-0.0.2.tgz}
 
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==, tarball: https://registry.npmjs.org/openai/-/openai-5.23.2.tgz}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  opencode-ai@1.3.2:
-    resolution: {integrity: sha512-InyDAXKoh+fVxWrBMJZaf1xIYpASZ2zX4O/u7nwtiYzxy/kqHySvQe9jDVrhMgbMdb4CXzACid7M2HDUa+vz2Q==, tarball: https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.3.2.tgz}
-    hasBin: true
-
-  opencode-darwin-arm64@1.3.2:
-    resolution: {integrity: sha512-/7V+J3XZGF/sCdMbEb5E3mUvuOIVvGkVjgYH1k/pnTfdGaPW/C7RgW2dU2HedXvkw4Y3CplUS+5VfA/F5kufXw==, tarball: https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.3.2.tgz}
-    cpu: [arm64]
-    os: [darwin]
-
-  opencode-darwin-x64-baseline@1.3.2:
-    resolution: {integrity: sha512-jBusp8Vb1wsGKHD2AOD+Cr4qL4zSDut80Sy0CnMH8AwnSCNzaSVi2wnE/7vPrgCa44Xr0MknSE2S0wHQ5SbLaw==, tarball: https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.3.2.tgz}
-    cpu: [x64]
-    os: [darwin]
-
-  opencode-darwin-x64@1.3.2:
-    resolution: {integrity: sha512-J7HgNBUoDpsKHAiky18aUm4xMKmUIJqlvVMkvL9NVjwDRMuAKnbYcxpRK8O+NKzeVx29IWwX8zizUwCuqXAAlA==, tarball: https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.3.2.tgz}
-    cpu: [x64]
-    os: [darwin]
-
-  opencode-linux-arm64-musl@1.3.2:
-    resolution: {integrity: sha512-ZOB6+NvkZ19mzi6j4VAHtQDAeTXvQJqg4YtclT3wbMof8y3jn5S8vUmaXLk9d9FryEcdIoMK/oFLkcLkS1OXpA==, tarball: https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.3.2.tgz}
-    cpu: [arm64]
-    os: [linux]
-
-  opencode-linux-arm64@1.3.2:
-    resolution: {integrity: sha512-+q0PJ86LPitMIGf9sGXdtOcwpdiwbzdw91zXAHFe7rXZZm4Cvu9qjvt6WT/lKJqL8f6pyJs9Kbt4XJ/C20swQA==, tarball: https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.3.2.tgz}
-    cpu: [arm64]
-    os: [linux]
-
-  opencode-linux-x64-baseline-musl@1.3.2:
-    resolution: {integrity: sha512-8XYcAqZBcUgYHfae9qoTT8erqFjd6AKTrSu60gRgzTN8cUybG4iPyAVt4GUcXCzUw44Qo++d/8I9hwpUTCoFYg==, tarball: https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.3.2.tgz}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-linux-x64-baseline@1.3.2:
-    resolution: {integrity: sha512-QXiF1+PJH5AOHMSTdYngOB7yWULFQKJpIbx77ZHM1MKyxiBweIrZ03nG86iXIZIVGBxEfH1CcKDU28lFGUJdNg==, tarball: https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.3.2.tgz}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-linux-x64-musl@1.3.2:
-    resolution: {integrity: sha512-o4aXgcWQidxQ6cJMsgLcCMv9MSKtLEqm3OAFm6eN7hVgHV9m7rz035BICNZ1YLltIEdQYAHXx5MGM21J4/vBdw==, tarball: https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.3.2.tgz}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-linux-x64@1.3.2:
-    resolution: {integrity: sha512-/+OtuHr2O0/QKpBrZBnutr0ZLe+LmOx003Z99b21BgG9wsVo7gFuNpfLPVXnqcEY6D5DuWl4aEJW4+w+K0urYw==, tarball: https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.3.2.tgz}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-windows-arm64@1.3.2:
-    resolution: {integrity: sha512-3xJEjSLdk7I5Z6yyrT4LCQeK4VCj6mo/l4JdUa0zocV8wCzUtY1lSHeipDAaNr8TwD6NeTxr1iomIjuatKAFOA==, tarball: https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.3.2.tgz}
-    cpu: [arm64]
-    os: [win32]
-
-  opencode-windows-x64-baseline@1.3.2:
-    resolution: {integrity: sha512-RVx9e1KBNTSWjrtfRpGIIcJDsM13OUY/lYqJXI1oj34lMOEj5G57fypjk9yBqUHBR+7tolGmewwJJU6SDgyPXQ==, tarball: https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.3.2.tgz}
-    cpu: [x64]
-    os: [win32]
-
-  opencode-windows-x64@1.3.2:
-    resolution: {integrity: sha512-pJMpptERqz8pjnW1pTQf5Ru2WbJz7P2BPM5De5gdUd10y0yUoGvY7uzyJYuGpsrCqeWrEYokERnbv8A/4V3Yaw==, tarball: https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.3.2.tgz}
-    cpu: [x64]
-    os: [win32]
-
-  openurl@1.1.1:
-    resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==, tarball: https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==, tarball: https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz}
     engines: {node: '>= 0.8.0'}
-
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==, tarball: https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz}
-    engines: {node: '>=0.10.0'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==, tarball: https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz}
@@ -4637,10 +3968,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==, tarball: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz}
     engines: {node: '>=10'}
-
-  p-retry@4.6.2:
-    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==, tarball: https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz}
-    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==, tarball: https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz}
@@ -4685,10 +4012,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==, tarball: https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==, tarball: https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz}
-    engines: {node: 18 || 20 || >=22}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==, tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz}
 
@@ -4730,10 +4053,6 @@ packages:
     resolution: {integrity: sha512-NFnZqUliT+OHkRXVSf8vdOr13N1wv31hRryVjqbreVh/SDCNaI6mnRDDq89HVRCbem1SAl7yj04OANeqP0nT6A==, tarball: https://registry.npmjs.org/pino/-/pino-10.2.0.tgz}
     hasBin: true
 
-  pino@10.3.1:
-    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==, tarball: https://registry.npmjs.org/pino/-/pino-10.3.1.tgz}
-    hasBin: true
-
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz}
     engines: {node: '>=16.20.0'}
@@ -4763,18 +4082,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==, tarball: https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==, tarball: https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==, tarball: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz}
     engines: {node: '>= 0.8.0'}
-
-  process-warning@4.0.1:
-    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==, tarball: https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==, tarball: https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz}
@@ -5057,10 +4367,6 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==, tarball: https://registry.npmjs.org/rc/-/rc-1.2.8.tgz}
-    hasBin: true
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==, tarball: https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz}
     peerDependencies:
@@ -5115,10 +4421,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==, tarball: https://registry.npmjs.org/react/-/react-18.3.1.tgz}
     engines: {node: '>=0.10.0'}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz}
-    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==, tarball: https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz}
@@ -5183,20 +4485,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==, tarball: https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz}
 
-  ret@0.5.0:
-    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==, tarball: https://registry.npmjs.org/ret/-/ret-0.5.0.tgz}
-    engines: {node: '>=10'}
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==, tarball: https://registry.npmjs.org/retry/-/retry-0.13.1.tgz}
-    engines: {node: '>= 4'}
-
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==, tarball: https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==, tarball: https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz}
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==, tarball: https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz}
@@ -5205,10 +4496,6 @@ packages:
     resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==, tarball: https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  rotating-file-stream@3.2.9:
-    resolution: {integrity: sha512-i9i0KkHh12ryl4xtELg+0gyoFre2PJ9RcQQLzquWsiqygyYsrZLckrqqYrthhnJZGZb4g+KUHtcoWYVq34gaug==, tarball: https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.2.9.tgz}
-    engines: {node: '>=14.0'}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==, tarball: https://registry.npmjs.org/router/-/router-2.2.0.tgz}
@@ -5226,10 +4513,6 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==, tarball: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz}
-
-  safe-regex2@5.1.0:
-    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==, tarball: https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.0.tgz}
-    hasBin: true
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==, tarball: https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz}
@@ -5265,11 +4548,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==, tarball: https://registry.npmjs.org/semver/-/semver-7.7.4.tgz}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==, tarball: https://registry.npmjs.org/send/-/send-1.2.1.tgz}
     engines: {node: '>= 18'}
@@ -5294,10 +4572,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==, tarball: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==, tarball: https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz}
-    engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==, tarball: https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz}
@@ -5328,20 +4602,11 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==, tarball: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==, tarball: https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==, tarball: https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==, tarball: https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==, tarball: https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz}
-
-  sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==, tarball: https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==, tarball: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz}
@@ -5394,9 +4659,6 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==, tarball: https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz}
     engines: {node: '>=12'}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==, tarball: https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==, tarball: https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz}
 
@@ -5411,10 +4673,6 @@ packages:
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==, tarball: https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz}
     engines: {node: '>=12'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==, tarball: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==, tarball: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz}
@@ -5453,13 +4711,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==, tarball: https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==, tarball: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==, tarball: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz}
-    engines: {node: '>=6'}
-
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==, tarball: https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz}
     engines: {node: '>=20'}
@@ -5467,9 +4718,6 @@ packages:
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==, tarball: https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz}
     engines: {node: '>=12.22'}
-
-  tiktoken@1.0.22:
-    resolution: {integrity: sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==, tarball: https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==, tarball: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz}
@@ -5504,17 +4752,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==, tarball: https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz}
     engines: {node: '>=14.0.0'}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==, tarball: https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz}
-    engines: {node: '>=0.6.0'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==, tarball: https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz}
     engines: {node: '>=8.0'}
-
-  toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==, tarball: https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz}
-    engines: {node: '>=12'}
 
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==, tarball: https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz}
@@ -5552,16 +4792,9 @@ packages:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==, tarball: https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz}
     engines: {node: '>=0.6.x'}
 
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==, tarball: https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==, tarball: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz}
     engines: {node: '>= 0.8.0'}
-
-  type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==, tarball: https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz}
-    engines: {node: '>=10'}
 
   type-fest@4.2.0:
     resolution: {integrity: sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==, tarball: https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz}
@@ -5585,10 +4818,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
-
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==, tarball: https://registry.npmjs.org/undici/-/undici-7.24.6.tgz}
-    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==, tarball: https://registry.npmjs.org/unified/-/unified-11.0.5.tgz}
@@ -5763,10 +4992,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==, tarball: https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz}
-    engines: {node: '>= 8'}
-
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==, tarball: https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz}
 
@@ -5784,10 +5009,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==, tarball: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz}
     engines: {node: '>=0.10.0'}
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz}
-    engines: {node: '>=8'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
     engines: {node: '>=10'}
@@ -5801,18 +5022,6 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==, tarball: https://registry.npmjs.org/ws/-/ws-8.19.0.tgz}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==, tarball: https://registry.npmjs.org/ws/-/ws-8.20.0.tgz}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5846,10 +5055,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==, tarball: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz}
     engines: {node: '>=10'}
-
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==, tarball: https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz}
-    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==, tarball: https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz}
@@ -5963,20 +5168,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.5.0
       tinyexec: 1.0.1
-
-  '@anthropic-ai/claude-code@2.1.109':
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-
-  '@anthropic-ai/sdk@0.54.0': {}
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -6391,104 +5582,6 @@ snapshots:
       '@eslint/core': 0.16.0
       levn: 0.4.1
 
-  '@fastify/accept-negotiator@2.0.1': {}
-
-  '@fastify/ajv-compiler@4.0.5':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
-
-  '@fastify/cors@11.2.0':
-    dependencies:
-      fastify-plugin: 5.1.0
-      toad-cache: 3.7.0
-
-  '@fastify/error@4.2.0': {}
-
-  '@fastify/fast-json-stringify-compiler@5.0.3':
-    dependencies:
-      fast-json-stringify: 6.3.0
-
-  '@fastify/forwarded@3.0.1': {}
-
-  '@fastify/merge-json-schemas@0.2.1':
-    dependencies:
-      dequal: 2.0.3
-
-  '@fastify/proxy-addr@5.1.0':
-    dependencies:
-      '@fastify/forwarded': 3.0.1
-      ipaddr.js: 2.3.0
-
-  '@fastify/send@4.1.0':
-    dependencies:
-      '@lukeed/ms': 2.0.2
-      escape-html: 1.0.3
-      fast-decode-uri-component: 1.0.1
-      http-errors: 2.0.1
-      mime: 3.0.0
-
-  '@fastify/static@8.3.0':
-    dependencies:
-      '@fastify/accept-negotiator': 2.0.1
-      '@fastify/send': 4.1.0
-      content-disposition: 0.5.4
-      fastify-plugin: 5.1.0
-      fastq: 1.20.1
-      glob: 11.1.0
-
-  '@github/copilot-darwin-arm64@1.0.27':
-    optional: true
-
-  '@github/copilot-darwin-x64@1.0.27':
-    optional: true
-
-  '@github/copilot-linux-arm64@1.0.27':
-    optional: true
-
-  '@github/copilot-linux-x64@1.0.27':
-    optional: true
-
-  '@github/copilot-win32-arm64@1.0.27':
-    optional: true
-
-  '@github/copilot-win32-x64@1.0.27':
-    optional: true
-
-  '@github/copilot@1.0.27':
-    optionalDependencies:
-      '@github/copilot-darwin-arm64': 1.0.27
-      '@github/copilot-darwin-x64': 1.0.27
-      '@github/copilot-linux-arm64': 1.0.27
-      '@github/copilot-linux-x64': 1.0.27
-      '@github/copilot-win32-arm64': 1.0.27
-      '@github/copilot-win32-x64': 1.0.27
-
-  '@google/gemini-cli@0.38.0':
-    optionalDependencies:
-      '@lydell/node-pty': 1.1.0
-      '@lydell/node-pty-darwin-arm64': 1.1.0
-      '@lydell/node-pty-darwin-x64': 1.1.0
-      '@lydell/node-pty-linux-x64': 1.1.0
-      '@lydell/node-pty-win32-arm64': 1.1.0
-      '@lydell/node-pty-win32-x64': 1.1.0
-      keytar: 7.9.0
-      node-pty: 1.1.0
-
-  '@google/genai@1.47.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.20.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.4)(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@hapi/bourne@3.0.0': {}
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
@@ -6506,168 +5599,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
-
-  '@inquirer/checkbox@2.5.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 1.5.5
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/confirm@3.2.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-
-  '@inquirer/core@9.2.1':
-    dependencies:
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 2.0.0
-      '@types/mute-stream': 0.0.4
-      '@types/node': 22.19.15
-      '@types/wrap-ansi': 3.0.0
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 1.0.0
-      signal-exit: 4.1.0
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/editor@2.2.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-      external-editor: 3.1.0
-
-  '@inquirer/expand@2.3.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/figures@1.0.15': {}
-
-  '@inquirer/input@2.3.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-
-  '@inquirer/number@1.1.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-
-  '@inquirer/password@2.2.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-      ansi-escapes: 4.3.2
-
-  '@inquirer/prompts@5.5.0':
-    dependencies:
-      '@inquirer/checkbox': 2.5.0
-      '@inquirer/confirm': 3.2.0
-      '@inquirer/editor': 2.2.0
-      '@inquirer/expand': 2.3.0
-      '@inquirer/input': 2.3.0
-      '@inquirer/number': 1.1.0
-      '@inquirer/password': 2.2.0
-      '@inquirer/rawlist': 2.3.0
-      '@inquirer/search': 1.1.0
-      '@inquirer/select': 2.5.0
-
-  '@inquirer/rawlist@2.3.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/type': 1.5.5
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/search@1.1.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 1.5.5
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/select@2.5.0':
-    dependencies:
-      '@inquirer/core': 9.2.1
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 1.5.5
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.3
-
-  '@inquirer/type@1.5.5':
-    dependencies:
-      mute-stream: 1.0.0
-
-  '@inquirer/type@2.0.0':
-    dependencies:
-      mute-stream: 1.0.0
-
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -6682,8 +5613,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6732,36 +5661,6 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@lukeed/ms@2.0.2': {}
-
-  '@lydell/node-pty-darwin-arm64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty-darwin-x64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty-linux-arm64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty-linux-x64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty-win32-arm64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty-win32-x64@1.1.0':
-    optional: true
-
-  '@lydell/node-pty@1.1.0':
-    optionalDependencies:
-      '@lydell/node-pty-darwin-arm64': 1.1.0
-      '@lydell/node-pty-darwin-x64': 1.1.0
-      '@lydell/node-pty-linux-arm64': 1.1.0
-      '@lydell/node-pty-linux-x64': 1.1.0
-      '@lydell/node-pty-win32-arm64': 1.1.0
-      '@lydell/node-pty-win32-x64': 1.1.0
-    optional: true
-
   '@mizchi/lsmcp@0.10.0':
     dependencies:
       gitaware-glob: 0.2.0
@@ -6803,50 +5702,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@musistudio/claude-code-router@1.0.73(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)':
-    dependencies:
-      '@fastify/static': 8.3.0
-      '@inquirer/prompts': 5.5.0
-      '@musistudio/llms': 1.0.53(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
-      dotenv: 16.6.1
-      find-process: 2.1.1
-      json5: 2.2.3
-      lru-cache: 11.2.7
-      minimist: 1.2.8
-      openurl: 1.1.1
-      rotating-file-stream: 3.2.9
-      shell-quote: 1.8.3
-      tiktoken: 1.0.22
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@musistudio/llms@1.0.53(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.54.0
-      '@fastify/cors': 11.2.0
-      '@google/genai': 1.47.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.4)(zod@3.25.76))
-      dotenv: 16.6.1
-      fastify: 5.8.4
-      google-auth-library: 10.6.2
-      json5: 2.2.3
-      jsonrepair: 3.13.3
-      openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
-      undici: 7.24.6
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6860,33 +5715,6 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/function-bind@1.0.21': {}
-
-  '@openai/codex@0.120.0':
-    optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.120.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.120.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.120.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.120.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.120.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.120.0-win32-x64'
-
-  '@openai/codex@0.120.0-darwin-arm64':
-    optional: true
-
-  '@openai/codex@0.120.0-darwin-x64':
-    optional: true
-
-  '@openai/codex@0.120.0-linux-arm64':
-    optional: true
-
-  '@openai/codex@0.120.0-linux-x64':
-    optional: true
-
-  '@openai/codex@0.120.0-win32-arm64':
-    optional: true
-
-  '@openai/codex@0.120.0-win32-x64':
-    optional: true
 
   '@parcel/watcher-android-arm64@2.5.4':
     optional: true
@@ -7293,10 +6121,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/mute-stream@0.0.4':
-    dependencies:
-      '@types/node': 22.19.15
-
   '@types/node-notifier@8.0.5':
     dependencies:
       '@types/node': 22.18.12
@@ -7308,6 +6132,7 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+    optional: true
 
   '@types/prop-types@15.7.15': {}
 
@@ -7323,8 +6148,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/retry@0.12.0': {}
 
   '@types/send@1.2.1':
     dependencies:
@@ -7343,8 +6166,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/uuid@9.0.8': {}
-
-  '@types/wrap-ansi@3.0.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -7617,8 +6438,6 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
-  abstract-logging@2.0.1: {}
-
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -7635,15 +6454,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.4: {}
-
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
-
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
 
   ajv@6.12.6:
     dependencies:
@@ -7658,17 +6471,6 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  ansi-escapes@4.3.2:
-    dependencies:
-      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -7754,11 +6556,6 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  avvio@9.2.0:
-    dependencies:
-      '@fastify/error': 4.2.0
-      fastq: 1.20.1
-
   axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
@@ -7771,20 +6568,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@4.0.4: {}
-
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.10.13: {}
-
-  bignumber.js@9.3.1: {}
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -7811,10 +6595,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
-    dependencies:
-      balanced-match: 4.0.4
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -7826,14 +6606,6 @@ snapshots:
       electron-to-chromium: 1.5.237
       node-releases: 2.0.25
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
-
-  buffer-equal-constant-time@1.0.1: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    optional: true
 
   builtin-modules@5.0.0: {}
 
@@ -7885,16 +6657,11 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chardet@0.7.0: {}
-
   check-error@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chownr@1.1.4:
-    optional: true
 
   ci-info@4.3.1: {}
 
@@ -7903,8 +6670,6 @@ snapshots:
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-
-  cli-width@4.1.0: {}
 
   co-body@6.2.0:
     dependencies:
@@ -7931,8 +6696,6 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
-
-  commander@14.0.3: {}
 
   commander@7.2.0: {}
 
@@ -8181,8 +6944,6 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
-  data-uri-to-buffer@4.0.1: {}
-
   dateformat@4.6.3: {}
 
   dayjs@1.11.19: {}
@@ -8195,17 +6956,9 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-    optional: true
-
   deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
-
-  deep-extend@0.6.0:
-    optional: true
 
   deep-is@0.1.4: {}
 
@@ -8267,10 +7020,6 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -8680,9 +7429,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3:
-    optional: true
-
   expect-type@1.2.2: {}
 
   express-rate-limit@7.5.1(express@5.2.1):
@@ -8726,15 +7472,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  external-editor@3.1.0:
-    dependencies:
-      chardet: 0.7.0
-      iconv-lite: 0.4.24
-      tmp: 0.0.33
-
   fast-copy@4.0.2: {}
-
-  fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -8748,50 +7486,13 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-json-stringify@6.3.0:
-    dependencies:
-      '@fastify/merge-json-schemas': 0.2.1
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
-      json-schema-ref-resolver: 3.0.0
-      rfdc: 1.4.1
-
   fast-levenshtein@2.0.6: {}
-
-  fast-querystring@1.1.2:
-    dependencies:
-      fast-decode-uri-component: 1.0.1
 
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
-  fastify-plugin@5.1.0: {}
-
-  fastify@5.8.4:
-    dependencies:
-      '@fastify/ajv-compiler': 4.0.5
-      '@fastify/error': 4.2.0
-      '@fastify/fast-json-stringify-compiler': 5.0.3
-      '@fastify/proxy-addr': 5.1.0
-      abstract-logging: 2.0.1
-      avvio: 9.2.0
-      fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
-      light-my-request: 6.6.0
-      pino: 10.3.1
-      process-warning: 5.0.0
-      rfdc: 1.4.1
-      secure-json-parse: 4.1.0
-      semver: 7.7.4
-      toad-cache: 3.7.0
-
   fastq@1.19.1:
-    dependencies:
-      reusify: 1.1.0
-
-  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
@@ -8802,11 +7503,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
-
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8826,18 +7522,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  find-my-way@9.5.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-querystring: 1.1.2
-      safe-regex2: 5.1.0
-
-  find-process@2.1.1:
-    dependencies:
-      chalk: 4.1.2
-      commander: 14.0.3
-      loglevel: 1.9.2
 
   find-up-simple@1.0.1: {}
 
@@ -8870,10 +7554,6 @@ snapshots:
 
   format@0.2.2: {}
 
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
-
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -8884,27 +7564,8 @@ snapshots:
     dependencies:
       js-yaml: 3.14.2
 
-  fs-constants@1.0.0:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
-
-  gaxios@7.1.4:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@8.1.2:
-    dependencies:
-      gaxios: 7.1.4
-      google-logging-utils: 1.1.3
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -8934,9 +7595,6 @@ snapshots:
     dependencies:
       minimatch: 10.1.1
 
-  github-from-package@0.0.0:
-    optional: true
-
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -8956,15 +7614,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
-
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -8972,19 +7621,6 @@ snapshots:
   globals@16.4.0: {}
 
   globrex@0.1.2: {}
-
-  google-auth-library@10.6.2:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -9084,13 +7720,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   i18next-browser-languagedetector@8.2.0:
     dependencies:
       '@babel/runtime': 7.28.6
@@ -9113,9 +7742,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -9137,9 +7763,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
-
   inline-style-parser@0.2.7: {}
 
   internmap@1.0.1: {}
@@ -9147,8 +7770,6 @@ snapshots:
   internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.3.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -9195,10 +7816,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
-
   jose@6.1.3: {}
 
   jotai@2.16.2(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@18.3.27)(react@18.3.1):
@@ -9233,15 +7850,7 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-bigint@1.0.0:
-    dependencies:
-      bignumber.js: 9.3.1
-
   json-buffer@3.0.1: {}
-
-  json-schema-ref-resolver@3.0.0:
-    dependencies:
-      dequal: 2.0.3
 
   json-schema-traverse@0.4.1: {}
 
@@ -9264,19 +7873,6 @@ snapshots:
       espree: 9.6.1
       semver: 7.7.3
 
-  jsonrepair@3.13.3: {}
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
-
   katex@0.16.28:
     dependencies:
       commander: 8.3.0
@@ -9284,12 +7880,6 @@ snapshots:
   keygrip@1.1.0:
     dependencies:
       tsscmp: 1.0.6
-
-  keytar@7.9.0:
-    dependencies:
-      node-addon-api: 4.3.0
-      prebuild-install: 7.1.3
-    optional: true
 
   keyv@4.5.4:
     dependencies:
@@ -9355,12 +7945,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  light-my-request@6.6.0:
-    dependencies:
-      cookie: 1.1.1
-      process-warning: 4.0.1
-      set-cookie-parser: 2.7.2
-
   local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.0
@@ -9381,8 +7965,6 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  loglevel@1.9.2: {}
-
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
@@ -9394,8 +7976,6 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9985,18 +8565,9 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  mime@3.0.0: {}
-
-  mimic-response@3.1.0:
-    optional: true
-
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
 
   minimatch@3.1.2:
     dependencies:
@@ -10009,11 +8580,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
-
-  minipass@7.1.3: {}
-
-  mkdirp-classic@0.5.3:
-    optional: true
 
   mlly@1.8.0:
     dependencies:
@@ -10031,12 +8597,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mute-stream@1.0.0: {}
-
   nanoid@3.3.11: {}
-
-  napi-build-utils@2.0.0:
-    optional: true
 
   natural-compare@1.4.0: {}
 
@@ -10046,23 +8607,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
-    optional: true
-
-  node-addon-api@4.3.0:
-    optional: true
-
   node-addon-api@7.1.1: {}
-
-  node-domexception@1.0.0: {}
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-notifier@10.0.1:
     dependencies:
@@ -10113,64 +8658,6 @@ snapshots:
 
   only@0.0.2: {}
 
-  openai@5.23.2(ws@8.20.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.20.0
-      zod: 3.25.76
-
-  opencode-ai@1.3.2:
-    optionalDependencies:
-      opencode-darwin-arm64: 1.3.2
-      opencode-darwin-x64: 1.3.2
-      opencode-darwin-x64-baseline: 1.3.2
-      opencode-linux-arm64: 1.3.2
-      opencode-linux-arm64-musl: 1.3.2
-      opencode-linux-x64: 1.3.2
-      opencode-linux-x64-baseline: 1.3.2
-      opencode-linux-x64-baseline-musl: 1.3.2
-      opencode-linux-x64-musl: 1.3.2
-      opencode-windows-arm64: 1.3.2
-      opencode-windows-x64: 1.3.2
-      opencode-windows-x64-baseline: 1.3.2
-
-  opencode-darwin-arm64@1.3.2:
-    optional: true
-
-  opencode-darwin-x64-baseline@1.3.2:
-    optional: true
-
-  opencode-darwin-x64@1.3.2:
-    optional: true
-
-  opencode-linux-arm64-musl@1.3.2:
-    optional: true
-
-  opencode-linux-arm64@1.3.2:
-    optional: true
-
-  opencode-linux-x64-baseline-musl@1.3.2:
-    optional: true
-
-  opencode-linux-x64-baseline@1.3.2:
-    optional: true
-
-  opencode-linux-x64-musl@1.3.2:
-    optional: true
-
-  opencode-linux-x64@1.3.2:
-    optional: true
-
-  opencode-windows-arm64@1.3.2:
-    optional: true
-
-  opencode-windows-x64-baseline@1.3.2:
-    optional: true
-
-  opencode-windows-x64@1.3.2:
-    optional: true
-
-  openurl@1.1.1: {}
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10180,8 +8667,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  os-tmpdir@1.0.2: {}
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -10189,11 +8674,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-retry@4.6.2:
-    dependencies:
-      '@types/retry': 0.12.0
-      retry: 0.13.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -10233,11 +8713,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.7
-      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 
@@ -10291,20 +8766,6 @@ snapshots:
       sonic-boom: 4.2.0
       thread-stream: 4.0.0
 
-  pino@10.3.1:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 3.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 4.0.0
-
   pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
@@ -10342,25 +8803,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-    optional: true
-
   prelude-ls@1.2.1: {}
-
-  process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
 
@@ -10745,14 +9188,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-    optional: true
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -10809,13 +9244,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-    optional: true
 
   readdirp@4.1.2: {}
 
@@ -10893,13 +9321,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  ret@0.5.0: {}
-
-  retry@0.13.1: {}
-
   reusify@1.1.0: {}
-
-  rfdc@1.4.1: {}
 
   robust-predicates@3.0.2: {}
 
@@ -10931,8 +9353,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.5
       fsevents: 2.3.3
 
-  rotating-file-stream@3.2.9: {}
-
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -10954,10 +9374,6 @@ snapshots:
       mri: 1.2.0
 
   safe-buffer@5.2.1: {}
-
-  safe-regex2@5.1.0:
-    dependencies:
-      ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
 
@@ -10990,8 +9406,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
-
-  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
@@ -11029,8 +9443,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.3: {}
 
   shellwords@0.1.1: {}
 
@@ -11077,23 +9489,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-    optional: true
-
   sisteransi@1.0.5: {}
 
   sonic-boom@4.2.0:
-    dependencies:
-      atomic-sleep: 1.0.0
-
-  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -11138,11 +9536,6 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -11157,9 +9550,6 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-indent@4.1.1: {}
-
-  strip-json-comments@2.0.1:
-    optional: true
 
   strip-json-comments@3.1.1: {}
 
@@ -11195,30 +9585,11 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-    optional: true
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-    optional: true
-
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
 
   throttle-debounce@5.0.2: {}
-
-  tiktoken@1.0.22: {}
 
   tinybench@2.9.0: {}
 
@@ -11241,15 +9612,9 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toad-cache@3.7.0: {}
 
   toggle-selection@1.0.6: {}
 
@@ -11276,16 +9641,9 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@0.21.3: {}
 
   type-fest@4.2.0: {}
 
@@ -11305,8 +9663,6 @@ snapshots:
   ufo@1.6.1: {}
 
   undici-types@6.21.0: {}
-
-  undici@7.24.6: {}
 
   unified@11.0.5:
     dependencies:
@@ -11532,8 +9888,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  web-streams-polyfill@3.3.3: {}
-
   web-worker@1.5.0: {}
 
   which@2.0.2:
@@ -11546,12 +9900,6 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
-
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -11569,8 +9917,6 @@ snapshots:
 
   ws@8.19.0: {}
 
-  ws@8.20.0: {}
-
   xml-name-validator@4.0.0: {}
 
   yallist@3.1.1: {}
@@ -11585,8 +9931,6 @@ snapshots:
   ylru@1.4.0: {}
 
   yocto-queue@0.1.0: {}
-
-  yoctocolors-cjs@2.1.3: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary
- Move adapter-native CLIs out of adapter package runtime dependencies and install them lazily into the project shared cache.
- Add version/source/path controls for every managed adapter CLI, including Kimi's uv-managed CLI and Claude Code Router as a separate target.
- Make shared CLI cache resolution work from linked git worktrees by resolving back to the primary workspace `.ai/caches`.
- Add `vf adapter prepare` plus an opt-in `@vibe-forge/cli` postinstall prewarm path for users who want CLIs downloaded during dependency installation.

## Design

### Managed CLI Runtime
Adapter packages no longer bundle heavyweight native CLIs. Each adapter resolves its native executable in this order:

1. Explicit path from config or env, for example `adapters.codex.cli.path` or `__VF_PROJECT_AI_ADAPTER_CODEX_CLI_PATH__`.
2. Managed project cache under `.ai/caches/adapter-<adapter>/cli/...`.
3. System `PATH`, unless `source: managed` is configured.
4. Auto-install into the managed cache when `autoInstall !== false`.

For npm-based CLIs this is centralized in `@vibe-forge/utils/managed-npm-cli`. Kimi keeps its uv tool install flow, but now uses the same shared project cache semantics.

### Worktree-Aware Shared Cache
Reusable resources should not be duplicated per linked worktree. `project-cache-path` resolves the cache root by:

1. honoring `__VF_PROJECT_AI_CACHE_DIR__` if explicitly set;
2. honoring `__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__` if set;
3. falling back to `git rev-parse --git-common-dir` to find the primary git worktree;
4. falling back to the current workspace.

Session-scoped state, mock home, and logs remain in the active worktree. Only reusable assets such as adapter CLIs and skill dependency bundles are shared upward to the primary workspace cache.

### Version and Source Control
Every adapter exposes user-facing CLI controls in config:

- npm adapters: `adapters.<name>.cli.source`, `path`, `package`, `version`, `autoInstall`, `npmPath`, `prepareOnInstall`
- Claude Code: `adapters.claude-code.cli` for Claude Code and `adapters.claude-code.routerCli` for CCR
- Kimi: `adapters.kimi.cli.source`, `path`, `package`, `version`, `python`, `autoInstall`, `uvPath`, `prepareOnInstall`

Environment overrides follow the existing adapter env naming, for example `__VF_PROJECT_AI_ADAPTER_CODEX_INSTALL_VERSION__` and `__VF_PROJECT_AI_ADAPTER_CLAUDE_CODE_ROUTER_CLI_PATH__`.

### Prepare Command
`vf adapter prepare` prewarms managed CLI resources without starting an adapter session.

- `vf adapter prepare` prepares only config entries with `prepareOnInstall: true`.
- `vf adapter prepare --all` prepares every known installed adapter CLI target.
- `vf adapter prepare codex claude-code gemini` prepares explicit adapters.
- `vf adapter prepare claude-code.routerCli` or `vf adapter prepare ccr` prepares Claude Code Router only.

Each adapter exports a lightweight `./cli-prepare` entry so the CLI can invoke the same installer logic without importing the full session runtime. During prepare, unspecified `source` defaults to `managed`, so prewarming actually populates `.ai/caches` even if a system CLI exists. Explicit `source: system` or `source: path` is still respected.

### Postinstall Prewarm
`@vibe-forge/cli` now has a conservative `postinstall` shim. It is intentionally opt-in:

- It only reads `.ai.config.json` or `infra/.ai.config.json` from `INIT_CWD`.
- It only runs when at least one adapter CLI config has `prepareOnInstall: true`.
- It delegates to `vf adapter prepare --from-postinstall`; there is no separate download implementation.
- It skips `CI=true` by default unless `VIBE_FORGE_POSTINSTALL_PREPARE=1` is set.
- It can be skipped with `VIBE_FORGE_SKIP_ADAPTER_PREPARE=1` or `VIBE_FORGE_SKIP_POSTINSTALL=1`.
- Failures warn by default instead of breaking dependency installation; `VIBE_FORGE_POSTINSTALL_STRICT=1` makes failures fatal.

This keeps normal dependency installation side-effect-light while supporting projects that want an offline/CI image prewarm step.

### CLI Version Defaults
- `@openai/codex` `0.121.0`
- `@google/gemini-cli` `0.38.2`
- `@github/copilot` `1.0.32`
- `opencode-ai` `1.14.18`
- `@anthropic-ai/claude-code` `2.1.114`
- `@musistudio/claude-code-router` `1.0.73` (intentionally not upgraded to 2.x)
- `kimi-cli` `1.36.0`

## Smoke Verification
- Forced Codex managed install in a zero project and verified `vf run -A codex` returns a real response.
- Verified Codex linked worktree smoke installs managed `codex` into the primary workspace `.ai/caches`, not the linked worktree.
- Verified real npm managed install for `@anthropic-ai/claude-code@2.1.114`.
- Verified real npm managed install for `@musistudio/claude-code-router@1.0.73`; fixed CCR validation to use `ccr version` instead of `ccr --version`.
- Verified real npm managed install for Gemini, Copilot, and OpenCode.
- Verified `kimi-cli==1.36.0` supports `kimi --version` in a Python venv.
- Verified `vf adapter prepare` no-ops when no config opts in.
- Verified `vf adapter prepare` with fake npm prewarms Codex into `.ai/caches`.
- Verified `postinstall.js` is a no-op without opt-in config.
- Verified `postinstall.js` triggers the same prepare path with fake npm when `.ai.config.json` has `prepareOnInstall: true`.

## Tests
- `pnpm exec vitest run apps/cli/__tests__/adapter-prepare.spec.ts apps/cli/__tests__/run.spec.ts packages/utils/__tests__/managed-npm-cli.spec.ts packages/adapters/kimi/__tests__/runtime-config.spec.ts packages/config/__tests__/schema.spec.ts packages/adapters/codex/__tests__/session.spec.ts packages/adapters/claude-code/__tests__/paths.spec.ts packages/adapters/gemini/__tests__/shared.spec.ts packages/adapters/copilot/__tests__/paths.spec.ts packages/adapters/opencode/__tests__/runtime-common.spec.ts`
- `pnpm exec dprint check ...changed files...`
- `pnpm exec eslint ...changed files...`
- `pnpm typecheck`