### PR TITLE
ci: move pwa deploy to external repository

### DIFF
--- a/.ai/docs/usage/pwa.md
+++ b/.ai/docs/usage/pwa.md
@@ -176,11 +176,9 @@ https://vf-api.example.com
 
 ## GitHub Pages 部署建议
 
-GitHub Pages 可以托管独立 client。推荐形态：
+GitHub Pages 可以托管独立 client。官方 PWA 部署由 `vibe-forge-ai/pwa` 仓库维护，访问地址是 `https://vibe-forge-ai.github.io/pwa/`。
 
-```text
-https://<github-user>.github.io/<repo-name>/
-```
+主仓库 `master` 出现 client 相关更新后，会触发 `vibe-forge-ai/pwa` 重新构建并发布自己的 `gh-pages`。主仓库的 `gh-pages` 不再承载 PWA，后续主要用于项目文档站。fork 或私有部署仍可使用 `https://<github-user>.github.io/<repo-name>/` 这类项目站点形态。
 
 用户首次打开后端地址时，优先填写 HTTPS 地址：
 
@@ -195,6 +193,4 @@ https://<random>.trycloudflare.com
 
 ## 安装、验证与排查
 
-继续阅读：[安装、验证与排查](./pwa/operations.md)。
-
-这里包括 Android / iOS 安装步骤、MIUI / HyperOS 桌面快捷方式权限、连接历史和登录态管理、移动端键盘遮挡处理、版本兼容规则、连通性检查、安全建议与参考资料。
+继续阅读：[安装、验证与排查](./pwa/operations.md)，包括 Android / iOS 安装、桌面快捷方式权限、连接历史、登录态管理、键盘遮挡、版本兼容、连通性检查和安全建议。

--- a/.ai/rules/MAINTENANCE.md
+++ b/.ai/rules/MAINTENANCE.md
@@ -72,6 +72,14 @@ description: 仓库通用维护与验证规则，包含启动、lint、格式化
 - 英文文本修改：编辑 `apps/client/src/resources/locales/en.json`。
 - 如果添加了新的 Key，请确保在两个文件中都进行添加，以保证多语言支持的完整性。
 
+### 5. PWA 独立部署维护
+
+- PWA 静态站点由 `vibe-forge-ai/pwa` 仓库维护，发布分支是该仓库的 `gh-pages`。
+- 本仓库的 `.github/workflows/deploy-pwa.yml` 只负责在 `master` 的 client 相关输入变化时触发 `vibe-forge-ai/pwa` 的 `deploy-pwa.yml` workflow，不再直接写本仓库的 `gh-pages`。
+- 本仓库需要配置 Actions secret `PWA_DEPLOY_TOKEN`，用于跨仓库触发 `vibe-forge-ai/pwa` workflow。推荐使用只授予 `vibe-forge-ai/pwa` Actions 写权限的 fine-grained token。
+- PWA 仓库部署时会 checkout 本仓库 `master` 的指定 commit，使用 `__VF_PROJECT_AI_CLIENT_MODE__=standalone` 和 `__VF_PROJECT_AI_CLIENT_BASE__=/pwa/` 构建 `apps/client`，然后把 `apps/client/dist/` 发布到 `vibe-forge-ai/pwa` 的 `gh-pages`。
+- 本仓库自己的 `gh-pages` 不再承载 PWA，后续主要用于项目文档站；文档站实现由单独分支维护时，不要把 PWA 发布逻辑重新写回本仓库。
+
 ## 注意事项
 
 - **持久化**: 数据库文件默认存储在 `~/.vf/db.sqlite`，可以使用标准的 SQLite 客户端进行查看和维护。

--- a/.github/workflows/deploy-pwa.yml
+++ b/.github/workflows/deploy-pwa.yml
@@ -1,111 +1,46 @@
-name: Deploy PWA
+name: Trigger PWA Deploy
 
 on:
   push:
     branches:
       - master
