### PR TITLE
feat(config): add inherited editing flow and mobile config nav

### DIFF
--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -34,6 +34,25 @@
 - 二级详情页会在 section 标题右侧展示字段路径面包屑，并提供返回入口；返回时会尽量恢复上一级列表的滚动位置。
 - 当前 `general.recommendedModels`、`general.notifications.events`、`modelServices`、`channels`、`adapters`、`plugins.plugins`、`plugins.marketplaces` 和 `mcp.mcpServers` 已经切到这套模式。
 
+### 继承与覆盖规则
+
+- `project` / `user` 配置页编辑的是当前 source 文件里的原始配置，不是 `extends` 展开后的结果。
+- `merged` 视图展示的是最终生效配置；它用于查看效果，不承担 source 文件编辑语义。
+- 如果某个值只来自 `extends`，界面会先按“继承值”展示；是否允许直接开始编辑，取决于字段类型和集合合并语义。
+
+| 类别                                | 代表字段                                                              | 继承态展示                       | 开始编辑方式                                | 写回粒度           |
+| ----------------------------------- | --------------------------------------------------------------------- | -------------------------------- | ------------------------------------------- | ------------------ |
+| inline override                     | `string` / `multiline` / `number` / `boolean` / `select` / `shortcut` | 直接把 inherited 值显示在控件里  | 直接修改                                    | 单个 field         |
+| 显式 whole-field override           | `string[]` / `json` / `record`                                        | 先只读展示 inherited 值          | 点 `Override in current config` 后再修改    | 整个 field         |
+| 显式 item override                  | `record` / `recordMap` 型 detail collection                           | 列表里标 `Inherited`，详情页只读 | 进入详情页后点 `Override in current config` | 单个 item          |
+| 允许 item override 的 list          | 有稳定 merge key 的 list detail collection                            | 同上                             | 同上                                        | 单个 item          |
+| 不允许 single-item override 的 list | append-only list detail collection                                    | 列表里标 `Inherited`，详情页只读 | 不能直接覆盖继承条目，只能新增本地项        | 只能 append 本地项 |
+
+- 当前按 `id + scope` 识别稳定 merge key 的列表是 `plugins.plugins`。
+- 当前按追加语义处理、不能单条覆盖继承项的列表是 `general.recommendedModels`。
+- 当前按对象条目做显式 item override 的字段包括：`modelServices`、`channels`、`adapters`、`plugins.marketplaces`、`mcp.mcpServers`、`general.notifications.events`。
+- 简单标量字段如果来自 `extends`，修改后会在当前 source 文件里落一个本地 override，不会回写到上游继承文件。
+
 ## Worktree 环境脚本
 
 每个环境目录可以包含这些脚本：

--- a/.ai/docs/usage/web.md
+++ b/.ai/docs/usage/web.md
@@ -30,6 +30,7 @@
 ## 配置页交互
 
 - 简单字段仍然在 section 页面内直接编辑。
+- 桌面端配置页左侧 section 导航支持搜索和折叠；收起左侧导航后，内容区标题左侧会出现一个展开按钮，方便在不离开当前配置页的情况下重新打开导航。
 - 复杂集合字段会拆成“一级摘要页 + 二级详情页”的模式：数组型字段在一级页负责新增、删除和排序；对象型字段会展示固定条目和快捷开关，进入二级页后再做细粒度配置。
 - 二级详情页会在 section 标题右侧展示字段路径面包屑，并提供返回入口；返回时会尽量恢复上一级列表的滚动位置。
 - 当前 `general.recommendedModels`、`general.notifications.events`、`modelServices`、`channels`、`adapters`、`plugins.plugins`、`plugins.marketplaces` 和 `mcp.mcpServers` 已经切到这套模式。

--- a/apps/client/__tests__/config-schema-form.spec.tsx
+++ b/apps/client/__tests__/config-schema-form.spec.tsx
@@ -479,6 +479,90 @@ describe('config schema form', () => {
     expect(html).toContain('config.fields.modelServices.item.models.label')
   })
 
