### PR TITLE
Fix CLI default skills and config schema package resolution

### DIFF
--- a/apps/cli/__tests__/run.spec.ts
+++ b/apps/cli/__tests__/run.spec.ts
@@ -1,11 +1,18 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+
 import { Command } from 'commander'
 import { describe, expect, it, vi } from 'vitest'
+
+import { resolveConfiguredPluginInstances } from '@vibe-forge/utils/plugin-resolver'
 
 import {
   createAdapterOption,
   createSessionExitController,
   getAdapterErrorMessage,
   getCliDefaultSkillNames,
+  getCliDefaultSkillPluginConfig,
   getDisallowedResumeFlags,
   getPrintableAssistantText,
   handlePrintEvent,
@@ -27,6 +34,37 @@ describe('run command print output', () => {
       'create-entity',
       'update-entity'
     ])
+  })
+
+  it('resolves default CLI skills without target workspace dependencies', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'vf-cli-default-skills-'))
+
+    try {
+      const plugins = getCliDefaultSkillPluginConfig()
+      const pluginId = plugins[0]?.id
+
+      expect(typeof pluginId).toBe('string')
+      if (typeof pluginId !== 'string') {
+        throw new TypeError('Expected the default CLI skill plugin id to be a path.')
+      }
+      expect(isAbsolute(pluginId)).toBe(true)
+
+      const instances = await resolveConfiguredPluginInstances({
+        cwd: workspace,
+        plugins
+      })
+      const [instance] = instances
+
+      expect(instance?.sourceType).toBe('directory')
+      if (instance == null) {
+        throw new TypeError('Expected the default CLI skill plugin to resolve.')
+      }
+      expect(await readdir(join(instance.rootDir, 'skills'))).toEqual(
+        expect.arrayContaining(getCliDefaultSkillNames())
+      )
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
   })
 
   it('extracts printable assistant text from string content', () => {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@vibe-forge/app-runtime": "workspace:^",
     "@vibe-forge/cli-helper": "workspace:^",
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/managed-plugins": "workspace:^",

--- a/apps/cli/src/default-skill-plugin.ts
+++ b/apps/cli/src/default-skill-plugin.ts
@@ -1,6 +1,10 @@
+import { createRequire } from 'node:module'
+import { dirname } from 'node:path'
+
 import type { PluginConfig } from '@vibe-forge/types'
 
 const CLI_DEFAULT_SKILL_PLUGIN_ID = '@vibe-forge/plugin-cli-skills'
+const requireFromCliPackage = createRequire(__filename)
 
 const CLI_DEFAULT_SKILL_NAMES = [
   'vf-cli-quickstart',
@@ -9,9 +13,13 @@ const CLI_DEFAULT_SKILL_NAMES = [
   'update-entity'
 ] as const
 
+const resolveCliDefaultSkillPluginRoot = () => (
+  dirname(requireFromCliPackage.resolve(`${CLI_DEFAULT_SKILL_PLUGIN_ID}/package.json`))
+)
+
 export const getCliDefaultSkillPluginConfig = (): PluginConfig => [
   {
-    id: CLI_DEFAULT_SKILL_PLUGIN_ID
+    id: resolveCliDefaultSkillPluginRoot()
   }
 ]
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,7 +22,7 @@
     "@vibe-forge/adapter-claude-code": "workspace:^",
     "@vibe-forge/app-runtime": "workspace:^",
     "@vibe-forge/channel-lark": "workspace:^",
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/core": "workspace:^",
     "@vibe-forge/definition-core": "workspace:^",
     "@vibe-forge/definition-loader": "workspace:^",

--- a/changelog/2.0.1/core.md
+++ b/changelog/2.0.1/core.md
@@ -1,0 +1,3 @@
+# @vibe-forge/core 2.0.1
+
+- 导出 `./config-schema` 子路径，供 config 与 adapter 包在发布安装环境中加载配置 schema helper。

--- a/changelog/2.0.2/config.md
+++ b/changelog/2.0.2/config.md
@@ -1,0 +1,3 @@
+# @vibe-forge/config 2.0.2
+
+- 将 `@vibe-forge/core` 依赖下限提升到 `2.0.1`，避免发布安装时解析到缺少 `./config-schema` export 的旧 core 包。

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -78,8 +78,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -80,8 +80,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -71,7 +71,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",
     "zod": "^3.24.1"

--- a/packages/adapters/gemini/package.json
+++ b/packages/adapters/gemini/package.json
@@ -80,7 +80,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",

--- a/packages/adapters/kimi/package.json
+++ b/packages/adapters/kimi/package.json
@@ -71,7 +71,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -71,8 +71,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/definition-loader": "workspace:^",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/types": "workspace:^",

--- a/packages/config/__tests__/schema.spec.ts
+++ b/packages/config/__tests__/schema.spec.ts
@@ -49,6 +49,54 @@ const writePackage = async (
 }
 
 describe('config schema bundle', () => {
+  it('pins config-schema consumers to a core package that exports the subpath', async () => {
+    const readPackageJson = async (relativePath: string) => (
+      JSON.parse(await readFile(path.resolve(process.cwd(), relativePath), 'utf8')) as {
+        dependencies?: Record<string, string>
+        exports?: Record<string, unknown>
+        version?: string
+      }
+    )
+    const corePackage = await readPackageJson('packages/core/package.json')
+    const configPackage = await readPackageJson('packages/config/package.json')
+
+    expect(corePackage.version).toBe('2.0.1')
+    expect(corePackage.exports).toHaveProperty('./config-schema')
+    expect(configPackage.version).toBe('2.0.2')
+    expect(configPackage.dependencies?.['@vibe-forge/core']).toBe('workspace:^2.0.1')
+
+    for (
+      const relativePath of [
+        'packages/adapters/claude-code/package.json',
+        'packages/adapters/codex/package.json',
+        'packages/adapters/copilot/package.json',
+        'packages/adapters/gemini/package.json',
+        'packages/adapters/kimi/package.json',
+        'packages/adapters/opencode/package.json'
+      ]
+    ) {
+      const packageJson = await readPackageJson(relativePath)
+      expect(packageJson.dependencies?.['@vibe-forge/core']).toBe('workspace:^2.0.1')
+    }
+
+    for (
+      const relativePath of [
+        'apps/cli/package.json',
+        'apps/server/package.json',
+        'packages/adapters/claude-code/package.json',
+        'packages/adapters/codex/package.json',
+        'packages/adapters/opencode/package.json',
+        'packages/hooks/package.json',
+        'packages/mcp/package.json',
+        'packages/task/package.json',
+        'packages/workspace-assets/package.json'
+      ]
+    ) {
+      const packageJson = await readPackageJson(relativePath)
+      expect(packageJson.dependencies?.['@vibe-forge/config']).toBe('workspace:^2.0.2')
+    }
+  })
+
   it('keeps the base schema adapter slot generic', () => {
     const bundle = composeBaseConfigSchemaBundle()
     const adapters = (bundle.jsonSchema.properties as Record<string, unknown>).adapters as Record<string, unknown>

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/config",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Shared config IO for Vibe Forge",
   "imports": {
     "#~/*.js": {
@@ -38,7 +38,7 @@
     "test": "pnpm -C ../.. exec vitest run --workspace vitest.workspace.ts --project bundler packages/config/__tests__"
   },
   "dependencies": {
-    "@vibe-forge/core": "workspace:^",
+    "@vibe-forge/core": "workspace:^2.0.1",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",
     "js-yaml": "^4.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -42,7 +42,7 @@
     "test": "pnpm -C ../.. exec vitest run --workspace vitest.workspace.ts --project bundler packages/hooks/__tests__"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/register": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@vibe-forge/cli-helper": "workspace:^",
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/register": "workspace:^",
     "@vibe-forge/task": "workspace:^",

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -29,7 +29,7 @@
     "test": "pnpm -C ../.. exec vitest run --workspace vitest.workspace.ts --project bundler packages/task/__tests__"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/hooks": "workspace:^",
     "@vibe-forge/managed-plugins": "workspace:^",
     "@vibe-forge/types": "workspace:^",

--- a/packages/workspace-assets/package.json
+++ b/packages/workspace-assets/package.json
@@ -29,7 +29,7 @@
     "test": "pnpm -C ../.. exec vitest run --workspace vitest.workspace.ts --project bundler packages/workspace-assets/__tests__"
   },
   "dependencies": {
-    "@vibe-forge/config": "workspace:^",
+    "@vibe-forge/config": "workspace:^2.0.2",
     "@vibe-forge/definition-core": "workspace:^",
     "@vibe-forge/types": "workspace:^",
     "@vibe-forge/utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/cli-helper
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../../packages/config
       '@vibe-forge/core':
         specifier: workspace:^
@@ -305,7 +305,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/channels/lark
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../../packages/config
       '@vibe-forge/core':
         specifier: workspace:^
@@ -387,10 +387,10 @@ importers:
   packages/adapters/claude-code:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../../config
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -408,10 +408,10 @@ importers:
   packages/adapters/codex:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../../config
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -429,7 +429,7 @@ importers:
   packages/adapters/copilot:
     dependencies:
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/types':
         specifier: workspace:^
@@ -444,7 +444,7 @@ importers:
   packages/adapters/gemini:
     dependencies:
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -462,7 +462,7 @@ importers:
   packages/adapters/kimi:
     dependencies:
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -480,10 +480,10 @@ importers:
   packages/adapters/opencode:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../../config
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../../core
       '@vibe-forge/definition-loader':
         specifier: workspace:^
@@ -567,7 +567,7 @@ importers:
   packages/config:
     dependencies:
       '@vibe-forge/core':
-        specifier: workspace:^
+        specifier: workspace:^2.0.1
         version: link:../core
       '@vibe-forge/types':
         specifier: workspace:^
@@ -628,7 +628,7 @@ importers:
   packages/hooks:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../config
       '@vibe-forge/register':
         specifier: workspace:^
@@ -662,7 +662,7 @@ importers:
         specifier: workspace:^
         version: link:../cli-helper
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../config
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -729,7 +729,7 @@ importers:
   packages/task:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../config
       '@vibe-forge/hooks':
         specifier: workspace:^
@@ -773,7 +773,7 @@ importers:
   packages/workspace-assets:
     dependencies:
       '@vibe-forge/config':
-        specifier: workspace:^
+        specifier: workspace:^2.0.2
         version: link:../config
       '@vibe-forge/definition-core':
         specifier: workspace:^


### PR DESCRIPTION
## Summary
- Resolve the CLI default skill plugin from the CLI package directory so external workspaces do not need to expose the transitive plugin dependency at the project root.
- Pin config-schema consumers to package versions that publish the required @vibe-forge/core/config-schema export, and add changelog entries.
- Add regressions covering default CLI skill plugin resolution and package metadata pins.

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/cli/__tests__/run.spec.ts
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/config/__tests__/schema.spec.ts
- pnpm exec eslint ...
- pnpm exec dprint check ...
- pnpm typecheck
- Local tarball smoke in an empty project, including user plugin skill/entity discovery and Codex mock-home skill projection