+    paths:
+      - apps/client/**
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .node-version
+      - .github/workflows/deploy-pwa.yml
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: deploy-pwa
+  group: trigger-pwa-deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: deploy-gh-pages
+  trigger:
+    name: trigger-pwa-repository
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.28.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build standalone PWA
-        run: pnpm --filter @vibe-forge/client exec vite build
+      - name: Trigger pwa repository deployment
         env:
-          __VF_PROJECT_AI_CLIENT_MODE__: standalone
-          __VF_PROJECT_AI_CLIENT_BASE__: /vibe-forge.ai/
-
-      - name: Check PWA artifact
-        id: pwa-artifact
-        run: |
-          missing=0
-          for artifact_path in \
-            apps/client/dist/manifest.webmanifest \
-            apps/client/dist/sw.js \
-            apps/client/dist/pwa-icon-192.png \
-            apps/client/dist/pwa-icon-512.png
-          do
-            if [ ! -f "$artifact_path" ]; then
-              echo "::warning::Missing $artifact_path; skipping gh-pages publish."
-              missing=1
-            fi
-          done
-
-          if [ "$missing" -eq 0 ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Prepare PWA artifact
-        if: steps.pwa-artifact.outputs.ready == 'true'
-        run: |
-          if [ -f .ai/docs/usage/pwa.md ]; then
-            cp .ai/docs/usage/pwa.md apps/client/dist/pwa.md
-          else
-            echo "No .ai/docs/usage/pwa.md found; preserving the existing gh-pages pwa.md when available."
-          fi
-          touch apps/client/dist/.nojekyll
-
-      - name: Publish to gh-pages
-        if: steps.pwa-artifact.outputs.ready == 'true'
+          GH_TOKEN: ${{ secrets.PWA_DEPLOY_TOKEN }}
+          SOURCE_REF: master
+          SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          rm -rf .gh-pages
-          git fetch origin gh-pages --depth=1 || true
-
-          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
-            git worktree add --detach .gh-pages origin/gh-pages
-          else
-            git worktree add --detach .gh-pages
-            git -C .gh-pages checkout --orphan gh-pages
-            git -C .gh-pages rm -rf . || true
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::Missing PWA_DEPLOY_TOKEN secret."
+            exit 1
           fi
 
-          if [ ! -f apps/client/dist/pwa.md ] && [ -f .gh-pages/pwa.md ]; then
-            cp .gh-pages/pwa.md apps/client/dist/pwa.md
-          fi
-
-          find .gh-pages -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-          cp -R apps/client/dist/. .gh-pages/
-
-          git -C .gh-pages add -A
-          if git -C .gh-pages diff --cached --quiet; then
-            echo "No PWA deployment changes."
-            exit 0
-          fi
-
-          git -C .gh-pages commit -m "Deploy PWA from ${GITHUB_SHA}"
-          git -C .gh-pages push origin HEAD:gh-pages
+          gh workflow run deploy-pwa.yml \
+            --repo vibe-forge-ai/pwa \
+            --ref master \
+            -f source_ref="${SOURCE_REF}" \
+            -f source_sha="${SOURCE_SHA}"

--- a/apps/client/src/components/server-connection/ServerConnectionGate.tsx
+++ b/apps/client/src/components/server-connection/ServerConnectionGate.tsx
@@ -26,7 +26,7 @@ import {
 } from './ServerConnectionUrlInput'
 import type { ServerConnectionFormValues } from './ServerConnectionUrlInput'
 
-const PWA_DOCS_URL = 'https://github.com/vibe-forge-ai/vibe-forge.ai/blob/gh-pages/pwa.md'
+const PWA_DOCS_URL = 'https://github.com/vibe-forge-ai/vibe-forge.ai/blob/master/.ai/docs/usage/pwa.md'
 
 interface ServerPublicStatus {
   version?: string


### PR DESCRIPTION
## Summary
- create the main-repo trigger workflow that dispatches PWA deployment to vibe-forge-ai/pwa instead of publishing this repo's gh-pages
- document the external PWA deployment ownership and required PWA_DEPLOY_TOKEN maintenance secret
- update the PWA docs link in the standalone client to point back to the source repo docs

## Verification
- pnpm exec eslint .
- pnpm exec dprint check
- pnpm typecheck
- vibe-forge-ai/pwa Deploy PWA workflow_dispatch succeeded after initializing the deployment repo