+  it('renders inherited detail-collection entries as readonly summaries in source views', () => {
+    const html = renderToStaticMarkup(
+      <SectionForm
+        sectionKey='modelServices'
+        value={{}}
+        resolvedValue={{
+          openai: {
+            title: 'OpenAI',
+            description: 'Inherited service'
+          }
+        }}
+        onChange={() => undefined}
+        mergedModelServices={{}}
+        mergedAdapters={{}}
+        t={t}
+      />
+    )
+
+    expect(html).toContain('OpenAI')
+    expect(html).toContain('config.detail.inheritedBadge')
+  })
+
+  it('renders inherited detail routes as readonly pages with an explicit override action', () => {
+    const html = renderToStaticMarkup(
+      <SectionForm
+        sectionKey='modelServices'
+        value={{}}
+        resolvedValue={{
+          openai: {
+            title: 'OpenAI',
+            description: 'Inherited service',
+            apiBaseUrl: 'https://api.openai.com/v1'
+          }
+        }}
+        onChange={() => undefined}
+        mergedModelServices={{}}
+        mergedAdapters={{}}
+        detailRoute={{
+          kind: 'detailCollectionItem',
+          fieldPath: [],
+          itemKey: 'openai'
+        }}
+        t={t}
+      />
+    )
+
+    expect(html).toContain('config.detail.inheritedReadonly')
+    expect(html).toContain('config.detail.override')
+    expect(html).toContain('config.fields.modelServices.item.apiBaseUrl.label')
+  })
+
+  it('renders local detail overrides with inherited field context', () => {
+    const html = renderToStaticMarkup(
+      <SectionForm
+        sectionKey='modelServices'
+        value={{
+          openai: {
+            apiBaseUrl: 'https://proxy.internal/v1'
+          }
+        }}
+        resolvedValue={{
+          openai: {
+            title: 'OpenAI',
+            description: 'Inherited service',
+            apiBaseUrl: 'https://proxy.internal/v1'
+          }
+        }}
+        onChange={() => undefined}
+        mergedModelServices={{}}
+        mergedAdapters={{}}
+        detailRoute={{
+          kind: 'detailCollectionItem',
+          fieldPath: [],
+          itemKey: 'openai'
+        }}
+        t={t}
+      />
+    )
+
+    expect(html).toContain('config.detail.partialOverride')
+    expect(html).toContain('config.fields.modelServices.item.title.label')
+    expect(html).toContain('config.fields.modelServices.item.description.label')
+  })
+
   it('renders mcp server detail collections as second-level config pages', () => {
     const html = renderToStaticMarkup(
       <SectionForm

--- a/apps/client/src/components/ConfigView.scss
+++ b/apps/client/src/components/ConfigView.scss
@@ -10,35 +10,22 @@
     display: flex;
     flex: 1;
     min-height: 0;
-    flex-direction: column;
-    gap: 0;
+    position: relative;
+    overflow: hidden;
   }
 
-  &__compact-controls {
+  &__compact-region {
+    flex: 1;
     display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 12px;
-    padding-bottom: 0;
-  }
-
-  &__compact-select {
-    width: 100%;
-
-    .ant-select-selector {
-      min-height: 36px !important;
-      border-radius: 8px !important;
-      padding-inline: 10px !important;
-      background: var(--subpage-content-card-bg) !important;
-    }
+    min-width: 0;
+    min-height: 0;
   }
 
   &__compact-panel {
     display: flex;
     flex: 1;
     min-height: 0;
-    margin: var(--subpage-content-card-gap);
-    margin-top: 12px;
+    margin: max(4px, env(safe-area-inset-top)) 4px 4px;
     border-radius: var(--subpage-content-card-radius);
     background: var(--subpage-content-card-bg);
     overflow: hidden;
@@ -411,10 +398,273 @@ html.dark .config-view__card {
   justify-content: center;
 }
 
+.config-view__compact-backdrop {
+  position: fixed;
+  inset: 0;
+  border: none;
+  background: rgba(0, 0, 0, .28);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity .24s ease, visibility 0s linear .24s;
+  z-index: 60;
+}
+
+.config-view__compact-backdrop.is-open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+
+.config-view__compact-sidebar-sheet {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: min(320px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  padding: max(4px, env(safe-area-inset-top)) 0
+    max(4px, env(safe-area-inset-bottom)) max(4px, env(safe-area-inset-left));
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition:
+    transform .24s cubic-bezier(.4, 0, .2, 1),
+    visibility 0s linear .24s;
+  z-index: 61;
+  pointer-events: none;
+  overscroll-behavior: contain;
+}
+
+.config-view__compact-sidebar-sheet.is-open {
+  transform: translateX(0);
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+
+.config-view__compact-sidebar-sheet > * {
+  height: 100%;
+  overflow: hidden;
+  border-radius: 0 8px 8px 0;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, .22);
+  overscroll-behavior: contain;
+}
+
 .config-view__tab-text {
   font-size: 12px;
   color: var(--text-color);
   line-height: 16px;
+}
+
+.config-view__desktop-shell {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.config-view__sidebar {
+  display: flex;
+  flex-direction: column;
+  width: var(--subpage-secondary-panel-width);
+  min-width: var(--subpage-secondary-panel-width);
+  max-width: var(--subpage-secondary-panel-width);
+  overflow: hidden;
+  background: var(--sub-bg-color);
+  transition:
+    width .24s cubic-bezier(.4, 0, .2, 1),
+    min-width .24s cubic-bezier(.4, 0, .2, 1),
+    max-width .24s cubic-bezier(.4, 0, .2, 1),
+    opacity .18s ease;
+}
+
+.config-view__sidebar--compact {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  height: 100%;
+}
+
+.config-view__desktop-shell.is-sidebar-collapsed .config-view__sidebar {
+  width: 0;
+  min-width: 0;
+  max-width: 0;
+  opacity: 0;
+}
+
+.config-view__sidebar-header {
+  padding: 8px 12px;
+  flex-shrink: 0;
+}
+
+.config-view__sidebar-search-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.config-view__sidebar-toggle.ant-btn {
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 6px;
+  color: var(--sub-text-color);
+}
+
+.config-view__sidebar-toggle.ant-btn .material-symbols-rounded {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.config-view__sidebar-search-input {
+  flex: 1;
+  height: 30px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.config-view__sidebar-search-input.ant-input-affix-wrapper {
+  padding-inline: 8px;
+}
+
+.config-view__sidebar-search-input.ant-input-affix-wrapper-focused,
+.config-view__sidebar-search-input.ant-input-affix-wrapper:focus-within {
+  border-color: rgba(37, 99, 235, .32) !important;
+  box-shadow: none !important;
+}
+
+.config-view__sidebar-search-input .ant-input {
+  font-size: 12px;
+}
+
+.config-view__sidebar-search-input .ant-input-prefix {
+  margin-inline-end: 4px;
+}
+
+.config-view__sidebar-search-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--sub-text-color);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.config-view__sidebar-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 12px 12px;
+  overflow: auto;
+}
+
+.config-view__sidebar-empty {
+  padding: 8px 2px;
+  font-size: 12px;
+  color: var(--sub-text-color);
+}
+
+.config-view__nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.config-view__nav-group-label {
+  padding: 2px;
+  color: var(--sub-text-color);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.config-view__nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.config-view__nav-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: var(--bg-color);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: .2s ease;
+}
+
+.config-view__nav-item:hover {
+  border-color: rgba(37, 99, 235, .18);
+  background-color: var(--tag-hover-bg);
+}
+
+.config-view__nav-item.is-active {
+  border-color: var(--primary-color);
+  background: var(--primary-soft-bg);
+  color: var(--sidebar-active-text, var(--primary-color));
+}
+
+.config-view__nav-item.is-active .config-view__tab-icon,
+.config-view__nav-item.is-active .config-view__tab-text {
+  color: var(--sidebar-active-text, var(--primary-color));
+}
+
+.config-view__nav-item.is-active .material-symbols-rounded {
+  font-variation-settings: 'FILL' 1;
+}
+
+.config-view__desktop-content {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  margin: var(--subpage-content-card-gap);
+  margin-left: 0;
+  padding: 12px;
+  border-radius: var(--subpage-content-card-radius);
+  background: var(--subpage-content-card-bg);
+  box-sizing: border-box;
+  overflow: hidden;
+  transition: margin-left .24s cubic-bezier(.4, 0, .2, 1);
+}
+
+.config-view__desktop-shell.is-sidebar-collapsed .config-view__desktop-content {
+  margin-left: var(--subpage-content-card-gap);
+}
+
+.config-view__standalone-header {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+}
+
+.config-view__section-toggle.ant-btn {
+  flex: 0 0 auto;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  margin-left: -6px;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.config-view__section-toggle.ant-btn .material-symbols-rounded {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.config-view__section-toggle.ant-btn:hover,
+.config-view__section-toggle.ant-btn:focus-visible,
+.config-view__section-toggle.ant-btn:active {
+  background: transparent;
 }
 
 .config-view__tabs > .ant-tabs-nav {
@@ -525,6 +775,26 @@ html.dark .config-view__card {
   }
 
   .config-view--compact {
+    .config-view__section-header {
+      align-items: flex-start;
+      flex-direction: row;
+      gap: 8px;
+    }
+
+    .config-view__section-header-extra {
+      width: auto;
+      justify-content: flex-end;
+      flex-wrap: nowrap;
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+
+    .config-view__section-title,
+    .config-view__detail-trail {
+      min-width: 0;
+      flex: 1 1 auto;
+    }
+
     .config-view__body {
       padding: 0;
     }
@@ -538,5 +808,17 @@ html.dark .config-view__card {
     .config-view__card {
       overflow: visible;
     }
+
+    .config-view__compact-panel {
+      border-radius: 8px;
+    }
   }
+}
+
+html.dark .config-view__compact-backdrop {
+  background: rgba(0, 0, 0, .48);
+}
+
+html.dark .config-view__compact-sidebar-sheet > * {
+  box-shadow: 0 18px 44px rgba(0, 0, 0, .42);
 }

--- a/apps/client/src/components/ConfigView.scss
+++ b/apps/client/src/components/ConfigView.scss
@@ -316,7 +316,70 @@ html.dark .config-view__card {
 .config-view__source-option {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  line-height: 0;
+}
+
+.config-view__source-option-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.config-view__source-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--sub-bg-color);
+}
+
+.config-view__source-switch-button.ant-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--sub-text-color);
+  box-shadow: none;
+}
+
+.config-view__source-switch-button.ant-btn:hover,
+.config-view__source-switch-button.ant-btn:focus-visible {
+  background: color-mix(in srgb, var(--tag-hover-bg) 82%, transparent);
+  color: var(--text-color);
+}
+
+.config-view__source-switch-button.ant-btn.is-active,
+.config-view__source-switch-button.ant-btn.is-active:hover,
+.config-view__source-switch-button.ant-btn.is-active:focus-visible {
+  background: var(--subpage-content-card-bg);
+  color: var(--sidebar-active-text, var(--primary-color));
+  box-shadow: 0 1px 2px rgba(15, 23, 42, .08);
+}
+
+.config-view__source-switch-button.ant-btn
+  .material-symbols-rounded {
+  display: block;
+  font-size: 14px;
+  width: 14px;
+  height: 14px;
+  line-height: 14px;
 }
 
 .config-view .ant-empty-image {
@@ -440,13 +503,6 @@ html.dark .config-view__card {
   width: 100%;
   margin-left: 0;
   padding: 0;
-}
-
-@media (max-width: 1100px) {
-  .config-view__tabs > .ant-tabs-content-holder {
-    margin-top: 0;
-    margin-left: var(--subpage-content-card-gap);
-  }
 }
 
 @media (max-width: 960px) {

--- a/apps/client/src/components/ConfigView.tsx
+++ b/apps/client/src/components/ConfigView.tsx
@@ -1,6 +1,6 @@
 import './ConfigView.scss'
 
-import { App, Empty, Select, Space, Spin, Tabs } from 'antd'
+import { App, Button, Empty, Input, Space, Spin, Tooltip } from 'antd'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
@@ -9,6 +9,7 @@ import type { ConfigSource } from '@vibe-forge/core'
 import type { AboutInfo, ConfigResponse, ConfigUiSection } from '@vibe-forge/types'
 
 import { PageShell } from '#~/components/layout/PageShell'
+import { useMobileSidebarModal } from '#~/components/layout/@hooks/use-mobile-sidebar-modal'
 import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 import { getApiErrorMessage, getConfig, getConfigSchema, listWorktreeEnvironments, updateConfig } from '../api'
@@ -40,14 +41,20 @@ export function ConfigView() {
   const querySourceKey: ConfigSource = queryValues.source === 'user' ? 'user' : 'project'
   const [sourceKey, setSourceKeyState] = useState<ConfigSource>(querySourceKey)
   const [detailQuery, setDetailQueryState] = useState(queryValues.detail)
+  const [navSearchQuery, setNavSearchQuery] = useState('')
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
   const [drafts, setDrafts] = useState<Record<string, unknown>>({})
   const configPresent = data?.meta?.configPresent
   const currentSource = data?.sources?.[sourceKey]
   const currentResolvedSource = data?.resolvedSources?.[sourceKey]
   const draftsRef = useRef<Record<string, unknown>>(drafts)
+  const compactContentRegionRef = useRef<HTMLDivElement | null>(null)
+  const compactSidebarSheetRef = useRef<HTMLDivElement | null>(null)
   const saveTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   const savingRef = useRef<Record<string, boolean>>({})
   const lastSavedRef = useRef<Record<string, string>>({})
+  const compactSidebarBackgroundRefs = useMemo(() => [compactContentRegionRef], [])
   const mergedModelServices = useMemo(() => data?.sources?.merged?.modelServices ?? {}, [
     data?.sources?.merged?.modelServices
   ])
@@ -124,6 +131,40 @@ export function ConfigView() {
     { key: 'about', icon: 'info', label: t('config.sections.about'), value: data?.meta?.about }
   ], [currentSource, data?.meta?.about, data?.meta?.experiments, t])
   const tabKeys = useMemo(() => new Set(tabs.filter(tab => tab.type !== 'group').map(tab => tab.key)), [tabs])
+  const desktopNavGroups = useMemo(() => {
+    const query = navSearchQuery.trim().toLowerCase()
+    const groups: Array<{ key: string; label: string; tabs: Array<typeof tabs[number]> }> = []
+    let currentGroup: { key: string; label: string; tabs: Array<typeof tabs[number]> } | null = null
+
+    tabs.forEach((tab) => {
+      if (tab.type === 'group') {
+        if (currentGroup != null && currentGroup.tabs.length > 0) {
+          groups.push(currentGroup)
+        }
+        currentGroup = { key: tab.key, label: String(tab.label), tabs: [] }
+        return
+      }
+
+      if (currentGroup == null) {
+        currentGroup = { key: 'group-config', label: t('config.groups.config'), tabs: [] }
+      }
+
+      const label = String(tab.label)
+      const matches = query === ''
+        || label.toLowerCase().includes(query)
+        || tab.key.toLowerCase().includes(query)
+
+      if (matches) {
+        currentGroup.tabs.push(tab)
+      }
+    })
+
+    if (currentGroup != null && currentGroup.tabs.length > 0) {
+      groups.push(currentGroup)
+    }
+
+    return groups
+  }, [navSearchQuery, t, tabs])
 
   const queryTabKey = tabKeys.has(queryValues.tab) ? queryValues.tab : 'general'
   const [activeTabKey, setActiveTabKeyState] = useState(queryTabKey)
@@ -141,33 +182,34 @@ export function ConfigView() {
     updateQuery({ tab: key, detail: '' })
   }
   const isCompactView = isCompactLayout || isTouchInteraction
+  const resolveTooltipTitle = (title: string) => isTouchInteraction ? undefined : title
 
   const activeTab = useMemo(() => tabs.find(tab => tab.key === activeTabKey), [tabs, activeTabKey])
-  const compactTabOptions = useMemo(() => {
-    const groups: Array<{ label: string; options: Array<{ label: string; value: string }> }> = []
-    let currentGroup: { label: string; options: Array<{ label: string; value: string }> } | null = null
-
-    tabs.forEach((tab) => {
-      if (tab.type === 'group') {
-        currentGroup = { label: String(tab.label), options: [] }
-        groups.push(currentGroup)
-        return
-      }
-
-      if (currentGroup == null) {
-        currentGroup = { label: t('config.groups.config'), options: [] }
-        groups.push(currentGroup)
-      }
-
-      currentGroup.options.push({
-        value: tab.key,
-        label: String(tab.label)
-      })
-    })
-
-    return groups
-  }, [tabs, t])
   const uiSections = schemaData?.workspace.uiSchema?.sections ?? {}
+  const sourceOptions = useMemo(() => [
+    {
+      value: 'project' as const,
+      icon: 'folder',
+      label: configPresent?.project === true
+        ? t('config.sources.project')
+        : t('config.sources.projectMissing')
+    },
+    {
+      value: 'user' as const,
+      icon: 'person',
+      label: configPresent?.user === true
+        ? t('config.sources.user')
+        : t('config.sources.userMissing')
+    }
+  ], [configPresent?.project, configPresent?.user, t])
+
+  useMobileSidebarModal({
+    backgroundRefs: compactSidebarBackgroundRefs,
+    isCompactLayout: isCompactView,
+    isMobileSidebarOpen,
+    setIsMobileSidebarOpen,
+    sheetRef: compactSidebarSheetRef
+  })
 
   useEffect(() => {
     if (activeTab == null) return
@@ -197,6 +239,16 @@ export function ConfigView() {
   useEffect(() => {
     setDetailQueryState(queryValues.detail)
   }, [queryValues.detail])
+
+  useEffect(() => {
+    if (!isCompactView) return
+    setIsSidebarCollapsed(false)
+  }, [isCompactView])
+
+  useEffect(() => {
+    if (isCompactView) return
+    setIsMobileSidebarOpen(false)
+  }, [isCompactView])
 
   useEffect(() => {
     draftsRef.current = drafts
@@ -265,8 +317,106 @@ export function ConfigView() {
     scheduleSave(sectionKey, sourceKey, nextValue)
   }
 
-  const renderTabContent = (tab: typeof tabs[number]) => (
+  const renderSidebarExpandButton = () => (
+    <Tooltip title={resolveTooltipTitle(t('common.expand'))} placement='bottom'>
+      <Button
+        size='small'
+        type='text'
+        className='config-view__section-toggle'
+        aria-label={t('common.expand')}
+        icon={<span className='material-symbols-rounded'>left_panel_open</span>}
+        onClick={() => {
+          if (isCompactView) {
+            setIsMobileSidebarOpen(true)
+            return
+          }
+          setIsSidebarCollapsed(false)
+        }}
+      />
+    </Tooltip>
+  )
+
+  const renderStandaloneHeader = (showSidebarToggle: boolean) => {
+    if (!showSidebarToggle) return null
+    return (
+      <div className='config-view__standalone-header'>
+        {renderSidebarExpandButton()}
+      </div>
+    )
+  }
+
+  const renderSidebar = ({ compact = false }: { compact?: boolean } = {}) => (
+    <div className={`config-view__sidebar ${compact ? 'config-view__sidebar--compact' : ''}`}>
+      <div className='config-view__sidebar-header'>
+        <div className='config-view__sidebar-search-row'>
+          <Input
+            allowClear
+            value={navSearchQuery}
+            onChange={(event) => setNavSearchQuery(event.target.value)}
+            prefix={<span className='material-symbols-rounded config-view__sidebar-search-icon'>search</span>}
+            placeholder={t('config.navigation.search')}
+            className='config-view__sidebar-search-input'
+          />
+          <Tooltip
+            title={resolveTooltipTitle(compact ? t('common.close') : t('common.collapse'))}
+            placement='bottom'
+          >
+            <Button
+              type='text'
+              className='config-view__sidebar-toggle'
+              aria-label={compact ? t('common.close') : t('common.collapse')}
+              onClick={() => {
+                if (compact) {
+                  setIsMobileSidebarOpen(false)
+                  return
+                }
+                setIsSidebarCollapsed(true)
+              }}
+              icon={<span className='material-symbols-rounded'>{compact ? 'close' : 'left_panel_close'}</span>}
+            />
+          </Tooltip>
+        </div>
+      </div>
+      <div className='config-view__sidebar-body'>
+        {desktopNavGroups.length === 0
+          ? (
+            <div className='config-view__sidebar-empty'>{t('config.navigation.noResults')}</div>
+          )
+          : desktopNavGroups.map(group => (
+            <div key={group.key} className='config-view__nav-group'>
+              <div className='config-view__nav-group-label'>{group.label}</div>
+              <div className='config-view__nav-list'>
+                {group.tabs.map(tab => (
+                  <button
+                    key={tab.key}
+                    type='button'
+                    className={`config-view__nav-item ${activeTabKey === tab.key ? 'is-active' : ''}`}
+                    onClick={() => {
+                      setActiveTabKey(tab.key)
+                      if (compact) {
+                        setIsMobileSidebarOpen(false)
+                      }
+                    }}
+                  >
+                    <span className='config-view__tab-label'>
+                      <span className='material-symbols-rounded config-view__tab-icon'>{tab.icon}</span>
+                      <span className='config-view__tab-text'>{tab.label}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  )
+
+  const renderTabContent = (
+    tab: typeof tabs[number],
+    { showSidebarToggle = false }: { showSidebarToggle?: boolean } = {}
+  ) => (
     <div key={`${sourceKey}:${tab.key}`} className='config-view__content'>
+      {renderStandaloneHeader(showSidebarToggle && !configTabKeys.has(tab.key))}
       {tab.key === 'about' && (
         <AboutSection value={tab.value as AboutInfo | undefined} />
       )}
@@ -302,32 +452,16 @@ export function ConfigView() {
           detailQuery={activeTabKey === tab.key ? detailQuery : ''}
           onDetailQueryChange={activeTabKey === tab.key ? setDetailQuery : undefined}
           t={t}
-          headerExtra={isCompactView
-            ? undefined
-            : (
-              <Space size={12}>
-                <ConfigSourceSwitch
-                  value={sourceKey}
-                  onChange={setSourceKey}
-                  options={[
-                    {
-                      value: 'project',
-                      icon: 'folder',
-                      label: configPresent?.project === true
-                        ? t('config.sources.project')
-                        : t('config.sources.projectMissing')
-                    },
-                    {
-                      value: 'user',
-                      icon: 'person',
-                      label: configPresent?.user === true
-                        ? t('config.sources.user')
-                        : t('config.sources.userMissing')
-                    }
-                  ]}
-                />
-              </Space>
-            )}
+          headerLeading={showSidebarToggle ? renderSidebarExpandButton() : undefined}
+          headerExtra={(
+            <Space size={12}>
+              <ConfigSourceSwitch
+                value={sourceKey}
+                onChange={setSourceKey}
+                options={sourceOptions}
+              />
+            </Space>
+          )}
         />
       )}
     </div>
@@ -352,77 +486,42 @@ export function ConfigView() {
         isCompactView
           ? (
             <div className='config-view__compact-shell'>
-              <div className='config-view__compact-controls'>
-                <Select
-                  value={activeTabKey}
-                  onChange={setActiveTabKey}
-                  options={compactTabOptions}
-                  className='config-view__compact-select'
-                  popupMatchSelectWidth={false}
-                />
-                {activeTab != null && configTabKeys.has(activeTab.key) && (
-                  <ConfigSourceSwitch
-                    value={sourceKey}
-                    onChange={setSourceKey}
-                    options={[
-                      {
-                        value: 'project',
-                        icon: 'folder',
-                        label: configPresent?.project === true
-                          ? t('config.sources.project')
-                          : t('config.sources.projectMissing')
-                      },
-                      {
-                        value: 'user',
-                        icon: 'person',
-                        label: configPresent?.user === true
-                          ? t('config.sources.user')
-                          : t('config.sources.userMissing')
-                      }
-                    ]}
-                  />
-                )}
+              <div
+                ref={compactContentRegionRef}
+                className='config-view__compact-region'
+                aria-hidden={isMobileSidebarOpen ? true : undefined}
+              >
+                <div className='config-view__compact-panel'>
+                  {activeTab != null ? renderTabContent(activeTab, { showSidebarToggle: true }) : null}
+                </div>
               </div>
-              <div className='config-view__compact-panel'>
-                {activeTab != null ? renderTabContent(activeTab) : null}
+              <button
+                type='button'
+                className={`config-view__compact-backdrop ${isMobileSidebarOpen ? 'is-open' : ''}`}
+                aria-label={t('common.close')}
+                aria-hidden={!isMobileSidebarOpen}
+                tabIndex={-1}
+                onClick={() => setIsMobileSidebarOpen(false)}
+              />
+              <div
+                ref={compactSidebarSheetRef}
+                className={`config-view__compact-sidebar-sheet ${isMobileSidebarOpen ? 'is-open' : ''}`}
+                role='dialog'
+                aria-modal={isMobileSidebarOpen ? 'true' : undefined}
+                aria-label={t('common.settings')}
+                aria-hidden={!isMobileSidebarOpen}
+                tabIndex={-1}
+              >
+                {renderSidebar({ compact: true })}
               </div>
             </div>
           )
           : (
-            <div className='config-view__tabs-wrap'>
-              <Tabs
-                destroyOnHidden
-                tabPosition='left'
-                tabBarGutter={4}
-                indicator={{ size: 0 }}
-                className='config-view__tabs'
-                activeKey={activeTabKey}
-                onChange={(key) => {
-                  if (key !== 'group-config' && key !== 'group-app') {
-                    setActiveTabKey(key)
-                  }
-                }}
-                items={tabs.map((tab) => {
-                  if (tab.type === 'group') {
-                    return {
-                      key: tab.key,
-                      label: <span className='config-view__group-label'>{tab.label}</span>,
-                      disabled: true,
-                      children: <div />
-                    }
-                  }
-                  return {
-                    key: tab.key,
-                    label: (
-                      <span className='config-view__tab-label'>
-                        <span className='material-symbols-rounded config-view__tab-icon'>{tab.icon}</span>
-                        <span className='config-view__tab-text'>{tab.label}</span>
-                      </span>
-                    ),
-                    children: renderTabContent(tab)
-                  }
-                })}
-              />
+            <div className={`config-view__desktop-shell ${isSidebarCollapsed ? 'is-sidebar-collapsed' : ''}`}>
+              {renderSidebar()}
+              <div className='config-view__desktop-content'>
+                {activeTab != null ? renderTabContent(activeTab, { showSidebarToggle: isSidebarCollapsed }) : null}
+              </div>
             </div>
           )
       )}

--- a/apps/client/src/components/ConfigView.tsx
+++ b/apps/client/src/components/ConfigView.tsx
@@ -43,6 +43,7 @@ export function ConfigView() {
   const [drafts, setDrafts] = useState<Record<string, unknown>>({})
   const configPresent = data?.meta?.configPresent
   const currentSource = data?.sources?.[sourceKey]
+  const currentResolvedSource = data?.resolvedSources?.[sourceKey]
   const draftsRef = useRef<Record<string, unknown>>(drafts)
   const saveTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   const savingRef = useRef<Record<string, boolean>>({})
@@ -216,7 +217,9 @@ export function ConfigView() {
   }, [drafts, currentSource?.general, sourceKey])
   const selectedModelService = (() => {
     const value = getValueByPath(generalDraftValue, ['defaultModelService'])
-    return typeof value === 'string' ? value : undefined
+    if (typeof value === 'string' && value !== '') return value
+    const fallbackValue = getValueByPath(currentResolvedSource?.general, ['defaultModelService'])
+    return typeof fallbackValue === 'string' && fallbackValue !== '' ? fallbackValue : undefined
   })()
   const worktreeEnvironmentOptions = useMemo(() => (
     worktreeEnvironmentData?.environments.map(environment => ({
@@ -286,6 +289,11 @@ export function ConfigView() {
           icon={tab.icon}
           uiSection={uiSections[tab.key] as ConfigUiSection | undefined}
           value={drafts[getDraftKey(tab.key)] ?? cloneValue(tab.value ?? {}) ?? {}}
+          resolvedValue={cloneValue(
+            currentResolvedSource != null
+              ? (currentResolvedSource as Record<string, unknown>)[tab.key]
+              : undefined
+          ) ?? {}}
           onChange={(next) => handleDraftChange(tab.key, next)}
           mergedModelServices={mergedModelServices as Record<string, unknown>}
           mergedAdapters={mergedAdapters as Record<string, unknown>}

--- a/apps/client/src/components/config/ConfigSectionForm.scss
+++ b/apps/client/src/components/config/ConfigSectionForm.scss
@@ -4,6 +4,40 @@
   gap: 6px;
 }
 
+.config-view__detail-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.config-view__detail-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: var(--subpage-tertiary-border);
+  border-radius: var(--subpage-tertiary-radius);
+  background: var(--subpage-tertiary-bg);
+}
+
+.config-view__detail-notice-text {
+  font-size: 12px;
+  color: var(--sub-text-color);
+}
+
+.config-view__field-readonly {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+}
+
+.config-view__field-readonly-value {
+  width: 100%;
+}
+
 .config-view__field-list {
   display: flex;
   flex-direction: column;

--- a/apps/client/src/components/config/ConfigSectionForm.tsx
+++ b/apps/client/src/components/config/ConfigSectionForm.tsx
@@ -1,12 +1,13 @@
 import './ConfigSectionForm.scss'
 
-import { Collapse, Empty, Input, InputNumber, Select, Slider, Switch } from 'antd'
+import { Button, Collapse, Empty, Input, InputNumber, Select, Slider, Switch } from 'antd'
 import type { ReactNode } from 'react'
 
 import type { ConfigUiSection } from '@vibe-forge/types'
 
 import { normalizeSendShortcut, resolveSendShortcut } from '#~/utils/shortcutUtils'
 
+import { DisplayValue } from './ConfigDisplayValue'
 import { ComplexTextEditor, StringArrayEditor } from './ConfigEditors'
 import { FieldRow } from './ConfigFieldRow'
 import { ShortcutInput } from './ConfigShortcutInput'
@@ -14,7 +15,7 @@ import { DetailCollectionField } from './DetailListField'
 import { McpServerItemEditor } from './McpServerItemEditor'
 import { RecommendedModelsItemEditor } from './RecommendedModelsItemEditor'
 import type { ConfigDetailRoute } from './configDetail'
-import { resolveConfigDetailRouteMeta, toDetailCollectionEntries } from './configDetail'
+import { resolveConfigDetailRouteMeta } from './configDetail'
 import type { FieldSpec } from './configSchema'
 import { configGroupMeta, configGroupOrder, configSchema } from './configSchema'
 import {
@@ -46,6 +47,7 @@ export const SectionForm = ({
   fields: providedFields,
   uiSection,
   value,
+  resolvedValue,
   onChange,
   mergedModelServices,
   mergedAdapters,
@@ -59,6 +61,7 @@ export const SectionForm = ({
   fields?: FieldSpec[]
   uiSection?: ConfigUiSection
   value: unknown
+  resolvedValue?: unknown
   onChange: (nextValue: unknown) => void
   mergedModelServices: Record<string, unknown>
   mergedAdapters: Record<string, unknown>
@@ -138,19 +141,58 @@ export const SectionForm = ({
     label: <span>{key}</span>
   }))
 
+  const renderInheritedReadonlyControl = ({
+    fieldValue,
+    fieldPath,
+    onOverride
+  }: {
+    fieldValue: unknown
+    fieldPath: string[]
+    onOverride?: () => void
+  }) => (
+    <div className='config-view__field-readonly'>
+      <div className='config-view__field-readonly-value'>
+        <DisplayValue value={fieldValue} sectionKey={sectionKey} path={fieldPath} t={t} />
+      </div>
+      {onOverride != null && (
+        <Button size='small' onClick={onOverride}>
+          {t('config.detail.override')}
+        </Button>
+      )}
+    </div>
+  )
+
   const renderField = ({
     field,
     currentValue,
+    currentResolvedValue,
     onCurrentValueChange,
-    keyPrefix
+    keyPrefix,
+    readOnly = false
   }: {
     field: FieldSpec
     currentValue: unknown
+    currentResolvedValue?: unknown
     onCurrentValueChange: (nextValue: unknown) => void
     keyPrefix: string
+    readOnly?: boolean
   }) => {
     const fieldValue = getValueByPath(currentValue, field.path)
-    const valueToUse = fieldValue !== undefined ? fieldValue : field.defaultValue
+    const resolvedFieldValue = getValueByPath(currentResolvedValue, field.path)
+    const hasLocalValue = fieldValue !== undefined
+    const hasResolvedValue = resolvedFieldValue !== undefined
+    const inheritedOnly = !hasLocalValue && hasResolvedValue
+    const canInlineOverride = field.type === 'string' ||
+      field.type === 'multiline' ||
+      field.type === 'number' ||
+      field.type === 'boolean' ||
+      field.type === 'select' ||
+      field.type === 'shortcut'
+    const valueToUse = hasLocalValue
+      ? fieldValue
+      : hasResolvedValue && canInlineOverride
+      ? resolvedFieldValue
+      : field.defaultValue
     const label = field.labelKey
       ? t(field.labelKey)
       : getFieldLabel(t, sectionKey, field.path, field.path[field.path.length - 1] ?? '')
@@ -164,8 +206,42 @@ export const SectionForm = ({
 
     let control: ReactNode = null
     const isStacked = ['multiline', 'json', 'record', 'string[]', 'detailCollection'].includes(field.type)
+    const overrideCurrentField = () => {
+      if (!hasResolvedValue) return
+      handleValueChange(resolvedFieldValue)
+    }
 
-    if (field.type === 'string') {
+    if (readOnly) {
+      control = (
+        <DisplayValue
+          value={hasResolvedValue ? resolvedFieldValue : fieldValue ?? field.defaultValue}
+          sectionKey={sectionKey}
+          path={field.path}
+          t={t}
+        />
+      )
+    } else if (field.type === 'detailCollection') {
+      control = (
+        <DetailCollectionField
+          sectionKey={sectionKey}
+          field={field}
+          value={fieldValue}
+          resolvedValue={resolvedFieldValue}
+          onChange={(next) => handleValueChange(next)}
+          onOpenDetail={(route) => onOpenDetailRoute?.(route)}
+          mergedModelServices={mergedModelServices}
+          mergedAdapters={mergedAdapters}
+          uiSection={uiSection}
+          t={t}
+        />
+      )
+    } else if (inheritedOnly && !canInlineOverride) {
+      control = renderInheritedReadonlyControl({
+        fieldValue: resolvedFieldValue,
+        fieldPath: field.path,
+        onOverride: overrideCurrentField
+      })
+    } else if (field.type === 'string') {
       const placeholder = field.placeholderKey ? t(field.placeholderKey) : undefined
       if (field.sensitive === true) {
         control = (
@@ -278,20 +354,6 @@ export const SectionForm = ({
           onChange={handleValueChange}
         />
       )
-    } else if (field.type === 'detailCollection') {
-      control = (
-        <DetailCollectionField
-          sectionKey={sectionKey}
-          field={field}
-          value={valueToUse}
-          onChange={(next) => handleValueChange(next)}
-          onOpenDetail={(route) => onOpenDetailRoute?.(route)}
-          mergedModelServices={mergedModelServices}
-          mergedAdapters={mergedAdapters}
-          uiSection={uiSection}
-          t={t}
-        />
-      )
     } else if (field.type === 'record') {
       const recordValue = (valueToUse != null && typeof valueToUse === 'object')
         ? valueToUse as Record<string, unknown>
@@ -402,13 +464,17 @@ export const SectionForm = ({
   const renderFieldGroups = ({
     currentFields,
     currentValue,
+    currentResolvedValue,
     onCurrentValueChange,
-    keyPrefix
+    keyPrefix,
+    readOnly = false
   }: {
     currentFields: FieldSpec[]
     currentValue: unknown
+    currentResolvedValue?: unknown
     onCurrentValueChange: (nextValue: unknown) => void
     keyPrefix: string
+    readOnly?: boolean
   }) => {
     const groupedFields = currentFields.reduce<Record<string, FieldSpec[]>>((acc, field) => {
       const key = field.group ?? 'default'
@@ -430,8 +496,10 @@ export const SectionForm = ({
                     renderField({
                       field,
                       currentValue,
+                      currentResolvedValue,
                       onCurrentValueChange,
-                      keyPrefix
+                      keyPrefix,
+                      readOnly
                     })
                   )}
                 </div>
@@ -443,8 +511,10 @@ export const SectionForm = ({
                   renderField({
                     field,
                     currentValue,
+                    currentResolvedValue,
                     onCurrentValueChange,
-                    keyPrefix
+                    keyPrefix,
+                    readOnly
                   })
                 )}
               </div>
@@ -507,6 +577,7 @@ export const SectionForm = ({
                     onChange={(next) => {
                       onCurrentValueChange(setValueByPath(currentValue, group.meta.togglePath!, !next))
                     }}
+                    disabled={readOnly}
                     onClick={(_, event) => {
                       event.stopPropagation()
                     }}
@@ -520,8 +591,10 @@ export const SectionForm = ({
                   renderField({
                     field,
                     currentValue,
+                    currentResolvedValue,
                     onCurrentValueChange,
-                    keyPrefix
+                    keyPrefix,
+                    readOnly
                   })
                 )}
               </div>
@@ -534,8 +607,10 @@ export const SectionForm = ({
                 renderField({
                   field,
                   currentValue,
+                  currentResolvedValue,
                   onCurrentValueChange,
-                  keyPrefix
+                  keyPrefix,
+                  readOnly
                 })
               )}
               {collapseItems.length > 0 && (
@@ -593,13 +668,20 @@ export const SectionForm = ({
     sectionKey,
     fields,
     value,
+    resolvedValue,
     route: detailRoute,
     detailContext,
     t
   })
 
   if (detailMeta != null) {
-    const updateDetailItem = (nextItem: unknown) => {
+    const detailCollection = detailMeta.field.detailCollection
+    const canOverrideInheritedDetailItem = detailCollection != null &&
+      (
+        detailCollection.collectionKind !== 'list' ||
+        detailCollection.getMergeKey != null
+      )
+    const writeDetailItem = (nextItem: unknown) => {
       if (detailMeta.field.type !== 'detailCollection' || detailMeta.field.detailCollection == null) return
       const resolvedNextItem = (
           nextItem != null &&
@@ -610,37 +692,104 @@ export const SectionForm = ({
         : {}
 
       if (detailMeta.field.detailCollection.collectionKind === 'list') {
-        const nextItems = toDetailCollectionEntries({
-          field: detailMeta.field,
-          value: getValueByPath(value, detailMeta.field.path)
-        }).map((entry) => (
-          entry.index === detailMeta.itemIndex ? resolvedNextItem : entry.item
-        ))
+        const currentListValue = getValueByPath(value, detailMeta.field.path)
+        const currentItems = Array.isArray(currentListValue)
+          ? currentListValue.filter((item): item is Record<string, unknown> => (
+            item != null &&
+            typeof item === 'object' &&
+            !Array.isArray(item)
+          ))
+          : []
+        const nextItems = [...currentItems]
+        if (detailMeta.localItemIndex == null) {
+          nextItems.push(resolvedNextItem)
+        } else {
+          nextItems[detailMeta.localItemIndex] = resolvedNextItem
+        }
         onChange(setValueByPath(value, detailMeta.field.path, nextItems))
         return
       }
 
       onChange(setValueByPath(value, [...detailMeta.field.path, detailMeta.itemKey], resolvedNextItem))
     }
+    const overrideDetailItem = () => {
+      if (!canOverrideInheritedDetailItem) return
+      writeDetailItem(detailMeta.resolvedItem)
+    }
+    const detailNotice = detailMeta.itemSource === 'inherited'
+      ? (
+        <div className='config-view__detail-notice'>
+          <div className='config-view__detail-notice-text'>
+            {canOverrideInheritedDetailItem
+              ? t('config.detail.inheritedReadonly')
+              : t('config.detail.inheritedAppendOnly')}
+          </div>
+          {canOverrideInheritedDetailItem && (
+            <Button size='small' type='primary' onClick={overrideDetailItem}>
+              {t('config.detail.override')}
+            </Button>
+          )}
+        </div>
+      )
+      : detailMeta.hasResolvedOverlay
+      ? (
+        <div className='config-view__detail-notice'>
+          <div className='config-view__detail-notice-text'>
+            {t('config.detail.partialOverride')}
+          </div>
+        </div>
+      )
+      : null
+
+    if (detailMeta.itemSource === 'inherited') {
+      if ((detailMeta.field.detailCollection?.itemFields?.length ?? 0) > 0) {
+        return (
+          <div className='config-view__detail-panel'>
+            {detailNotice}
+            {renderFieldGroups({
+              currentFields: detailMeta.field.detailCollection!.itemFields!,
+              currentValue: undefined,
+              currentResolvedValue: detailMeta.resolvedItem,
+              onCurrentValueChange: () => undefined,
+              keyPrefix: `detail:${detailMeta.field.path.join('.')}:${detailMeta.itemKey}`,
+              readOnly: true
+            })}
+          </div>
+        )
+      }
+
+      return (
+        <div className='config-view__detail-panel'>
+          {detailNotice}
+          <DisplayValue value={detailMeta.resolvedItem} sectionKey={sectionKey} path={detailMeta.field.path} t={t} />
+        </div>
+      )
+    }
 
     if (detailMeta.field.detailCollection?.detailKind === 'recommendedModels') {
       return (
-        <RecommendedModelsItemEditor
-          value={detailMeta.item}
-          onChange={updateDetailItem}
-          mergedModelServices={mergedModelServices}
-          t={t}
-        />
+        <div className='config-view__detail-panel'>
+          {detailNotice}
+          <RecommendedModelsItemEditor
+            value={detailMeta.item}
+            onChange={writeDetailItem}
+            mergedModelServices={mergedModelServices}
+            t={t}
+          />
+        </div>
       )
     }
 
     if (detailMeta.field.detailCollection?.detailKind === 'mcpServer') {
       return (
-        <McpServerItemEditor
-          value={detailMeta.item}
-          onChange={updateDetailItem}
-          t={t}
-        />
+        <div className='config-view__detail-panel'>
+          {detailNotice}
+          <McpServerItemEditor
+            value={detailMeta.item}
+            onChange={writeDetailItem}
+            t={t}
+          />
+        </div>
       )
     }
 
@@ -655,43 +804,61 @@ export const SectionForm = ({
 
       if (shouldRenderJsonFallback) {
         return (
-          <ComplexTextEditor
-            value={detailMeta.item}
-            onChange={(next) => updateDetailItem((next ?? {}) as Record<string, unknown>)}
-          />
+          <div className='config-view__detail-panel'>
+            {detailNotice}
+            <ComplexTextEditor
+              value={detailMeta.item}
+              onChange={(next) => writeDetailItem((next ?? {}) as Record<string, unknown>)}
+            />
+          </div>
         )
       }
 
       if (itemSchema != null) {
         return (
-          <SchemaObjectEditor
-            value={detailMeta.item}
-            schema={itemSchema}
-            onChange={updateDetailItem}
-            t={t}
-            hideFieldPath={isKnownEntry && uiSection.recordMap.mode === 'discriminated'
-              ? [discriminatorField]
-              : undefined}
-          />
+          <div className='config-view__detail-panel'>
+            {detailNotice}
+            <SchemaObjectEditor
+              value={detailMeta.item}
+              schema={itemSchema}
+              onChange={writeDetailItem}
+              t={t}
+              hideFieldPath={isKnownEntry && uiSection.recordMap.mode === 'discriminated'
+                ? [discriminatorField]
+                : undefined}
+            />
+          </div>
         )
       }
     }
 
     if ((detailMeta.field.detailCollection?.itemFields?.length ?? 0) > 0) {
-      return renderFieldGroups({
-        currentFields: detailMeta.field.detailCollection!.itemFields!,
-        currentValue: detailMeta.item,
-        onCurrentValueChange: updateDetailItem,
-        keyPrefix: `detail:${detailMeta.field.path.join('.')}:${detailMeta.itemKey}`
-      })
+      return (
+        <div className='config-view__detail-panel'>
+          {detailNotice}
+          {renderFieldGroups({
+            currentFields: detailMeta.field.detailCollection!.itemFields!,
+            currentValue: detailMeta.item,
+            currentResolvedValue: detailMeta.resolvedItem,
+            onCurrentValueChange: writeDetailItem,
+            keyPrefix: `detail:${detailMeta.field.path.join('.')}:${detailMeta.itemKey}`
+          })}
+        </div>
+      )
     }
 
-    return <Empty description={t('common.noData')} image={null} />
+    return (
+      <div className='config-view__detail-panel'>
+        {detailNotice}
+        <Empty description={t('common.noData')} image={null} />
+      </div>
+    )
   }
 
   return renderFieldGroups({
     currentFields: fields,
     currentValue: value,
+    currentResolvedValue: resolvedValue,
     onCurrentValueChange: onChange,
     keyPrefix: sectionKey
   })

--- a/apps/client/src/components/config/ConfigSectionPanel.tsx
+++ b/apps/client/src/components/config/ConfigSectionPanel.tsx
@@ -22,6 +22,7 @@ export function ConfigSectionPanel({
   sectionKey,
   title,
   icon,
+  headerLeading,
   fields,
   uiSection,
   value,
@@ -40,6 +41,7 @@ export function ConfigSectionPanel({
   sectionKey: string
   title?: ReactNode
   icon?: ReactNode
+  headerLeading?: ReactNode
   fields?: FieldSpec[]
   uiSection?: ConfigUiSection
   value: unknown
@@ -78,7 +80,7 @@ export function ConfigSectionPanel({
     t
   })
   const currentViewKey = getConfigDetailRouteKey(detailRoute)
-  const hasHeader = hasHeading || headerExtra != null || detailMeta != null
+  const hasHeader = hasHeading || headerLeading != null || headerExtra != null || detailMeta != null
   const headerClassName = [
     'config-view__section-header',
     !hasHeading ? 'config-view__section-header--actions-only' : ''
@@ -120,6 +122,7 @@ export function ConfigSectionPanel({
             ? detailMeta == null
               ? (
                 <div className='config-view__section-title'>
+                  {headerLeading}
                   {icon != null && (
                     <span className='material-symbols-rounded config-view__section-icon'>
                       {icon}
@@ -130,6 +133,7 @@ export function ConfigSectionPanel({
               )
               : (
                 <div className='config-view__detail-trail'>
+                  {headerLeading}
                   <Tooltip title={t('config.detail.back')}>
                     <Button
                       size='small'

--- a/apps/client/src/components/config/ConfigSectionPanel.tsx
+++ b/apps/client/src/components/config/ConfigSectionPanel.tsx
@@ -25,6 +25,7 @@ export function ConfigSectionPanel({
   fields,
   uiSection,
   value,
+  resolvedValue,
   onChange,
   mergedModelServices,
   mergedAdapters,
@@ -42,6 +43,7 @@ export function ConfigSectionPanel({
   fields?: FieldSpec[]
   uiSection?: ConfigUiSection
   value: unknown
+  resolvedValue?: unknown
   onChange: (nextValue: unknown) => void
   mergedModelServices: Record<string, unknown>
   mergedAdapters: Record<string, unknown>
@@ -66,6 +68,7 @@ export function ConfigSectionPanel({
     sectionKey,
     fields: resolvedFields,
     value,
+    resolvedValue,
     route: detailRoute,
     detailContext: {
       mergedModelServices,
@@ -168,6 +171,7 @@ export function ConfigSectionPanel({
           fields={resolvedFields}
           uiSection={uiSection}
           value={value}
+          resolvedValue={resolvedValue}
           onChange={onChange}
           mergedModelServices={mergedModelServices}
           mergedAdapters={mergedAdapters}

--- a/apps/client/src/components/config/ConfigSourceSwitch.tsx
+++ b/apps/client/src/components/config/ConfigSourceSwitch.tsx
@@ -1,7 +1,8 @@
-import { Radio } from 'antd'
+import { Button, Tooltip } from 'antd'
 import type { ReactNode } from 'react'
 
 import type { ConfigSource } from '@vibe-forge/core'
+import { useResponsiveLayout } from '#~/hooks/use-responsive-layout'
 
 export function ConfigSourceSwitch({
   value,
@@ -12,24 +13,37 @@ export function ConfigSourceSwitch({
   onChange: (value: ConfigSource) => void
   options: Array<{ value: ConfigSource; icon: string; label: ReactNode }>
 }) {
+  const { isTouchInteraction } = useResponsiveLayout()
+
   return (
-    <Radio.Group
-      value={value}
-      optionType='button'
-      buttonStyle='solid'
-      size='small'
-      onChange={(event) => {
-        onChange(event.target.value as ConfigSource)
-      }}
-      options={options.map(opt => ({
-        value: opt.value,
-        label: (
-          <span className='config-view__source-option'>
-            <span className='material-symbols-rounded'>{opt.icon}</span>
-            <span>{opt.label}</span>
-          </span>
+    <div className='config-view__source-switch' role='group'>
+      {options.map(opt => {
+        const isActive = opt.value === value
+        return (
+          <Tooltip
+            key={opt.value}
+            title={isTouchInteraction ? undefined : opt.label}
+            placement='top'
+          >
+            <Button
+              type='text'
+              size='small'
+              aria-pressed={isActive}
+              aria-label={String(opt.label)}
+              className={`config-view__source-switch-button ${isActive ? 'is-active' : ''}`}
+              icon={(
+                <span className='config-view__source-option' aria-hidden='true'>
+                  <span className='material-symbols-rounded'>{opt.icon}</span>
+                  <span className='config-view__source-option-label'>{opt.label}</span>
+                </span>
+              )}
+              onClick={() => {
+                onChange(opt.value)
+              }}
+            />
+          </Tooltip>
         )
-      }))}
-    />
+      })}
+    </div>
   )
 }

--- a/apps/client/src/components/config/DetailListField.tsx
+++ b/apps/client/src/components/config/DetailListField.tsx
@@ -18,6 +18,7 @@ export const DetailCollectionField = ({
   sectionKey,
   field,
   value,
+  resolvedValue,
   onChange,
   onOpenDetail,
   mergedModelServices,
@@ -28,6 +29,7 @@ export const DetailCollectionField = ({
   sectionKey: string
   field: FieldSpec
   value: unknown
+  resolvedValue?: unknown
   onChange: (nextValue: unknown) => void
   onOpenDetail: (route: ConfigDetailRoute) => void
   mergedModelServices: Record<string, unknown>
@@ -44,7 +46,8 @@ export const DetailCollectionField = ({
 
   const items = toDetailCollectionEntries({
     field,
-    value
+    value,
+    resolvedValue
   })
   const detailContext = {
     mergedModelServices,
@@ -73,6 +76,11 @@ export const DetailCollectionField = ({
       }))
       : []
   ), [uiSection])
+  const localListItems = isListCollection && Array.isArray(value)
+    ? value.filter(item => item != null && typeof item === 'object' && !Array.isArray(item)) as Array<
+      Record<string, unknown>
+    >
+    : []
 
   const updateRecordEntry = (itemKey: string, nextItem: Record<string, unknown>) => {
     onChange(setValueByPath(value, [itemKey], nextItem))
@@ -82,20 +90,20 @@ export const DetailCollectionField = ({
     onChange(nextItems)
   }
 
-  const moveItem = (index: number, direction: -1 | 1) => {
+  const moveItem = (localIndex: number, direction: -1 | 1) => {
     if (!isListCollection) return
-    const targetIndex = index + direction
-    if (targetIndex < 0 || targetIndex >= items.length) return
-    const next = items.map(item => item.item)
-    const [current] = next.splice(index, 1)
+    const targetIndex = localIndex + direction
+    if (targetIndex < 0 || targetIndex >= localListItems.length) return
+    const next = [...localListItems]
+    const [current] = next.splice(localIndex, 1)
     if (current == null) return
     next.splice(targetIndex, 0, current)
     updateListItems(next)
   }
 
-  const removeItem = (index: number) => {
+  const removeItem = (localIndex: number) => {
     if (!isListCollection) return
-    updateListItems(items.filter((_, itemIndex) => itemIndex !== index).map(item => item.item))
+    updateListItems(localListItems.filter((_, itemIndex) => itemIndex !== localIndex))
   }
 
   const removeRecordItem = (itemKey: string) => {
@@ -115,7 +123,20 @@ export const DetailCollectionField = ({
     })
   }
 
-  const renderSummaryControls = (item: Record<string, unknown>, itemKey: string, title: string) => {
+  const renderSummaryControls = ({
+    item,
+    itemKey,
+    title,
+    localIndex,
+    source
+  }: {
+    item: Record<string, unknown>
+    itemKey: string
+    title: string
+    localIndex?: number
+    source: 'local' | 'inherited'
+  }) => {
+    if (source !== 'local') return null
     if ((detailCollection.summaryControls?.length ?? 0) === 0) return null
 
     return (
@@ -143,9 +164,9 @@ export const DetailCollectionField = ({
                   nextChecked ? checkedValue : !checkedValue
                 ) as Record<string, unknown>
                 if (isListCollection) {
-                  const nextItems = items.map(entry => (
-                    entry.key === itemKey ? nextItem : entry.item
-                  ))
+                  if (localIndex == null) return
+                  const nextItems = [...localListItems]
+                  nextItems[localIndex] = nextItem
                   updateListItems(nextItems)
                   return
                 }
@@ -184,16 +205,34 @@ export const DetailCollectionField = ({
 
   return (
     <div className='config-view__detail-list'>
-      {items.map(({ item, key, index }) => {
+      {items.map(({ item, key, index, localIndex, source, hasResolvedOverlay }) => {
         const title = detailCollection.getItemTitle(item, key, index, detailContext)
         const subtitle = detailCollection.getItemSubtitle?.(item, key, index, detailContext)
         const description = detailCollection.getItemDescription?.(item, key, index, detailContext)
         return (
-          <div key={`${field.path.join('.')}:${key}:${title}`} className='config-view__record-card'>
+          <div
+            key={`${field.path.join('.')}:${key}:${title}`}
+            className={`config-view__record-card${source === 'inherited' ? ' config-view__record-card--readonly' : ''}`}
+          >
             <div className='config-view__detail-list-row'>
               <button type='button' className='config-view__detail-list-main' onClick={() => openDetail(key)}>
                 <div className='config-view__record-heading'>
-                  <div>{title}</div>
+                  <div className='config-view__detail-list-title'>
+                    <span>{title}</span>
+                    {(source === 'inherited' || hasResolvedOverlay) && (
+                      <span
+                        className={`config-view__detail-badge${
+                          source === 'inherited'
+                            ? ' config-view__detail-badge--readonly'
+                            : ' config-view__detail-badge--override'
+                        }`}
+                      >
+                        {source === 'inherited'
+                          ? t('config.detail.inheritedBadge')
+                          : t('config.detail.overrideBadge')}
+                      </span>
+                    )}
+                  </div>
                   {subtitle != null && subtitle !== '' && (
                     <div className='config-view__record-subtitle'>
                       {subtitle}
@@ -204,15 +243,23 @@ export const DetailCollectionField = ({
                   )}
                 </div>
               </button>
-              {renderSummaryControls(item, key, title)}
-              {(isListCollection || isRecordMapCollection) && (
+              {renderSummaryControls({ item, itemKey: key, title, localIndex, source })}
+              {(isListCollection || isRecordMapCollection) && source === 'local' && (
                 <DetailCollectionFieldActions
-                  index={index}
-                  itemCount={items.length}
-                  onMove={isListCollection ? (direction) => moveItem(index, direction) : undefined}
+                  index={localIndex ?? 0}
+                  itemCount={isListCollection
+                    ? localListItems.length
+                    : items.filter(entry => entry.source === 'local').length}
+                  onMove={isListCollection
+                    ? (direction) => {
+                      if (localIndex == null) return
+                      moveItem(localIndex, direction)
+                    }
+                    : undefined}
                   onRemove={() => {
                     if (isListCollection) {
-                      removeItem(index)
+                      if (localIndex == null) return
+                      removeItem(localIndex)
                       return
                     }
                     removeRecordItem(key)
@@ -240,12 +287,15 @@ export const DetailCollectionField = ({
               aria-label={t('config.editor.addItem')}
               icon={<span className='material-symbols-rounded'>add</span>}
               onClick={() => {
-                const next = [
-                  ...items.map(item => item.item),
-                  detailCollection.createItem()
-                ]
+                const next = [...localListItems, detailCollection.createItem()]
                 updateListItems(next)
-                openDetail(String(next.length - 1))
+                const nextEntries = toDetailCollectionEntries({
+                  field,
+                  value: next,
+                  resolvedValue
+                })
+                const nextEntry = nextEntries.find(entry => entry.localIndex === next.length - 1)
+                openDetail(nextEntry?.key ?? String(next.length - 1))
               }}
             />
           </Tooltip>

--- a/apps/client/src/components/config/configDetail.ts
+++ b/apps/client/src/components/config/configDetail.ts
@@ -14,15 +14,26 @@ export interface DetailCollectionEntry {
   key: string
   item: Record<string, unknown>
   index: number
+  localIndex?: number
+  resolvedIndex?: number
+  source: 'local' | 'inherited'
+  localItem?: Record<string, unknown>
+  resolvedItem: Record<string, unknown>
+  hasResolvedOverlay: boolean
 }
 
 export interface ConfigDetailRouteMeta {
   field: FieldSpec
   fieldLabel: string
   item: Record<string, unknown>
+  resolvedItem: Record<string, unknown>
   itemLabel: string
   itemKey: string
   itemIndex: number
+  localItemIndex?: number
+  resolvedItemIndex?: number
+  itemSource: 'local' | 'inherited'
+  hasResolvedOverlay: boolean
 }
 
 const isRecordObject = (value: unknown): value is Record<string, unknown> => (
@@ -36,50 +47,201 @@ const isSamePath = (left: string[], right: string[]) => (
   left.every((segment, index) => segment === right[index])
 )
 
+const isSameConfigValue = (left: unknown, right: unknown) => (
+  JSON.stringify(left) === JSON.stringify(right)
+)
+
 export const getSectionFields = (sectionKey: string, providedFields?: FieldSpec[]) => (
   providedFields ?? configSchema[sectionKey] ?? []
 )
 
 export const toDetailCollectionEntries = ({
   field,
-  value
+  value,
+  resolvedValue
 }: {
   field: FieldSpec
   value: unknown
+  resolvedValue?: unknown
 }): DetailCollectionEntry[] => {
   const detailCollection = field.detailCollection
   if (field.type !== 'detailCollection' || detailCollection == null) return []
 
   if (detailCollection.collectionKind === 'list') {
-    const items = Array.isArray(value)
+    const localItems = Array.isArray(value)
       ? value.filter(isRecordObject)
       : []
-    return items.map((item, index) => ({
+    const resolvedItems = Array.isArray(resolvedValue)
+      ? resolvedValue.filter(isRecordObject)
+      : localItems
+    const getMergeKey = detailCollection.getMergeKey
+
+    if (getMergeKey != null) {
+      const localIndexesByKey = new Map<string, number[]>()
+      localItems.forEach((item, localIndex) => {
+        const mergeKey = getMergeKey(item)
+        if (mergeKey == null || mergeKey === '') return
+        const existing = localIndexesByKey.get(mergeKey) ?? []
+        existing.push(localIndex)
+        localIndexesByKey.set(mergeKey, existing)
+      })
+
+      const matchedLocalIndexes = new Set<number>()
+      const entries: DetailCollectionEntry[] = resolvedItems.map((resolvedItem, resolvedIndex) => {
+        const mergeKey = getMergeKey(resolvedItem)
+        const matchedIndex = mergeKey != null
+          ? localIndexesByKey.get(mergeKey)?.shift()
+          : undefined
+        if (matchedIndex == null) {
+          return {
+            key: String(resolvedIndex),
+            item: resolvedItem,
+            index: resolvedIndex,
+            resolvedIndex,
+            source: 'inherited',
+            resolvedItem,
+            hasResolvedOverlay: false
+          }
+        }
+
+        const localItem = localItems[matchedIndex]!
+        matchedLocalIndexes.add(matchedIndex)
+        return {
+          key: String(resolvedIndex),
+          item: localItem,
+          index: resolvedIndex,
+          localIndex: matchedIndex,
+          resolvedIndex,
+          source: 'local',
+          localItem,
+          resolvedItem,
+          hasResolvedOverlay: !isSameConfigValue(localItem, resolvedItem)
+        }
+      })
+
+      localItems.forEach((localItem, localIndex) => {
+        if (matchedLocalIndexes.has(localIndex)) return
+        const index = entries.length
+        entries.push({
+          key: String(index),
+          item: localItem,
+          index,
+          localIndex,
+          source: 'local',
+          localItem,
+          resolvedItem: localItem,
+          hasResolvedOverlay: false
+        })
+      })
+
+      return entries
+    }
+
+    const inheritedCount = Math.max(resolvedItems.length - localItems.length, 0)
+    const inheritedEntries = resolvedItems.slice(0, inheritedCount).map((item, index) => ({
       key: String(index),
       item,
-      index
+      index,
+      resolvedIndex: index,
+      source: 'inherited' as const,
+      resolvedItem: item,
+      hasResolvedOverlay: false
     }))
+    const localEntries = localItems.map((item, localIndex) => {
+      const resolvedIndex = inheritedCount + localIndex
+      const resolvedItem = resolvedItems[resolvedIndex]
+      const normalizedResolvedItem = isRecordObject(resolvedItem) ? resolvedItem : item
+      return {
+        key: String(resolvedIndex),
+        item,
+        index: resolvedIndex,
+        localIndex,
+        resolvedIndex,
+        source: 'local' as const,
+        localItem: item,
+        resolvedItem: normalizedResolvedItem,
+        hasResolvedOverlay: !isSameConfigValue(item, normalizedResolvedItem)
+      }
+    })
+    return [...inheritedEntries, ...localEntries]
   }
 
   if (detailCollection.collectionKind === 'recordMap') {
-    const source = isRecordObject(value) ? value : {}
-    return Object.entries(source).map(([itemKey, item], index) => ({
-      key: itemKey,
-      item: isRecordObject(item) ? item : detailCollection.createItem?.(itemKey) ?? {},
-      index
-    }))
+    const localSource = isRecordObject(value) ? value : {}
+    const resolvedSource = isRecordObject(resolvedValue) ? resolvedValue : localSource
+    const resolvedKeys = Object.keys(resolvedSource)
+    const entries = resolvedKeys.map((itemKey, index) => {
+      const localItemValue = localSource[itemKey]
+      const localItem = isRecordObject(localItemValue)
+        ? localItemValue
+        : undefined
+      const resolvedItemValue = resolvedSource[itemKey]
+      const resolvedItem = isRecordObject(resolvedItemValue)
+        ? resolvedItemValue
+        : detailCollection.createItem?.(itemKey) ?? {}
+      if (localItem == null) {
+        return {
+          key: itemKey,
+          item: resolvedItem,
+          index,
+          resolvedIndex: index,
+          source: 'inherited' as const,
+          resolvedItem,
+          hasResolvedOverlay: false
+        }
+      }
+
+      return {
+        key: itemKey,
+        item: localItem,
+        index,
+        resolvedIndex: index,
+        source: 'local' as const,
+        localItem,
+        resolvedItem,
+        hasResolvedOverlay: !isSameConfigValue(localItem, resolvedItem)
+      }
+    })
+    const localOnlyEntries = Object.keys(localSource)
+      .filter(itemKey => !Object.hasOwn(resolvedSource, itemKey))
+      .map((itemKey, localOnlyIndex) => {
+        const localItemValue = localSource[itemKey]
+        const localItem = isRecordObject(localItemValue)
+          ? localItemValue
+          : detailCollection.createItem?.(itemKey) ?? {}
+        return {
+          key: itemKey,
+          item: localItem,
+          index: entries.length + localOnlyIndex,
+          source: 'local' as const,
+          localItem,
+          resolvedItem: localItem,
+          hasResolvedOverlay: false
+        }
+      })
+    return [...entries, ...localOnlyEntries]
   }
 
-  const source = isRecordObject(value) ? value : {}
+  const localSource = isRecordObject(value) ? value : {}
+  const resolvedSource = isRecordObject(resolvedValue) ? resolvedValue : localSource
   return detailCollection.itemKeys.map((itemKey, index) => {
-    const existing = source[itemKey]
-    const item = isRecordObject(existing)
-      ? existing
+    const localItemValue = localSource[itemKey]
+    const resolvedItemValue = resolvedSource[itemKey]
+    const localItem = isRecordObject(localItemValue)
+      ? localItemValue
+      : undefined
+    const resolvedItem = isRecordObject(resolvedItemValue)
+      ? resolvedItemValue
       : detailCollection.createItem?.(itemKey) ?? {}
     return {
       key: itemKey,
-      item,
-      index
+      item: localItem ?? resolvedItem,
+      index,
+      resolvedIndex: index,
+      source: localItem != null ? 'local' as const : 'inherited' as const,
+      localItem,
+      resolvedItem,
+      hasResolvedOverlay: localItem != null && !isSameConfigValue(localItem, resolvedItem)
     }
   })
 }
@@ -156,6 +318,7 @@ export const resolveConfigDetailRouteMeta = ({
   sectionKey,
   fields,
   value,
+  resolvedValue,
   route,
   detailContext,
   t
@@ -163,6 +326,7 @@ export const resolveConfigDetailRouteMeta = ({
   sectionKey: string
   fields?: FieldSpec[]
   value: unknown
+  resolvedValue?: unknown
   route: ConfigDetailRoute | null
   detailContext: DetailCollectionContext
   t: TranslationFn
@@ -178,7 +342,8 @@ export const resolveConfigDetailRouteMeta = ({
 
   const itemEntries = toDetailCollectionEntries({
     field,
-    value: getValueByPath(value, field.path)
+    value: getValueByPath(value, field.path),
+    resolvedValue: getValueByPath(resolvedValue ?? value, field.path)
   })
   const entry = itemEntries.find(item => item.key === route.itemKey)
   if (entry == null) return null
@@ -200,8 +365,13 @@ export const resolveConfigDetailRouteMeta = ({
     field,
     fieldLabel,
     item: entry.item,
+    resolvedItem: entry.resolvedItem,
     itemLabel,
     itemKey: entry.key,
-    itemIndex: entry.index
+    itemIndex: entry.index,
+    localItemIndex: entry.localIndex,
+    resolvedItemIndex: entry.resolvedIndex,
+    itemSource: entry.source,
+    hasResolvedOverlay: entry.hasResolvedOverlay
   }
 }

--- a/apps/client/src/components/config/configSchema.ts
+++ b/apps/client/src/components/config/configSchema.ts
@@ -88,6 +88,7 @@ interface DetailCollectionBaseSpec {
 export interface DetailListCollectionSpec extends DetailCollectionBaseSpec {
   collectionKind: 'list'
   createItem: () => Record<string, unknown>
+  getMergeKey?: (item: Record<string, unknown>) => string | undefined
   keyPlaceholderKey?: never
 }
 
@@ -594,6 +595,12 @@ export const configSchema: Record<string, FieldSpec[]> = {
           options: {},
           children: []
         }),
+        getMergeKey: (item) => {
+          const id = typeof item.id === 'string' ? item.id.trim() : ''
+          if (id === '') return undefined
+          const scope = typeof item.scope === 'string' ? item.scope.trim() : ''
+          return `${id}::${scope}`
+        },
         itemFields: pluginInstanceDetailFields,
         summaryControls: [{ kind: 'boolean', path: ['enabled'], checkedValue: true }],
         getItemTitle: (item, _itemKey, itemIndex) => {

--- a/apps/client/src/components/config/record-editors/RecordEditors.scss
+++ b/apps/client/src/components/config/record-editors/RecordEditors.scss
@@ -20,6 +20,10 @@
   background: var(--subpage-tertiary-hover-bg);
 }
 
+.config-view__record-card--readonly {
+  border-style: dashed;
+}
+
 .config-view__record-title {
   display: flex;
   align-items: center;
@@ -56,6 +60,45 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+.config-view__detail-list-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.config-view__detail-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--subpage-tertiary-hover-bg) 72%,
+    transparent
+  );
+  color: var(--sub-text-color);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.config-view__detail-badge--readonly {
+  background: color-mix(
+    in srgb,
+    var(--subpage-tertiary-hover-border) 30%,
+    transparent
+  );
+}
+
+.config-view__detail-badge--override {
+  background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+  color: var(--primary-color);
 }
 
 .config-view__record-subtitle {

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -1146,7 +1146,14 @@
       }
     },
     "detail": {
-      "back": "Back"
+      "back": "Back",
+      "override": "Override in current config",
+      "inheritedReadonly": "This value comes from an extended config. Override it here before editing.",
+      "inheritedAppendOnly": "This item comes from an extended config. This collection merges by append, so edit it in the source config or override the whole collection here.",
+      "partialOverride": "This entry overrides an inherited config. Fields not set locally still come from the inherited layer.",
+      "inheritedBadge": "Inherited",
+      "overrideBadge": "Override",
+      "localBadge": "Local"
     },
     "fields": {
       "general": {

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -1078,6 +1078,10 @@
       "projectMissing": "Project (Not created)",
       "userMissing": "User (Not created)"
     },
+    "navigation": {
+      "search": "Search config sections",
+      "noResults": "No matching sections"
+    },
     "actions": {
       "edit": "Edit",
       "save": "Save",
@@ -1366,7 +1370,7 @@
       },
       "models": {
         "items": {
-          "label": "Model Selector Entries",
+          "label": "Model Metadata Entries",
           "desc": "Model metadata keyed by `service` or `service,model`. Display metadata like alias/title/description only applies to exact `model` or `service,model` matches"
         }
       },
@@ -1528,7 +1532,7 @@
         "http": "HTTP"
       },
       "recommendedModels": {
-        "modelSelector": "Model Selector"
+        "modelSelector": "Model Metadata"
       }
     },
     "sectionGroups": {

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -1147,7 +1147,14 @@
       }
     },
     "detail": {
-      "back": "返回"
+      "back": "返回",
+      "override": "覆盖到当前配置",
+      "inheritedReadonly": "这个值来自 extends 继承配置。先覆盖到当前配置，再进行编辑。",
+      "inheritedAppendOnly": "这个条目来自 extends 继承配置。当前集合按追加方式合并，不能直接在这里改这个继承条目；需要去源配置修改，或者整体覆盖当前集合。",
+      "partialOverride": "这个条目正在覆盖一份继承配置。未在本地设置的字段仍然来自继承层。",
+      "inheritedBadge": "继承",
+      "overrideBadge": "覆盖",
+      "localBadge": "本地"
     },
     "fields": {
       "general": {

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -1079,6 +1079,10 @@
       "projectMissing": "项目（未创建）",
       "userMissing": "用户（未创建）"
     },
+    "navigation": {
+      "search": "搜索配置分类",
+      "noResults": "没有匹配的配置分类"
+    },
     "actions": {
       "edit": "编辑",
       "save": "保存",
@@ -1101,7 +1105,7 @@
       "addEnvVar": "添加环境变量",
       "addHeader": "添加请求头",
       "addEntry": "添加条目",
-      "newModelSelectorName": "新增模型选择器",
+      "newModelSelectorName": "新增模型元数据",
       "moveUp": "上移",
       "moveDown": "下移",
       "shortcutPlaceholder": "按下快捷键",
@@ -1367,7 +1371,7 @@
       },
       "models": {
         "items": {
-          "label": "模型选择器明细",
+          "label": "模型元数据明细",
           "desc": "按 `service` 或 `service,model` 配置模型元信息；展示元数据如 alias/title/description 仅在 `model` 或 `service,model` 精确匹配时生效"
         }
       },
@@ -1529,7 +1533,7 @@
         "http": "HTTP"
       },
       "recommendedModels": {
-        "modelSelector": "模型选择器"
+        "modelSelector": "模型元数据"
       }
     },
     "sectionGroups": {
@@ -1631,7 +1635,7 @@
     "sections": {
       "general": "通用",
       "conversation": "会话",
-      "models": "模型选择器",
+      "models": "模型元数据",
       "modelServices": "模型服务",
       "channels": "频道",
       "adapters": "适配器",

--- a/apps/server/src/routes/config.ts
+++ b/apps/server/src/routes/config.ts
@@ -9,6 +9,7 @@ import {
   buildConfigSections,
   composeBaseConfigSchemaBundle,
   composeWorkspaceConfigSchemaBundle,
+  resolveWritableConfigPath,
   updateConfigFile,
   validateConfigSection,
   writeWorkspaceConfigSchemaFile
@@ -129,7 +130,12 @@ export function configRouter(): Router {
 
   router.get('/', async (ctx) => {
     try {
-      const { workspaceFolder, projectConfig, userConfig, mergedConfig } = await loadConfigState()
+      const {
+        workspaceFolder,
+        mergedConfig,
+        projectSource,
+        userSource
+      } = await loadConfigState()
       const urls = {
         repo: 'https://github.com/vibe-forge-ai/vibe-forge.ai',
         docs: 'https://github.com/vibe-forge-ai/vibe-forge.ai',
@@ -145,15 +151,31 @@ export function configRouter(): Router {
       mergedSections.adapterBuiltinModels = loadAdapterBuiltinModels(mergedConfig.adapters)
       ctx.body = {
         sources: {
-          project: buildSections(projectConfig),
-          user: buildSections(userConfig),
+          project: buildSections(projectSource?.rawConfig),
+          user: buildSections(userSource?.rawConfig),
           merged: mergedSections
+        },
+        resolvedSources: {
+          project: buildSections(projectSource?.resolvedConfig),
+          user: buildSections(userSource?.resolvedConfig)
         },
         meta: {
           workspaceFolder,
           configPresent: {
-            project: projectConfig != null,
-            user: userConfig != null
+            project: projectSource?.configPath != null,
+            user: userSource?.configPath != null
+          },
+          sourceFiles: {
+            project: {
+              configPath: projectSource?.configPath,
+              writableConfigPath: resolveWritableConfigPath(workspaceFolder, 'project'),
+              extendPaths: projectSource?.extendPaths ?? []
+            },
+            user: {
+              configPath: userSource?.configPath,
+              writableConfigPath: resolveWritableConfigPath(workspaceFolder, 'user'),
+              extendPaths: userSource?.extendPaths ?? []
+            }
           },
           experiments: {},
           about: {

--- a/apps/server/src/services/config/index.ts
+++ b/apps/server/src/services/config/index.ts
@@ -16,7 +16,7 @@ export function buildConfigJsonVariables(
 }
 
 export async function loadConfigState(workspaceFolder = getWorkspaceFolder()) {
-  const { projectConfig, userConfig, mergedConfig } = await loadWorkspaceConfigState({
+  const { projectConfig, userConfig, mergedConfig, projectSource, userSource } = await loadWorkspaceConfigState({
     cwd: workspaceFolder,
     jsonVariables: buildConfigJsonVariables(workspaceFolder)
   })
@@ -24,6 +24,8 @@ export async function loadConfigState(workspaceFolder = getWorkspaceFolder()) {
     workspaceFolder,
     projectConfig,
     userConfig,
-    mergedConfig
+    mergedConfig,
+    projectSource,
+    userSource
   }
 }

--- a/packages/config/__tests__/load.spec.ts
+++ b/packages/config/__tests__/load.spec.ts
@@ -11,6 +11,7 @@ import {
   buildResolvedConfigState,
   loadAdapterConfig,
   loadConfig,
+  loadConfigState,
   resetConfigCache,
   resolveAdapterCommonConfig,
   resolveAdapterConfig,
@@ -201,6 +202,62 @@ describe('loadConfig', () => {
       }
       resetConfigCache()
       await rm(workspaceDir, { force: true, recursive: true })
+    }
+  })
+
+  it('exposes raw and resolved source config state for extended configs', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vf-config-source-state-'))
+
+    try {
+      await writeFile(
+        path.join(tempDir, 'base.yaml'),
+        `
+permissions:
+  allow:
+    - Read
+notifications:
+  events:
+    completed:
+      title: Base Title
+`
+      )
+      await writeFile(
+        path.join(tempDir, '.ai.config.json'),
+        JSON.stringify({
+          extend: './base.yaml',
+          permissions: {
+            allow: ['Edit']
+          },
+          notifications: {
+            events: {
+              completed: {
+                sound: '/tmp/done.mp3'
+              }
+            }
+          }
+        })
+      )
+
+      resetConfigCache()
+      const state = await loadConfigState({
+        cwd: tempDir,
+        jsonVariables: {}
+      })
+
+      expect(state.projectSource?.configPath).toBe(path.join(tempDir, '.ai.config.json'))
+      expect(state.projectSource?.extendPaths).toEqual(['./base.yaml'])
+      expect(state.projectSource?.rawConfig?.permissions?.allow).toEqual(['Edit'])
+      expect(state.projectSource?.resolvedConfig?.permissions?.allow).toEqual(['Read', 'Edit'])
+      expect(state.projectSource?.rawConfig?.notifications?.events?.completed).toEqual({
+        sound: '/tmp/done.mp3'
+      })
+      expect(state.projectSource?.resolvedConfig?.notifications?.events?.completed).toEqual({
+        title: 'Base Title',
+        sound: '/tmp/done.mp3'
+      })
+    } finally {
+      resetConfigCache()
+      await rm(tempDir, { force: true, recursive: true })
     }
   })
 

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -18,10 +18,19 @@ export interface LoadConfigOptions {
   disableDevConfig?: boolean
 }
 
+export interface ConfigSourceState {
+  rawConfig?: Config
+  resolvedConfig?: Config
+  configPath?: string
+  extendPaths: string[]
+}
+
 export interface ResolvedConfigState {
   projectConfig?: Config
   userConfig?: Config
   mergedConfig: Config
+  projectSource?: ConfigSourceState
+  userSource?: ConfigSourceState
 }
 
 export interface ResolveConfigStateOptions {
@@ -359,11 +368,11 @@ const readConfigFile = async (
   throw new Error(`Unsupported config file extension "${extension || '<none>'}"`)
 }
 
-const loadResolvedConfigFile = async (
+const loadResolvedConfigFileState = async (
   configPath: string,
   jsonVariables: Record<string, string | null | undefined>,
   loadingStack: Set<string>
-): Promise<Config> => {
+): Promise<Required<Pick<ConfigSourceState, 'rawConfig' | 'resolvedConfig' | 'extendPaths'>>> => {
   if (loadingStack.has(configPath)) {
     throw new Error(`Circular config extend detected: ${
       [
@@ -392,25 +401,39 @@ const loadResolvedConfigFile = async (
       throw new Error(`Extended config "${extendPath}" not found from "${configPath}"`)
     }
 
-    const extendedConfig = await loadResolvedConfigFile(
+    const extendedConfig = await loadResolvedConfigFileState(
       extendedConfigPath,
       jsonVariables,
       nextLoadingStack
     )
-    mergedExtendedConfig = mergeConfigs(mergedExtendedConfig, extendedConfig)
+    mergedExtendedConfig = mergeConfigs(mergedExtendedConfig, extendedConfig.resolvedConfig)
   }
 
-  return mergeConfigs(
-    mergedExtendedConfig,
-    omitExtendField(rawConfig)
-  ) ?? omitExtendField(rawConfig)
+  const rawEntryConfig = omitExtendField(rawConfig)
+
+  return {
+    rawConfig: rawEntryConfig,
+    resolvedConfig: mergeConfigs(
+      mergedExtendedConfig,
+      rawEntryConfig
+    ) ?? rawEntryConfig,
+    extendPaths: toExtendPaths(rawConfig.extend)
+  }
 }
 
-const loadConfigFromPaths = async (
+const loadResolvedConfigFile = async (
+  configPath: string,
+  jsonVariables: Record<string, string | null | undefined>,
+  loadingStack: Set<string>
+): Promise<Config> => (
+  (await loadResolvedConfigFileState(configPath, jsonVariables, loadingStack)).resolvedConfig
+)
+
+const loadConfigSourceFromPaths = async (
   cwd: string,
   paths: string[],
   jsonVariables: Record<string, string | null | undefined>
-) => {
+): Promise<ConfigSourceState | undefined> => {
   for (const path of paths) {
     try {
       const configPath = resolveConfigPath(cwd, path)
@@ -418,18 +441,22 @@ const loadConfigFromPaths = async (
         continue
       }
 
-      return await loadResolvedConfigFile(
+      const sourceState = await loadResolvedConfigFileState(
         configPath,
         jsonVariables,
         new Set()
       )
+      return {
+        ...sourceState,
+        configPath
+      }
     } catch (e) {
       console.error(`Failed to load config file ${path}: ${e}`)
     }
   }
 }
 
-const configCache = new Map<string, Promise<readonly [unknown | undefined, unknown | undefined]>>()
+const configCache = new Map<string, Promise<readonly [ConfigSourceState | undefined, ConfigSourceState | undefined]>>()
 export const DISABLE_DEV_CONFIG_ENV = '__VF_PROJECT_AI_DISABLE_DEV_CONFIG__'
 
 export const resetConfigCache = (cwd?: string) => {
@@ -446,10 +473,21 @@ export const resetConfigCache = (cwd?: string) => {
 }
 
 export const loadConfig = (options: LoadConfigOptions = {}) => {
+  return (async () => {
+    const [projectSource, userSource] = await loadConfigSources(options)
+    const [projectConfig, userConfig] = mergeDefaultVibeForgeMcpPermissions({
+      projectConfig: projectSource?.resolvedConfig,
+      userConfig: userSource?.resolvedConfig
+    })
+    return [projectConfig, userConfig] as const
+  })()
+}
+
+export const loadConfigSources = (options: LoadConfigOptions = {}) => {
   const cacheKey = resolveConfigCacheKey(options)
   const cachedConfig = configCache.get(cacheKey)
   if (cachedConfig != null) {
-    return cachedConfig as Promise<readonly [Config | undefined, Config | undefined]>
+    return cachedConfig
   }
 
   const launchCwd = options.cwd ?? process.cwd()
@@ -460,7 +498,7 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
   const jsonVariables = options.jsonVariables ?? {}
 
   const nextConfig = (async () => {
-    const projectConfig = await loadConfigFromPaths(
+    const projectSource = await loadConfigSourceFromPaths(
       configCwd,
       [
         './.ai.config.json',
@@ -473,9 +511,9 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
       jsonVariables
     )
 
-    let userConfig: Config | undefined
+    let userSource: ConfigSourceState | undefined
     if (shouldLoadDevConfig) {
-      userConfig = await loadConfigFromPaths(
+      userSource = await loadConfigSourceFromPaths(
         configCwd,
         [
           './.ai.dev.config.json',
@@ -487,10 +525,10 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
         ],
         jsonVariables
       )
-      if (userConfig == null) {
+      if (userSource == null) {
         const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(workspaceFolder)
         if (primaryWorkspaceFolder != null) {
-          userConfig = await loadConfigFromPaths(
+          userSource = await loadConfigSourceFromPaths(
             primaryWorkspaceFolder,
             [
               './.ai.dev.config.json',
@@ -506,10 +544,7 @@ export const loadConfig = (options: LoadConfigOptions = {}) => {
       }
     }
 
-    return mergeDefaultVibeForgeMcpPermissions({
-      projectConfig,
-      userConfig
-    })
+    return [projectSource, userSource] as const
   })()
   configCache.set(cacheKey, nextConfig)
   return nextConfig
@@ -522,11 +557,15 @@ export const resolveMergedConfig = (
 
 export const buildResolvedConfigState = (
   projectConfig?: Config,
-  userConfig?: Config
+  userConfig?: Config,
+  projectSource?: ConfigSourceState,
+  userSource?: ConfigSourceState
 ): ResolvedConfigState => ({
   projectConfig,
   userConfig,
-  mergedConfig: resolveMergedConfig(projectConfig, userConfig)
+  mergedConfig: resolveMergedConfig(projectConfig, userConfig),
+  projectSource,
+  userSource
 })
 
 export const resolveConfigState = (
@@ -538,8 +577,12 @@ export const resolveConfigState = (
 export const loadConfigState = async (
   options: LoadConfigOptions = {}
 ): Promise<ResolvedConfigState> => {
-  const [projectConfig, userConfig] = await loadConfig(options)
-  return buildResolvedConfigState(projectConfig, userConfig)
+  const [projectSource, userSource] = await loadConfigSources(options)
+  const [projectConfig, userConfig] = mergeDefaultVibeForgeMcpPermissions({
+    projectConfig: projectSource?.resolvedConfig,
+    userConfig: userSource?.resolvedConfig
+  })
+  return buildResolvedConfigState(projectConfig, userConfig, projectSource, userSource)
 }
 
 export const resolveAdapterConfigEntry = (

--- a/packages/config/src/update.ts
+++ b/packages/config/src/update.ts
@@ -77,7 +77,7 @@ const resolvePrimaryWorkspaceFolder = (
   }
 }
 
-const resolveWritableConfigPath = (
+export const resolveWritableConfigPath = (
   workspaceFolder: string,
   source: ConfigSource,
   env: Record<string, string | null | undefined> = process.env

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -372,11 +372,27 @@ export interface ConfigResponse {
     user?: ConfigSection
     merged?: ConfigSection
   }
+  resolvedSources?: {
+    project?: ConfigSection
+    user?: ConfigSection
+  }
   meta?: {
     workspaceFolder?: string
     configPresent?: {
       project?: boolean
       user?: boolean
+    }
+    sourceFiles?: {
+      project?: {
+        configPath?: string
+        writableConfigPath?: string
+        extendPaths?: string[]
+      }
+      user?: {
+        configPath?: string
+        writableConfigPath?: string
+        extendPaths?: string[]
+      }
     }
     experiments?: Record<string, unknown>
     about?: AboutInfo


### PR DESCRIPTION
## Summary
- edit project/user config sources against raw source data instead of pretending inherited resolved values are local
- add inherited/override-aware config UI behavior and source metadata plumbing
- rework config page mobile navigation into a left-side sheet and refine config section/mobile copy updates

## Testing
- pnpm exec eslint apps/client/src/components/ConfigView.tsx apps/client/src/components/config/ConfigSectionPanel.tsx apps/client/src/components/config/ConfigSourceSwitch.tsx
- pnpm exec dprint check .ai/docs/usage/web.md apps/client/src/resources/locales/en.json apps/client/src/resources/locales/zh.json
- pnpm -C apps/client prepublish
- pnpm -C packages/config test -- --run load.spec.ts
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler.web apps/client/__tests__/config-schema-form.spec.tsx
- pnpm typecheck