### PR TITLE
Refine chat composer UI and skill market search

### DIFF
--- a/apps/client/src/components/chat/NewSessionGuide.scss
+++ b/apps/client/src/components/chat/NewSessionGuide.scss
@@ -74,7 +74,7 @@
 
 .new-session-guide__grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -202,32 +202,6 @@
   color: var(--sub-text-color);
 }
 
-.new-session-guide__help {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.new-session-guide__help-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--sub-text-color);
-  line-height: 1.4;
-}
-
-.new-session-guide__help-icon {
-  font-size: 14px;
-  margin-top: 2px;
-  color: var(--sub-text-color);
-}
-
-.new-session-guide__help-footer {
-  font-size: 12px;
-  color: var(--sub-text-color);
-}
-
 .new-session-guide__more {
   font-size: 11px;
   color: var(--sub-text-color);
@@ -310,20 +284,6 @@
   overflow-wrap: anywhere;
 }
 
-.new-session-guide__compact-help-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  min-width: 0;
-  font-size: 11px;
-  line-height: 1.45;
-  color: var(--sub-text-color);
-
-  > span:last-child {
-    overflow-wrap: anywhere;
-  }
-}
-
 .new-session-guide__compact-inline-actions {
   display: flex;
   align-items: center;
@@ -383,14 +343,7 @@
     display: none;
   }
 
-  .new-session-guide--compact .new-session-guide__compact-help-item {
-    line-height: 1.35;
-  }
-
   .new-session-guide--compact .new-session-guide__compact-primary-desc,
-  .new-session-guide--compact
-    .new-session-guide__compact-help-item
-    > span:last-child,
   .new-session-guide--compact .new-session-guide__announcements-item > span {
     overflow-wrap: anywhere;
   }

