### PR TITLE
fix(client): hide assistant actions before trailing tools

### DIFF
--- a/apps/client/__tests__/message-utils.spec.ts
+++ b/apps/client/__tests__/message-utils.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@vibe-forge/core'
+
+import { getLastAssistantActionAnchorId } from '#~/components/chat/messages/message-action-utils'
+import { processMessages } from '#~/components/chat/messages/message-utils'
+
+const createMessage = (
+  id: string,
+  role: ChatMessage['role'],
+  content: ChatMessage['content']
+): ChatMessage => ({
+  id,
+  role,
+  content,
+  createdAt: 1_700_000_000_000
+})
+
+describe('message render utils', () => {
+  it('does not attach visible assistant actions to text when the latest render item is a tool group', () => {
+    const renderItems = processMessages([
+      createMessage('user-1', 'user', 'Run the checks.'),
+      createMessage('assistant-1', 'assistant', [
+        { type: 'text', text: 'I will run the checks now.' },
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'adapter:codex:Shell',
+          input: { cmd: 'pnpm test' }
+        }
+      ])
+    ])
+
+    expect(renderItems.map(item => item.type)).toEqual(['message', 'message', 'tool-group'])
+    expect(getLastAssistantActionAnchorId(renderItems)).toBeNull()
+  })
+
+  it('keeps actions on the latest assistant text when the turn ends with text', () => {
+    const renderItems = processMessages([
+      createMessage('user-1', 'user', 'Summarize the output.'),
+      createMessage('assistant-1', 'assistant', [
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'adapter:codex:Shell',
+          input: { cmd: 'pnpm test' }
+        },
+        { type: 'text', text: 'The checks passed.' }
+      ])
+    ])
+    let latestMessageAnchorId: string | undefined
+    for (let index = renderItems.length - 1; index >= 0; index -= 1) {
+      const item = renderItems[index]
+      if (item?.type === 'message' && item.message.role === 'assistant') {
+        latestMessageAnchorId = item.anchorId
+        break
+      }
+    }
+
+    expect(latestMessageAnchorId).toBeDefined()
+    expect(getLastAssistantActionAnchorId(renderItems)).toBe(latestMessageAnchorId)
+  })
+
+  it('preserves the existing latest assistant action when a user message follows it', () => {
+    const renderItems = processMessages([
+      createMessage('user-1', 'user', 'Start.'),
+      createMessage('assistant-1', 'assistant', 'Done.'),
+      createMessage('user-2', 'user', 'One more thing.')
+    ])
+
+    expect(getLastAssistantActionAnchorId(renderItems)).toBe('message-assistant-1')
+  })
+})

--- a/apps/client/src/components/chat/ChatHistoryView.tsx
+++ b/apps/client/src/components/chat/ChatHistoryView.tsx
@@ -42,6 +42,7 @@ import { QueuedMessagesCard } from './QueuedMessagesCard'
 import { MessageItem } from './messages/MessageItem'
 import { MessageStatusNotice } from './messages/MessageStatusNotice'
 import type { ChatHistoryStatusNotice } from './messages/build-chat-history-status-notices'
+import { getLastAssistantActionAnchorId } from './messages/message-action-utils'
 import { buildMessageTurns } from './messages/message-turns'
 import { processMessages } from './messages/message-utils'
 import { SenderInteractionPanel } from './sender/@components/sender-interaction-panel/SenderInteractionPanel'
@@ -410,16 +411,7 @@ export function ChatHistoryView({
       hashAnchorId: hashAnchorId !== '' ? hashAnchorId : targetAnchorId,
       keepLastTurnExpanded: isCreating || session?.status === 'running' || session?.status === 'waiting_input'
     }), [expandedTurnIds, hashAnchorId, isCreating, renderItems, session?.status, targetAnchorId])
-  const lastAssistantActionAnchorId = useMemo(() => {
-    for (let index = renderItems.length - 1; index >= 0; index -= 1) {
-      const item = renderItems[index]
-      if (item == null) continue
-      if (item.type === 'tool-group') continue
-      if (item.message.role === 'user') continue
-      return item.anchorId
-    }
-    return null
-  }, [renderItems])
+  const lastAssistantActionAnchorId = useMemo(() => getLastAssistantActionAnchorId(renderItems), [renderItems])
   const handleEditQueuedMessage = async (item: SessionQueuedMessage) => {
     const removed = await removeQueuedContent(item.id)
     if (!removed) {

--- a/apps/client/src/components/chat/messages/MessageItem.tsx
+++ b/apps/client/src/components/chat/messages/MessageItem.tsx
@@ -85,6 +85,7 @@ function MessageItemComponent({
   const canCopy = copyableText != null
   const shouldShowAssistantActions = !isUser && showAssistantActions
   const showCompactActionMenu = isCompactLayout || isTouchInteraction
+  const shouldShowCompactActionMenu = showCompactActionMenu && (isUser || shouldShowAssistantActions)
 
   useEffect(() => {
     setIsSubmitting(false)
@@ -440,7 +441,7 @@ function MessageItemComponent({
         className={`${isUser ? 'chat-message-user' : 'chat-message-assistant'} ${isEditing ? 'is-editing' : ''} ${
           !isFirstInGroup ? 'consecutive' : ''
         } ${isActionsVisible ? 'is-actions-visible' : ''} ${isTargeted ? 'is-targeted' : ''} ${
-          showCompactActionMenu ? 'has-compact-menu' : ''
+          shouldShowCompactActionMenu ? 'has-compact-menu' : ''
         }`}
         data-message-id={originalMessage.id}
         onPointerEnter={handleActionsPointerEnter}
@@ -477,7 +478,7 @@ function MessageItemComponent({
           </div>
           {!isEditing && (
             <MessageFooter msg={originalMessage} isUser={isUser}>
-              {showCompactActionMenu
+              {shouldShowCompactActionMenu
                 ? compactActionMenu
                 : shouldShowAssistantActions
                 ? actionButtons

--- a/apps/client/src/components/chat/messages/message-action-utils.ts
+++ b/apps/client/src/components/chat/messages/message-action-utils.ts
@@ -1,0 +1,18 @@
+import type { ChatRenderItem } from './message-utils'
+
+export function getLastAssistantActionAnchorId(renderItems: ChatRenderItem[]) {
+  const lastItem = renderItems[renderItems.length - 1]
+  if (lastItem?.type === 'tool-group') {
+    return null
+  }
+
+  for (let index = renderItems.length - 1; index >= 0; index -= 1) {
+    const item = renderItems[index]
+    if (item == null) continue
+    if (item.type === 'tool-group') continue
+    if (item.message.role === 'user') continue
+    return item.anchorId
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- hide assistant message actions when the latest render item is a trailing tool group
- keep compact assistant menus aligned with the same visibility rule
- add regression coverage for text followed by tool calls

## Validation
- pnpm exec dprint check apps/client/src/components/chat/messages/message-action-utils.ts apps/client/src/components/chat/messages/message-utils.ts apps/client/src/components/chat/ChatHistoryView.tsx apps/client/src/components/chat/messages/MessageItem.tsx apps/client/__tests__/message-utils.spec.ts
- pnpm exec eslint apps/client/src/components/chat/messages/message-action-utils.ts apps/client/src/components/chat/messages/message-utils.ts apps/client/src/components/chat/ChatHistoryView.tsx apps/client/src/components/chat/messages/MessageItem.tsx apps/client/__tests__/message-utils.spec.ts
- pnpm exec vitest run apps/client/__tests__/message-utils.spec.ts
- pnpm -C apps/client exec vite build
- pnpm typecheck