--- a/apps/client/src/components/chat/NewSessionGuide.tsx
+++ b/apps/client/src/components/chat/NewSessionGuide.tsx
@@ -50,12 +50,6 @@ export function NewSessionGuide({
   const isWorkspacesReady = workspacesRes != null
   const { announcements = [] } = configRes?.sources.merged?.general ?? {}
 
-  const helpItems = [
-    t('chat.newSessionGuide.help.item1'),
-    t('chat.newSessionGuide.help.item2'),
-    t('chat.newSessionGuide.help.item3')
-  ]
-
   const handleCreateSpec = () => {
     message.info(t('chat.newSessionGuide.specs.createToast'))
   }
@@ -100,12 +94,10 @@ export function NewSessionGuide({
   const visibleWorkspaceItems = isCompactLayout ? workspaceItems.slice(0, 1) : workspaceItems
   const visibleSpecItems = isCompactLayout ? specItems.slice(0, 1) : specItems
   const visibleEntityItems = isCompactLayout ? entityItems.slice(0, 1) : entityItems
-  const visibleHelpItems = isCompactLayout ? helpItems.slice(0, 1) : helpItems
   const hiddenAnnouncementCount = Math.max(announcements.length - visibleAnnouncements.length, 0)
   const hiddenWorkspaceCount = Math.max(workspaceItems.length - visibleWorkspaceItems.length, 0)
   const hiddenSpecCount = Math.max(specItems.length - visibleSpecItems.length, 0)
   const hiddenEntityCount = Math.max(entityItems.length - visibleEntityItems.length, 0)
-  const hiddenHelpCount = Math.max(helpItems.length - visibleHelpItems.length, 0)
 
   const renderMoreCount = (count: number) =>
     count > 0
@@ -144,9 +136,7 @@ export function NewSessionGuide({
         ? (
           <NewSessionGuideCompactPanel
             entityItems={entityItems}
-            helpItems={helpItems}
             hiddenEntityCount={hiddenEntityCount}
-            hiddenHelpCount={hiddenHelpCount}
             hiddenSpecCount={hiddenSpecCount}
             hiddenWorkspaceCount={hiddenWorkspaceCount}
             isEntitiesReady={isEntitiesReady}
@@ -157,7 +147,6 @@ export function NewSessionGuide({
             renderMoreCount={renderMoreCount}
             specItems={specItems}
             visibleEntityItems={visibleEntityItems}
-            visibleHelpItems={visibleHelpItems}
             visibleSpecItems={visibleSpecItems}
             visibleWorkspaceItems={visibleWorkspaceItems}
             workspaceItems={workspaceItems}
@@ -166,7 +155,6 @@ export function NewSessionGuide({
         : (
           <NewSessionGuideGrid
             entityItems={entityItems}
-            hiddenHelpCount={hiddenHelpCount}
             isEntitiesReady={isEntitiesReady}
             isSpecsReady={isSpecsReady}
             isWorkspacesReady={isWorkspacesReady}
@@ -174,7 +162,6 @@ export function NewSessionGuide({
             onCreateSpec={handleCreateSpec}
             renderMoreCount={renderMoreCount}
             specItems={specItems}
-            visibleHelpItems={visibleHelpItems}
             workspaceItems={workspaceItems}
           />
         )}

--- a/apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx
+++ b/apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx
@@ -81,9 +81,7 @@ function CompactResourceRow({
 
 export function NewSessionGuideCompactPanel({
   entityItems,
-  helpItems,
   hiddenEntityCount,
-  hiddenHelpCount,
   hiddenSpecCount,
   hiddenWorkspaceCount,
   isEntitiesReady,
@@ -94,15 +92,12 @@ export function NewSessionGuideCompactPanel({
   renderMoreCount,
   specItems,
   visibleEntityItems,
-  visibleHelpItems,
   visibleSpecItems,
   visibleWorkspaceItems,
   workspaceItems
 }: {
   entityItems: NewSessionGuideResourceItem[]
-  helpItems: string[]
   hiddenEntityCount: number
-  hiddenHelpCount: number
   hiddenSpecCount: number
   hiddenWorkspaceCount: number
   isEntitiesReady: boolean
@@ -113,7 +108,6 @@ export function NewSessionGuideCompactPanel({
   renderMoreCount: (count: number) => ReactNode
   specItems: NewSessionGuideResourceItem[]
   visibleEntityItems: NewSessionGuideResourceItem[]
-  visibleHelpItems: string[]
   visibleSpecItems: NewSessionGuideResourceItem[]
   visibleWorkspaceItems: NewSessionGuideResourceItem[]
   workspaceItems: NewSessionGuideResourceItem[]
@@ -158,26 +152,6 @@ export function NewSessionGuideCompactPanel({
         onCreate={onCreateEntity}
         renderMoreCount={renderMoreCount}
       />
-
-      <div className='new-session-guide__compact-row'>
-        <div className='new-session-guide__compact-row-header'>
-          <div className='new-session-guide__title'>
-            <span className='material-symbols-rounded new-session-guide__title-icon'>tips_and_updates</span>
-            <span>{t('chat.newSessionGuide.help.title')}</span>
-          </div>
-          <div className='new-session-guide__count'>{helpItems.length}</div>
-        </div>
-
-        <div className='new-session-guide__compact-row-main'>
-          {visibleHelpItems[0] != null && (
-            <div className='new-session-guide__compact-help-item'>
-              <span className='material-symbols-rounded new-session-guide__help-icon'>check_circle</span>
-              <span>{visibleHelpItems[0]}</span>
-            </div>
-          )}
-          {renderMoreCount(hiddenHelpCount)}
-        </div>
-      </div>
     </div>
   )
 }

--- a/apps/client/src/components/chat/NewSessionGuideGrid.tsx
+++ b/apps/client/src/components/chat/NewSessionGuideGrid.tsx
@@ -6,7 +6,6 @@ import type { NewSessionGuideResourceItem } from './NewSessionGuideResourceCard'
 
 export function NewSessionGuideGrid({
   entityItems,
-  hiddenHelpCount,
   isEntitiesReady,
   isSpecsReady,
   isWorkspacesReady,
@@ -14,11 +13,9 @@ export function NewSessionGuideGrid({
   onCreateSpec,
   renderMoreCount,
   specItems,
-  visibleHelpItems,
   workspaceItems
 }: {
   entityItems: NewSessionGuideResourceItem[]
-  hiddenHelpCount: number
   isEntitiesReady: boolean
   isSpecsReady: boolean
   isWorkspacesReady: boolean
@@ -26,7 +23,6 @@ export function NewSessionGuideGrid({
   onCreateSpec: () => void
   renderMoreCount: (count: number) => ReactNode
   specItems: NewSessionGuideResourceItem[]
-  visibleHelpItems: string[]
   workspaceItems: NewSessionGuideResourceItem[]
 }) {
   const { t } = useTranslation()
@@ -63,29 +59,6 @@ export function NewSessionGuideGrid({
         createLabel={t('chat.newSessionGuide.entities.create')}
         onCreate={onCreateEntity}
       />
-
-      <div className='new-session-guide__card'>
-        <div className='new-session-guide__header'>
-          <div className='new-session-guide__title'>
-            <span className='material-symbols-rounded new-session-guide__title-icon'>tips_and_updates</span>
-            <span>{t('chat.newSessionGuide.help.title')}</span>
-          </div>
-        </div>
-        <div className='new-session-guide__body'>
-          <div className='new-session-guide__help'>
-            {visibleHelpItems.map(item => (
-              <div key={item} className='new-session-guide__help-item'>
-                <span className='material-symbols-rounded new-session-guide__help-icon'>check_circle</span>
-                <span>{item}</span>
-              </div>
-            ))}
-          </div>
-          {renderMoreCount(hiddenHelpCount)}
-          <div className='new-session-guide__help-footer'>
-            {t('chat.newSessionGuide.help.footer')}
-          </div>
-        </div>
-      </div>
     </div>
   )
 }

--- a/apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.scss
+++ b/apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.scss
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   min-width: 0;
-  padding: 3px 12px;
+  padding: 5px 6px;
   margin: -12px -12px 6px;
   border-radius: 11px 11px 0 0;
   background: color-mix(in srgb, var(--sub-bg-color) 82%, var(--border-color));
@@ -18,12 +18,13 @@
 }
 
 .sender-session-target__trigger {
-  min-width: 210px;
+  width: fit-content;
+  min-width: 0;
   max-width: min(420px, 100%);
-  min-height: 28px;
+  height: 24px;
   border: 0;
   border-radius: 8px;
-  padding: 1px 0;
+  padding: 0 6px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -51,7 +52,7 @@
 .sender-session-target__trigger-icon,
 .sender-session-target__trigger-chevron,
 .sender-session-target__menu-icon {
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1;
 }
 
@@ -64,13 +65,13 @@
   align-items: baseline;
   gap: 8px;
   min-width: 0;
-  flex: 1;
+  flex: 0 1 auto;
 }
 
 .sender-session-target__trigger-mode {
   flex-shrink: 0;
   color: var(--sub-text-color);
-  font-size: 11px;
+  font-size: 10px;
   line-height: 1.2;
 }
 
@@ -78,7 +79,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text-color);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   line-height: 1.2;
   text-overflow: ellipsis;
@@ -92,13 +93,20 @@
 
 .sender-session-target__menu-icon {
   color: var(--sub-text-color);
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 16px;
   vertical-align: middle;
 }
 
 .sender-session-target__menu-item {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
   min-width: 160px;
   max-width: 280px;
 }
@@ -106,8 +114,8 @@
 .sender-session-target__menu-item-name {
   overflow: hidden;
   color: var(--text-color);
-  font-size: 12px;
-  line-height: 1.3;
+  font-size: 11px;
+  line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -115,21 +123,72 @@
 .sender-session-target__menu-item-desc {
   overflow: hidden;
   color: var(--sub-text-color);
-  font-size: 11px;
-  line-height: 1.3;
+  font-size: 10px;
+  line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.sender-session-target__dropdown.ant-dropdown,
+.sender-session-target__submenu-popup {
+  .ant-dropdown-menu {
+    min-width: 168px;
+    padding: 4px !important;
+  }
+
+  .ant-dropdown-menu-item,
+  .ant-dropdown-menu-submenu-title {
+    min-height: 28px !important;
+    height: auto;
+    display: flex !important;
+    align-items: center !important;
+    padding: 4px 8px !important;
+    border-radius: 8px !important;
+    font-size: 11px !important;
+    line-height: 16px !important;
+  }
+
+  .ant-dropdown-menu-item-icon {
+    width: 16px;
+    min-width: 16px;
+    height: 16px;
+    display: inline-flex !important;
+    align-items: center !important;
+    align-self: center !important;
+    justify-content: center !important;
+    margin-inline-end: 8px !important;
+    line-height: 16px !important;
+  }
+
+  .ant-dropdown-menu-title-content {
+    display: inline-flex !important;
+    align-items: center !important;
+    min-height: 16px;
+    font-size: 11px !important;
+    line-height: 16px !important;
+  }
+
+  .ant-dropdown-menu-submenu-expand-icon {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    inset-inline-end: 8px !important;
+    color: var(--placeholder-color, #9ca3af) !important;
+  }
+}
+
+.sender-session-target__submenu-chevron {
+  font-size: 14px;
+  line-height: 1;
+}
+
 @media (max-width: 720px) {
   .sender-session-target__controls {
-    align-items: stretch;
+    align-items: flex-start;
     flex-direction: column;
   }
 
   .sender-session-target__trigger {
-    width: 100%;
-    max-width: none;
-    min-width: 0;
+    max-width: 100%;
   }
 }

--- a/apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.tsx
+++ b/apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.tsx
@@ -59,7 +59,7 @@ export function SenderSessionTargetBar({
   const isControlDisabled = locked || disabled === true
   const selectedLabel = draft.label ?? draft.name
   const selectedText = activeType === 'default'
-    ? t('chat.sessionTarget.defaultSummary')
+    ? null
     : selectedLabel ?? t(`chat.sessionTarget.placeholders.${activeType}`)
 
   const handleSelect = (type: ChatSessionTargetType, resource?: ChatSessionTargetResource) => {
@@ -88,6 +88,7 @@ export function SenderSessionTargetBar({
       key: type,
       label: t(`chat.sessionTarget.modes.${type}`),
       icon: <span className='material-symbols-rounded sender-session-target__menu-icon'>{modeIcons[type]}</span>,
+      popupClassName: 'sender-session-target__submenu-popup',
       children: resourcesByType[type].length > 0
         ? resourcesByType[type].map(resource => ({
           key: `${type}${menuKeySeparator}${type === 'workspace' ? resource.id : resource.name}`,
@@ -128,9 +129,19 @@ export function SenderSessionTargetBar({
     <div className={`sender-session-target ${locked ? 'is-locked' : ''}`}>
       <div className='sender-session-target__controls'>
         <Dropdown
-          menu={{ items: menuItems, onClick: handleMenuClick }}
+          menu={{
+            items: menuItems,
+            onClick: handleMenuClick,
+            className: 'sender-session-target__dropdown-menu',
+            expandIcon: (
+              <span className='material-symbols-rounded sender-session-target__submenu-chevron'>
+                chevron_right
+              </span>
+            )
+          }}
           trigger={['click']}
           placement='topLeft'
+          overlayClassName='sender-session-target__dropdown'
           disabled={isControlDisabled}
         >
           <button
@@ -146,7 +157,9 @@ export function SenderSessionTargetBar({
               <span className='sender-session-target__trigger-mode'>
                 {t(`chat.sessionTarget.modes.${activeType}`)}
               </span>
-              <span className='sender-session-target__trigger-value'>{selectedText}</span>
+              {selectedText != null && (
+                <span className='sender-session-target__trigger-value'>{selectedText}</span>
+              )}
             </span>
             <span className='material-symbols-rounded sender-session-target__trigger-chevron'>expand_more</span>
           </button>

--- a/apps/client/src/components/chat/sender/Sender.scss
+++ b/apps/client/src/components/chat/sender/Sender.scss
@@ -22,7 +22,6 @@
   transition: all .2s;
 
   &:focus-within {
-    border-color: #3b82f6;
     background-color: var(--input-focus-bg, #f9fafb);
     box-shadow: none;
   }

--- a/apps/client/src/components/knowledge-base/components/SkillMarketView.tsx
+++ b/apps/client/src/components/knowledge-base/components/SkillMarketView.tsx
@@ -8,6 +8,7 @@ import type { SkillMarketViewProps } from './SkillMarketView.types'
 import { SkillRegistryErrors } from './SkillRegistryErrors'
 import { ALL_REGISTRIES, ALL_SKILL_SOURCES } from './skill-hub-utils'
 import type { SkillHubInstallFilter, SkillHubSortKey } from './skill-hub-utils'
+import { useSkillMarketQueryInput } from './use-skill-market-query-input'
 
 export function SkillMarketView({
   canLoadMore,
@@ -35,6 +36,10 @@ export function SkillMarketView({
 }: SkillMarketViewProps) {
   const { t } = useTranslation()
   const [actionsOpen, setActionsOpen] = React.useState(false)
+  const { draftQuery, flushDraftQuery, setDraftQuery } = useSkillMarketQueryInput({
+    query,
+    onQueryChange
+  })
   const hasRegistryFilter = registry !== ALL_REGISTRIES
   const hasSourceFilter = sourceFilter !== ALL_SKILL_SOURCES
   const hasInstallFilter = installFilter !== 'all'
@@ -79,8 +84,16 @@ export function SkillMarketView({
           }
           placeholder={t('knowledge.skills.searchHub')}
           allowClear
-          value={query}
-          onChange={(event) => onQueryChange(event.target.value)}
+          value={draftQuery}
+          onBlur={() => flushDraftQuery()}
+          onChange={(event) => {
+            const nextQuery = event.target.value
+            setDraftQuery(nextQuery)
+            if (nextQuery === '') {
+              flushDraftQuery('')
+            }
+          }}
+          onPressEnter={() => flushDraftQuery()}
         />
       </div>
       <div className={`knowledge-base-view__skill-market-actions ${actionsOpen ? 'is-open' : ''}`}>

--- a/apps/client/src/components/knowledge-base/components/use-skill-market-query-input.ts
+++ b/apps/client/src/components/knowledge-base/components/use-skill-market-query-input.ts
@@ -1,0 +1,44 @@
+import React from 'react'
+
+const QUERY_SYNC_DELAY_MS = 160
+
+export function useSkillMarketQueryInput({
+  query,
+  onQueryChange
+}: {
+  query: string
+  onQueryChange: (value: string) => void
+}) {
+  const [draftQuery, setDraftQuery] = React.useState(query)
+
+  React.useEffect(() => {
+    setDraftQuery(previous => previous === query ? previous : query)
+  }, [query])
+
+  React.useEffect(() => {
+    if (draftQuery === query) return
+
+    const timer = window.setTimeout(() => {
+      React.startTransition(() => {
+        onQueryChange(draftQuery)
+      })
+    }, QUERY_SYNC_DELAY_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [draftQuery, onQueryChange, query])
+
+  const flushDraftQuery = React.useCallback((nextQuery?: string) => {
+    const resolvedQuery = nextQuery ?? draftQuery
+    if (resolvedQuery === query) return
+
+    React.startTransition(() => {
+      onQueryChange(resolvedQuery)
+    })
+  }, [draftQuery, onQueryChange, query])
+
+  return {
+    draftQuery,
+    flushDraftQuery,
+    setDraftQuery
+  }
+}

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -547,7 +547,6 @@
       "title": "Session target",
       "lockedHint": "Fixed after creation",
       "creatingHint": "Creating session",
-      "defaultSummary": "Use the current project defaults",
       "missingResourceWarning": "Choose a resource for the current mode first",
       "modes": {
         "default": "Default",
@@ -908,13 +907,6 @@
         "empty": "No agents found. Add entity definition files to show them here.",
         "create": "Quick Create Agent",
         "createToast": "Create an entity definition file, then refresh the page."
-      },
-      "help": {
-        "title": "Help",
-        "item1": "Flow files can include name/description/params for better discovery",
-        "item2": "Entities can be described with index.json or README.md",
-        "item3": "After creation, refresh the page to see them here",
-        "footer": "Add usage guidance to flow descriptions when needed"
       }
     },
     "attachments": {

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -548,7 +548,6 @@
       "title": "会话目标",
       "lockedHint": "创建后已固定",
       "creatingHint": "正在创建会话",
-      "defaultSummary": "使用当前项目默认上下文",
       "missingResourceWarning": "请先选择当前模式下的资源",
       "modes": {
         "default": "默认",
@@ -909,13 +908,6 @@
         "empty": "暂未发现 Agent，加入实体定义文件后即可展示。",
         "create": "快速创建 Agent",
         "createToast": "请创建实体定义文件，保存后刷新页面。"
-      },
-      "help": {
-        "title": "一些帮助",
-        "item1": "流程文件支持 name/description/params 等元信息，便于识别和调用",
-        "item2": "实体可使用 index.json 或 README.md 描述能力与职责",
-        "item3": "创建完成后刷新页面即可出现在这里",
-        "footer": "需要更多引导时，可在流程描述中写明使用方式"
       }
     },
     "attachments": {


### PR DESCRIPTION
## Summary
- remove the new-session help card and tighten the session target trigger layout across breakpoints
- simplify sender focus styling and polish the session target dropdown menu visuals
- debounce skill market query input updates so typing no longer stalls on every keystroke

## Validation
- pnpm exec dprint check apps/client/src/components/chat/NewSessionGuide.scss apps/client/src/components/chat/NewSessionGuide.tsx apps/client/src/components/chat/NewSessionGuideGrid.tsx apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.scss apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.tsx apps/client/src/components/chat/sender/Sender.scss apps/client/src/components/knowledge-base/components/SkillMarketView.tsx apps/client/src/components/knowledge-base/components/use-skill-market-query-input.ts apps/client/src/resources/locales/en.json apps/client/src/resources/locales/zh.json
- pnpm exec eslint apps/client/src/components/chat/NewSessionGuide.tsx apps/client/src/components/chat/NewSessionGuideGrid.tsx apps/client/src/components/chat/NewSessionGuideCompactPanel.tsx apps/client/src/components/chat/sender/@components/session-target/SenderSessionTargetBar.tsx apps/client/src/components/knowledge-base/components/SkillMarketView.tsx apps/client/src/components/knowledge-base/components/use-skill-market-query-input.ts
- pnpm typecheck