### PR TITLE
fix(codex): dedupe managed config project blocks

### DIFF
--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -427,6 +427,110 @@ describe('initCodexAdapter', () => {
     expect(configContent).toContain('command = "node"')
   })
 
+  it('does not treat table-like lines inside a workspace multiline string as TOML sections', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const projectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+    const projectPromptBlock = [
+      'project_prompt = """',
+      '[not.a.table]',
+      'keep me inside the string',
+      '"""'
+    ].join('\n')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        projectKey,
+        'trust_level = "manual"',
+        projectPromptBlock,
+        ''
+      ].join('\n')
+    )
+
+    const ctx = {
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any
+
+    await initCodexAdapter(ctx)
+    await initCodexAdapter(ctx)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain(projectPromptBlock)
+    expect(configContent).toContain('trust_level = "trusted"')
+    expect(configContent.split(projectKey)).toHaveLength(2)
+  })
+
+  it('does not insert the managed root block into a root multiline string that contains a table-like line', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const rootPromptBlock = [
+      'developer_instructions = """',
+      '[not.a.real.table]',
+      'keep this preamble intact',
+      '"""'
+    ].join('\n')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        rootPromptBlock,
+        '',
+        '[notice]',
+        'hide_full_access_warning = true',
+        ''
+      ].join('\n')
+    )
+
+    const ctx = {
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any
+
+    await initCodexAdapter(ctx)
+    await initCodexAdapter(ctx)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain(rootPromptBlock)
+    expect(configContent).toContain('# BEGIN VIBE FORGE MANAGED CODEX ROOT CONFIG')
+    expect(configContent).toContain('[notice]')
+    expect(configContent).toContain('hide_full_access_warning = true')
+  })
+
   it('keeps concurrent skill sync idempotent when multiple vf processes initialize the same mock home', async () => {
     const workspace = await createWorkspace()
     const mockHome = join(workspace, '.ai', '.mock')

--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -333,6 +334,97 @@ describe('initCodexAdapter', () => {
     expect(configContent).toContain('hide_full_access_warning = true')
     expect(configContent).toContain('check_for_update_on_startup = false')
     expect(configContent.split(projectKey)).toHaveLength(2)
+  })
+
+  it('dedupes an existing workspace project table even when the config uses CRLF line endings', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const projectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        'model_reasoning_effort = "xhigh"',
+        projectKey,
+        'trust_level = "trusted"',
+        ''
+      ].join('\r\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain('# BEGIN VIBE FORGE MANAGED CODEX PROJECT CONFIG')
+    expect(configContent.split(projectKey)).toHaveLength(2)
+  })
+
+  it('preserves existing workspace project settings and subtables without writing a duplicate project table', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const projectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+    const nestedProjectKey = `[projects.${JSON.stringify(resolve(workspace))}.mcp_servers.local]`
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        projectKey,
+        'trust_level = "manual"',
+        'workspace_write = true',
+        '',
+        nestedProjectKey,
+        'command = "node"',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent.split(projectKey)).toHaveLength(2)
+    expect(configContent).toContain('trust_level = "trusted"')
+    expect(configContent).toContain('workspace_write = true')
+    expect(configContent).toContain(nestedProjectKey)
+    expect(configContent).toContain('command = "node"')
   })
 
   it('keeps concurrent skill sync idempotent when multiple vf processes initialize the same mock home', async () => {

--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -531,6 +531,139 @@ describe('initCodexAdapter', () => {
     expect(configContent).toContain('hide_full_access_warning = true')
   })
 
+  it('preserves other workspaces managed project markers while rewriting the current workspace block', async () => {
+    const workspace = await createWorkspace()
+    const otherWorkspace = resolve(workspace, '..', 'other-workspace')
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const currentProjectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+    const otherProjectKey = `[projects.${JSON.stringify(otherWorkspace)}]`
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        '',
+        '# BEGIN VIBE FORGE MANAGED CODEX PROJECT CONFIG',
+        '# This project block is managed by Vibe Forge.',
+        otherProjectKey,
+        'trust_level = "trusted"',
+        '# END VIBE FORGE MANAGED CODEX PROJECT CONFIG',
+        '',
+        currentProjectKey,
+        'trust_level = "manual"',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain(otherProjectKey)
+    expect(configContent.match(/BEGIN VIBE FORGE MANAGED CODEX PROJECT CONFIG/g)).toHaveLength(2)
+    expect(configContent.split(currentProjectKey)).toHaveLength(2)
+  })
+
+  it('recognizes root table headers that carry inline comments', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'developer_instructions = "hi"',
+        '',
+        '[notice] # keep this comment',
+        'hide_full_access_warning = true',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain('# BEGIN VIBE FORGE MANAGED CODEX ROOT CONFIG')
+    expect(configContent).toContain('[notice] # keep this comment')
+  })
+
+  it('recognizes workspace project headers that carry inline comments', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const projectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        `${projectKey} # keep this comment`,
+        'trust_level = "manual"',
+        'workspace_write = true',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent.split(projectKey)).toHaveLength(2)
+    expect(configContent).toContain('workspace_write = true')
+  })
+
   it('keeps concurrent skill sync idempotent when multiple vf processes initialize the same mock home', async () => {
     const workspace = await createWorkspace()
     const mockHome = join(workspace, '.ai', '.mock')

--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -479,6 +479,57 @@ describe('initCodexAdapter', () => {
     expect(configContent.split(projectKey)).toHaveLength(2)
   })
 
+  it('does not strip managed marker-shaped lines when they appear inside a workspace multiline string', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const projectKey = `[projects.${JSON.stringify(resolve(workspace))}]`
+    const projectPromptBlock = [
+      'project_prompt = """',
+      '# BEGIN VIBE FORGE MANAGED CODEX PROJECT CONFIG',
+      '# This project block is managed by Vibe Forge.',
+      '# END VIBE FORGE MANAGED CODEX PROJECT CONFIG',
+      '"""'
+    ].join('\n')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        projectKey,
+        'trust_level = "manual"',
+        projectPromptBlock,
+        ''
+      ].join('\n')
+    )
+
+    const ctx = {
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any
+
+    await initCodexAdapter(ctx)
+    await initCodexAdapter(ctx)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain(projectPromptBlock)
+    expect(configContent).toContain('trust_level = "trusted"')
+  })
+
   it('does not insert the managed root block into a root multiline string that contains a table-like line', async () => {
     const workspace = await createWorkspace()
     const mockHome = join(workspace, '.ai', '.mock')

--- a/packages/adapters/codex/src/runtime/config.ts
+++ b/packages/adapters/codex/src/runtime/config.ts
@@ -30,24 +30,26 @@ const LEGACY_MANAGED_CONFIG_BLOCK_PATTERN = new RegExp(
   'g'
 )
 
-const MANAGED_PROJECT_MARKER_LINES_PATTERN = new RegExp(
-  [
-    `^${MANAGED_PROJECT_BLOCK_START.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
-    '^# This project block is managed by Vibe Forge\\.$',
-    `^${MANAGED_PROJECT_BLOCK_END.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`
-  ].join('|'),
-  'gm'
-)
+const MANAGED_PROJECT_BLOCK_COMMENT = '# This project block is managed by Vibe Forge.'
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => (
   value != null && typeof value === 'object' && !Array.isArray(value)
 )
 
-const TOML_TABLE_HEADER_PATTERN = /^\s*(?:\[\[.+\]\]|\[.+\])\s*$/
-
 interface TomlSection {
   header: string | undefined
   lines: string[]
+  startLine: number
+  endLine: number
+  startOffset: number
+  endOffset: number
+}
+
+interface TomlLine {
+  text: string
+  startOffset: number
+  endOffset: number
+  stringStateBefore: TomlStringScanState
 }
 
 type TomlStringScanState = 'none' | 'multiline-basic' | 'multiline-literal'
@@ -146,38 +148,135 @@ const getTomlLineEndStringState = (line: string, initialState: TomlStringScanSta
   return state === 'basic' || state === 'literal' ? 'none' : state
 }
 
-const splitTomlSections = (content: string): TomlSection[] => {
-  const normalizedContent = normalizeTomlContent(content)
-  const lines = normalizedContent.split('\n')
-  const sections: TomlSection[] = []
-  let currentSection: TomlSection = {
-    header: undefined,
-    lines: []
+const parseTomlTableHeaderLine = (line: string): string | undefined => {
+  let startIndex = 0
+  while (startIndex < line.length && /\s/.test(line[startIndex] ?? '')) {
+    startIndex += 1
   }
-  let stringState: TomlStringScanState = 'none'
 
-  for (const line of lines) {
-    if (stringState === 'none' && TOML_TABLE_HEADER_PATTERN.test(line)) {
-      if (currentSection.lines.length > 0) {
-        sections.push(currentSection)
+  if (line[startIndex] !== '[') return undefined
+
+  const isArrayTable = line[startIndex + 1] === '['
+  let quoteState: 'none' | 'basic' | 'literal' = 'none'
+  let index = startIndex + (isArrayTable ? 2 : 1)
+
+  for (; index < line.length; index += 1) {
+    const character = line[index]
+
+    if (quoteState === 'none') {
+      if (character === '#') return undefined
+      if (character === '"') {
+        quoteState = 'basic'
+        continue
       }
-      currentSection = {
-        header: line.trim(),
-        lines: [line]
+      if (character === "'") {
+        quoteState = 'literal'
+        continue
       }
-      stringState = getTomlLineEndStringState(line, stringState)
+      if (!isArrayTable && character === ']') {
+        index += 1
+        break
+      }
+      if (isArrayTable && character === ']' && line[index + 1] === ']') {
+        index += 2
+        break
+      }
       continue
     }
 
+    if (quoteState === 'basic') {
+      if (character === '\\') {
+        index += 1
+        continue
+      }
+      if (character === '"') {
+        quoteState = 'none'
+      }
+      continue
+    }
+
+    if (character === "'") {
+      quoteState = 'none'
+    }
+  }
+
+  if (quoteState !== 'none') return undefined
+
+  const header = line.slice(startIndex, index).trim()
+  if (header === '' || !header.endsWith(isArrayTable ? ']]' : ']')) return undefined
+  if (!/^\s*(?:#.*)?$/.test(line.slice(index))) return undefined
+
+  return header
+}
+
+const scanTomlSections = (content: string): {
+  lines: TomlLine[]
+  sections: TomlSection[]
+} => {
+  const normalizedContent = normalizeTomlContent(content)
+  const rawLines = normalizedContent.split('\n')
+  const lines: TomlLine[] = []
+  const sections: TomlSection[] = []
+  let currentSection: TomlSection = {
+    header: undefined,
+    lines: [],
+    startLine: 0,
+    endLine: 0,
+    startOffset: 0,
+    endOffset: 0
+  }
+  let stringState: TomlStringScanState = 'none'
+  let offset = 0
+
+  for (const [lineIndex, line] of rawLines.entries()) {
+    const lineStartOffset = offset
+    const lineEndOffset = lineStartOffset + line.length + (lineIndex < rawLines.length - 1 ? 1 : 0)
+    lines.push({
+      text: line,
+      startOffset: lineStartOffset,
+      endOffset: lineEndOffset,
+      stringStateBefore: stringState
+    })
+
+    const header = stringState === 'none' ? parseTomlTableHeaderLine(line) : undefined
+    if (header != null) {
+      if (currentSection.lines.length > 0) {
+        currentSection.endLine = lineIndex
+        currentSection.endOffset = lineStartOffset
+        sections.push(currentSection)
+      }
+      currentSection = {
+        header,
+        lines: [line],
+        startLine: lineIndex,
+        endLine: lineIndex + 1,
+        startOffset: lineStartOffset,
+        endOffset: lineEndOffset
+      }
+      stringState = getTomlLineEndStringState(line, stringState)
+      offset = lineEndOffset
+      continue
+    }
+
+    if (currentSection.lines.length === 0) {
+      currentSection.startLine = lineIndex
+      currentSection.startOffset = lineStartOffset
+    }
     currentSection.lines.push(line)
     stringState = getTomlLineEndStringState(line, stringState)
+    offset = lineEndOffset
   }
 
   if (currentSection.lines.length > 0) {
+    currentSection.endLine = rawLines.length
+    currentSection.endOffset = normalizedContent.length
     sections.push(currentSection)
   }
 
-  return sections
+  return {
+    lines,
+    sections
+  }
 }
 
 const trimBlankLines = (lines: string[]) => {
@@ -193,8 +292,6 @@ const trimBlankLines = (lines: string[]) => {
 
   return lines.slice(start, end)
 }
-
-const joinTomlSections = (sections: TomlSection[]) => sections.map(section => section.lines.join('\n')).join('\n')
 
 const getTomlHeaderKey = (header: string | undefined) => {
   if (header == null) return undefined
@@ -212,6 +309,40 @@ const isWorkspaceProjectNamespaceHeader = (header: string | undefined, workspace
   const workspaceProjectKey = `projects.${JSON.stringify(resolve(workspacePath))}`
 
   return headerKey === workspaceProjectKey || headerKey?.startsWith(`${workspaceProjectKey}.`) === true
+}
+
+const isManagedProjectMarkerLine = (line: string) => {
+  const trimmedLine = line.trim()
+  return trimmedLine === MANAGED_PROJECT_BLOCK_START ||
+    trimmedLine === MANAGED_PROJECT_BLOCK_COMMENT ||
+    trimmedLine === MANAGED_PROJECT_BLOCK_END
+}
+
+const findManagedProjectPreambleStartLine = (lines: TomlLine[]) =>
+  lines.findIndex((line, lineIndex) =>
+    line.stringStateBefore === 'none' &&
+    line.text.trim() === MANAGED_PROJECT_BLOCK_START &&
+    lines[lineIndex + 1]?.stringStateBefore === 'none' &&
+    lines[lineIndex + 1]?.text.trim() === MANAGED_PROJECT_BLOCK_COMMENT
+  )
+
+const findManagedProjectPreambleLineNumbers = (lines: TomlLine[], headerLineIndex: number) => {
+  let candidateLineIndex = headerLineIndex - 1
+  while (candidateLineIndex >= 0 && lines[candidateLineIndex]?.text.trim() === '') {
+    candidateLineIndex -= 1
+  }
+
+  if (
+    candidateLineIndex >= 1 &&
+    lines[candidateLineIndex]?.stringStateBefore === 'none' &&
+    lines[candidateLineIndex - 1]?.stringStateBefore === 'none' &&
+    lines[candidateLineIndex]?.text.trim() === MANAGED_PROJECT_BLOCK_COMMENT &&
+    lines[candidateLineIndex - 1]?.text.trim() === MANAGED_PROJECT_BLOCK_START
+  ) {
+    return [candidateLineIndex - 1, candidateLineIndex]
+  }
+
+  return []
 }
 
 export const DEFAULT_CODEX_CONFIG_OVERRIDES: Record<string, unknown> = {
@@ -309,7 +440,7 @@ const buildManagedCodexProjectBlock = (params: {
 }) => {
   const blockLines = [
     MANAGED_PROJECT_BLOCK_START,
-    '# This project block is managed by Vibe Forge.',
+    MANAGED_PROJECT_BLOCK_COMMENT,
     `[projects.${JSON.stringify(resolve(params.workspacePath))}]`,
     'trust_level = "trusted"',
     ...trimBlankLines(params.preservedProjectBodyLines ?? [])
@@ -344,26 +475,24 @@ const upsertManagedRootBlock = (params: {
   const managedBlock = buildManagedCodexRootBlock({
     checkForUpdateOnStartup: params.checkForUpdateOnStartup
   })
-  const sections = splitTomlSections(strippedContent)
-  const firstTableSectionIndex = sections.findIndex(section => section.header != null)
-  const managedProjectBlockIndex = strippedContent.indexOf(MANAGED_PROJECT_BLOCK_START)
+  const scan = scanTomlSections(strippedContent)
+  const firstTableSection = scan.sections.find(section => section.header != null)
+  const managedProjectPreambleLineIndex = findManagedProjectPreambleStartLine(scan.lines)
 
   if (strippedContent === '') {
     return managedBlock
   }
 
-  if (firstTableSectionIndex < 0) {
+  if (firstTableSection == null) {
     return `${strippedContent}\n\n${managedBlock}`
   }
 
-  const firstTableHeader = sections[firstTableSectionIndex]?.header
-  const firstTableIndex = firstTableHeader == null
-    ? -1
-    : strippedContent.indexOf(firstTableHeader)
-  const insertionIndex =
-    managedProjectBlockIndex >= 0 && (firstTableIndex < 0 || managedProjectBlockIndex < firstTableIndex)
-      ? managedProjectBlockIndex
-      : firstTableIndex
+  const insertionIndex = managedProjectPreambleLineIndex >= 0
+    ? Math.min(
+      firstTableSection.startOffset,
+      scan.lines[managedProjectPreambleLineIndex]?.startOffset ?? firstTableSection.startOffset
+    )
+    : firstTableSection.startOffset
   const beforeTables = strippedContent.slice(0, insertionIndex).trimEnd()
   const fromFirstTable = strippedContent.slice(insertionIndex).trimStart()
 
@@ -379,30 +508,42 @@ const upsertManagedProjectBlock = (params: {
   workspacePath: string
 }) => {
   const strippedManagedContent = normalizeTomlContent(params.currentContent)
-    .replace(MANAGED_PROJECT_MARKER_LINES_PATTERN, '')
     .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
-  const sections = splitTomlSections(strippedManagedContent)
+  const scan = scanTomlSections(strippedManagedContent)
   const preservedProjectBodyLines: string[] = []
   const preservedNestedProjectSections: string[] = []
-  const strippedContent = sections
-    .filter((section) => {
-      if (!isWorkspaceProjectNamespaceHeader(section.header, params.workspacePath)) {
-        return true
+  const skippedLineNumbers = new Set<number>()
+
+  for (const section of scan.sections) {
+    if (!isWorkspaceProjectNamespaceHeader(section.header, params.workspacePath)) {
+      continue
+    }
+
+    for (let lineIndex = section.startLine; lineIndex < section.endLine; lineIndex += 1) {
+      skippedLineNumbers.add(lineIndex)
+    }
+
+    const headerKey = getTomlHeaderKey(section.header)
+    const workspaceProjectKey = `projects.${JSON.stringify(resolve(params.workspacePath))}`
+    const normalizedSectionLines = trimBlankLines(section.lines.filter(line => !isManagedProjectMarkerLine(line)))
+
+    if (headerKey === workspaceProjectKey) {
+      for (const lineIndex of findManagedProjectPreambleLineNumbers(scan.lines, section.startLine)) {
+        skippedLineNumbers.add(lineIndex)
       }
 
-      const headerKey = getTomlHeaderKey(section.header)
-      const workspaceProjectKey = `projects.${JSON.stringify(resolve(params.workspacePath))}`
-      if (headerKey === workspaceProjectKey) {
-        preservedProjectBodyLines.push(
-          ...trimBlankLines(section.lines.slice(1)).filter(line => !/^\s*trust_level\s*=/.test(line))
-        )
-      } else {
-        preservedNestedProjectSections.push(trimBlankLines(section.lines).join('\n'))
-      }
+      preservedProjectBodyLines.push(
+        ...trimBlankLines(normalizedSectionLines.slice(1)).filter(line => !/^\s*trust_level\s*=/.test(line))
+      )
+      continue
+    }
 
-      return false
-    })
-    .map(section => section.lines.join('\n'))
+    preservedNestedProjectSections.push(normalizedSectionLines.join('\n'))
+  }
+
+  const strippedContent = scan.lines
+    .filter((_, lineIndex) => !skippedLineNumbers.has(lineIndex))
+    .map(line => line.text)
     .join('\n')
     .trim()
   const managedBlock = buildManagedCodexProjectBlock({

--- a/packages/adapters/codex/src/runtime/config.ts
+++ b/packages/adapters/codex/src/runtime/config.ts
@@ -37,11 +37,81 @@ const LEGACY_MANAGED_CONFIG_BLOCK_PATTERN = new RegExp(
   'g'
 )
 
-const escapeRegExp = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
 const isPlainObject = (value: unknown): value is Record<string, unknown> => (
   value != null && typeof value === 'object' && !Array.isArray(value)
 )
+
+const TOML_TABLE_HEADER_PATTERN = /^\s*(?:\[\[.+\]\]|\[.+\])\s*$/
+
+interface TomlSection {
+  header: string | undefined
+  lines: string[]
+}
+
+const normalizeTomlContent = (content: string) => content.replaceAll('\r\n', '\n')
+
+const splitTomlSections = (content: string): TomlSection[] => {
+  const normalizedContent = normalizeTomlContent(content)
+  const lines = normalizedContent.split('\n')
+  const sections: TomlSection[] = []
+  let currentSection: TomlSection = {
+    header: undefined,
+    lines: []
+  }
+
+  for (const line of lines) {
+    if (TOML_TABLE_HEADER_PATTERN.test(line)) {
+      if (currentSection.lines.length > 0) {
+        sections.push(currentSection)
+      }
+      currentSection = {
+        header: line.trim(),
+        lines: [line]
+      }
+      continue
+    }
+
+    currentSection.lines.push(line)
+  }
+
+  if (currentSection.lines.length > 0) {
+    sections.push(currentSection)
+  }
+
+  return sections
+}
+
+const trimBlankLines = (lines: string[]) => {
+  let start = 0
+  let end = lines.length
+
+  while (start < end && lines[start]?.trim() === '') {
+    start += 1
+  }
+  while (end > start && lines[end - 1]?.trim() === '') {
+    end -= 1
+  }
+
+  return lines.slice(start, end)
+}
+
+const getTomlHeaderKey = (header: string | undefined) => {
+  if (header == null) return undefined
+  if (header.startsWith('[[') && header.endsWith(']]')) {
+    return header.slice(2, -2).trim()
+  }
+  if (header.startsWith('[') && header.endsWith(']')) {
+    return header.slice(1, -1).trim()
+  }
+  return undefined
+}
+
+const isWorkspaceProjectNamespaceHeader = (header: string | undefined, workspacePath: string) => {
+  const headerKey = getTomlHeaderKey(header)
+  const workspaceProjectKey = `projects.${JSON.stringify(resolve(workspacePath))}`
+
+  return headerKey === workspaceProjectKey || headerKey?.startsWith(`${workspaceProjectKey}.`) === true
+}
 
 export const DEFAULT_CODEX_CONFIG_OVERRIDES: Record<string, unknown> = {
   check_for_update_on_startup: false
@@ -133,21 +203,40 @@ const buildManagedCodexRootBlock = (params: {
 
 const buildManagedCodexProjectBlock = (params: {
   workspacePath: string
-}) =>
-  [
+  preservedProjectBodyLines?: string[]
+  preservedNestedProjectSections?: string[]
+}) => {
+  const blockLines = [
     MANAGED_PROJECT_BLOCK_START,
     '# This project block is managed by Vibe Forge.',
     `[projects.${JSON.stringify(resolve(params.workspacePath))}]`,
     'trust_level = "trusted"',
+    ...trimBlankLines(params.preservedProjectBodyLines ?? [])
+  ]
+
+  if ((params.preservedNestedProjectSections?.length ?? 0) > 0) {
+    blockLines.push('')
+    for (const [index, section] of (params.preservedNestedProjectSections ?? []).entries()) {
+      if (index > 0) {
+        blockLines.push('')
+      }
+      blockLines.push(...section.split('\n'))
+    }
+  }
+
+  blockLines.push(
     MANAGED_PROJECT_BLOCK_END,
     ''
-  ].join('\n')
+  )
+
+  return blockLines.join('\n')
+}
 
 const upsertManagedRootBlock = (params: {
   currentContent: string
   checkForUpdateOnStartup: unknown
 }) => {
-  const strippedContent = params.currentContent
+  const strippedContent = normalizeTomlContent(params.currentContent)
     .replace(MANAGED_ROOT_BLOCK_PATTERN, '')
     .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
     .trim()
@@ -182,19 +271,37 @@ const upsertManagedProjectBlock = (params: {
   currentContent: string
   workspacePath: string
 }) => {
-  const workspaceTrustBlockPattern = new RegExp(
-    `(^|\\n)\\[projects\\.${
-      escapeRegExp(JSON.stringify(resolve(params.workspacePath)))
-    }\\]\\ntrust_level = "trusted"\\n?`,
-    'g'
-  )
-  const strippedContent = params.currentContent
+  const strippedManagedContent = normalizeTomlContent(params.currentContent)
     .replace(MANAGED_PROJECT_BLOCK_PATTERN, '')
     .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
-    .replace(workspaceTrustBlockPattern, '$1')
+  const sections = splitTomlSections(strippedManagedContent)
+  const preservedProjectBodyLines: string[] = []
+  const preservedNestedProjectSections: string[] = []
+  const strippedContent = sections
+    .filter((section) => {
+      if (!isWorkspaceProjectNamespaceHeader(section.header, params.workspacePath)) {
+        return true
+      }
+
+      const headerKey = getTomlHeaderKey(section.header)
+      const workspaceProjectKey = `projects.${JSON.stringify(resolve(params.workspacePath))}`
+      if (headerKey === workspaceProjectKey) {
+        preservedProjectBodyLines.push(
+          ...trimBlankLines(section.lines.slice(1)).filter(line => !/^\s*trust_level\s*=/.test(line))
+        )
+      } else {
+        preservedNestedProjectSections.push(trimBlankLines(section.lines).join('\n'))
+      }
+
+      return false
+    })
+    .map(section => section.lines.join('\n'))
+    .join('\n')
     .trim()
   const managedBlock = buildManagedCodexProjectBlock({
-    workspacePath: params.workspacePath
+    workspacePath: params.workspacePath,
+    preservedProjectBodyLines,
+    preservedNestedProjectSections
   })
 
   return strippedContent === ''

--- a/packages/adapters/codex/src/runtime/config.ts
+++ b/packages/adapters/codex/src/runtime/config.ts
@@ -318,6 +318,14 @@ const isManagedProjectMarkerLine = (line: string) => {
     trimmedLine === MANAGED_PROJECT_BLOCK_END
 }
 
+const getSectionLineEntries = (section: TomlSection, lines: TomlLine[]) =>
+  lines.slice(section.startLine, section.endLine)
+
+const getManagedFilteredSectionLines = (section: TomlSection, lines: TomlLine[]) =>
+  getSectionLineEntries(section, lines)
+    .filter(line => !(line.stringStateBefore === 'none' && isManagedProjectMarkerLine(line.text)))
+    .map(line => line.text)
+
 const findManagedProjectPreambleStartLine = (lines: TomlLine[]) =>
   lines.findIndex((line, lineIndex) =>
     line.stringStateBefore === 'none' &&
@@ -525,7 +533,7 @@ const upsertManagedProjectBlock = (params: {
 
     const headerKey = getTomlHeaderKey(section.header)
     const workspaceProjectKey = `projects.${JSON.stringify(resolve(params.workspacePath))}`
-    const normalizedSectionLines = trimBlankLines(section.lines.filter(line => !isManagedProjectMarkerLine(line)))
+    const normalizedSectionLines = trimBlankLines(getManagedFilteredSectionLines(section, scan.lines))
 
     if (headerKey === workspaceProjectKey) {
       for (const lineIndex of findManagedProjectPreambleLineNumbers(scan.lines, section.startLine)) {

--- a/packages/adapters/codex/src/runtime/config.ts
+++ b/packages/adapters/codex/src/runtime/config.ts
@@ -23,18 +23,20 @@ const MANAGED_ROOT_BLOCK_PATTERN = new RegExp(
   'g'
 )
 
-const MANAGED_PROJECT_BLOCK_PATTERN = new RegExp(
-  `${MANAGED_PROJECT_BLOCK_START.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${
-    MANAGED_PROJECT_BLOCK_END.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  }\\n?`,
-  'g'
-)
-
 const LEGACY_MANAGED_CONFIG_BLOCK_PATTERN = new RegExp(
   `${LEGACY_MANAGED_CONFIG_BLOCK_START.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${
     LEGACY_MANAGED_CONFIG_BLOCK_END.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
   }\\n?`,
   'g'
+)
+
+const MANAGED_PROJECT_MARKER_LINES_PATTERN = new RegExp(
+  [
+    `^${MANAGED_PROJECT_BLOCK_START.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
+    '^# This project block is managed by Vibe Forge\\.$',
+    `^${MANAGED_PROJECT_BLOCK_END.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`
+  ].join('|'),
+  'gm'
 )
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => (
@@ -48,7 +50,101 @@ interface TomlSection {
   lines: string[]
 }
 
+type TomlStringScanState = 'none' | 'multiline-basic' | 'multiline-literal'
+
 const normalizeTomlContent = (content: string) => content.replaceAll('\r\n', '\n')
+
+const countConsecutiveCharacters = (content: string, startIndex: number, character: '"' | "'") => {
+  let index = startIndex
+  while (content[index] === character) {
+    index += 1
+  }
+  return index - startIndex
+}
+
+const getTomlLineEndStringState = (line: string, initialState: TomlStringScanState): TomlStringScanState => {
+  let state: TomlStringScanState | 'basic' | 'literal' = initialState
+
+  for (let index = 0; index < line.length;) {
+    if (state === 'none') {
+      const character = line[index]
+      if (character === '#') break
+      if (character === '"') {
+        const quoteCount = countConsecutiveCharacters(line, index, '"')
+        if (quoteCount >= 3) {
+          state = 'multiline-basic'
+          index += 3
+          continue
+        }
+        state = 'basic'
+        index += 1
+        continue
+      }
+      if (character === "'") {
+        const quoteCount = countConsecutiveCharacters(line, index, "'")
+        if (quoteCount >= 3) {
+          state = 'multiline-literal'
+          index += 3
+          continue
+        }
+        state = 'literal'
+        index += 1
+        continue
+      }
+      index += 1
+      continue
+    }
+
+    if (state === 'basic') {
+      if (line[index] === '\\') {
+        index += 2
+        continue
+      }
+      if (line[index] === '"') {
+        state = 'none'
+        index += 1
+        continue
+      }
+      index += 1
+      continue
+    }
+
+    if (state === 'literal') {
+      if (line[index] === "'") {
+        state = 'none'
+        index += 1
+        continue
+      }
+      index += 1
+      continue
+    }
+
+    if (state === 'multiline-basic') {
+      const quoteCount = countConsecutiveCharacters(line, index, '"')
+      if (quoteCount >= 3) {
+        state = 'none'
+        index += Math.min(quoteCount, 5)
+        continue
+      }
+      if (line[index] === '\\') {
+        index += 2
+        continue
+      }
+      index += 1
+      continue
+    }
+
+    const quoteCount = countConsecutiveCharacters(line, index, "'")
+    if (quoteCount >= 3) {
+      state = 'none'
+      index += Math.min(quoteCount, 5)
+      continue
+    }
+    index += 1
+  }
+
+  return state === 'basic' || state === 'literal' ? 'none' : state
+}
 
 const splitTomlSections = (content: string): TomlSection[] => {
   const normalizedContent = normalizeTomlContent(content)
@@ -58,9 +154,10 @@ const splitTomlSections = (content: string): TomlSection[] => {
     header: undefined,
     lines: []
   }
+  let stringState: TomlStringScanState = 'none'
 
   for (const line of lines) {
-    if (TOML_TABLE_HEADER_PATTERN.test(line)) {
+    if (stringState === 'none' && TOML_TABLE_HEADER_PATTERN.test(line)) {
       if (currentSection.lines.length > 0) {
         sections.push(currentSection)
       }
@@ -68,10 +165,12 @@ const splitTomlSections = (content: string): TomlSection[] => {
         header: line.trim(),
         lines: [line]
       }
+      stringState = getTomlLineEndStringState(line, stringState)
       continue
     }
 
     currentSection.lines.push(line)
+    stringState = getTomlLineEndStringState(line, stringState)
   }
 
   if (currentSection.lines.length > 0) {
@@ -94,6 +193,8 @@ const trimBlankLines = (lines: string[]) => {
 
   return lines.slice(start, end)
 }
+
+const joinTomlSections = (sections: TomlSection[]) => sections.map(section => section.lines.join('\n')).join('\n')
 
 const getTomlHeaderKey = (header: string | undefined) => {
   if (header == null) return undefined
@@ -243,20 +344,26 @@ const upsertManagedRootBlock = (params: {
   const managedBlock = buildManagedCodexRootBlock({
     checkForUpdateOnStartup: params.checkForUpdateOnStartup
   })
-  const firstTableMatch = strippedContent.match(/^\s*\[/m)
+  const sections = splitTomlSections(strippedContent)
+  const firstTableSectionIndex = sections.findIndex(section => section.header != null)
   const managedProjectBlockIndex = strippedContent.indexOf(MANAGED_PROJECT_BLOCK_START)
 
   if (strippedContent === '') {
     return managedBlock
   }
 
-  if (firstTableMatch == null || firstTableMatch.index == null) {
+  if (firstTableSectionIndex < 0) {
     return `${strippedContent}\n\n${managedBlock}`
   }
 
-  const insertionIndex = managedProjectBlockIndex >= 0 && managedProjectBlockIndex < firstTableMatch.index
-    ? managedProjectBlockIndex
-    : firstTableMatch.index
+  const firstTableHeader = sections[firstTableSectionIndex]?.header
+  const firstTableIndex = firstTableHeader == null
+    ? -1
+    : strippedContent.indexOf(firstTableHeader)
+  const insertionIndex =
+    managedProjectBlockIndex >= 0 && (firstTableIndex < 0 || managedProjectBlockIndex < firstTableIndex)
+      ? managedProjectBlockIndex
+      : firstTableIndex
   const beforeTables = strippedContent.slice(0, insertionIndex).trimEnd()
   const fromFirstTable = strippedContent.slice(insertionIndex).trimStart()
 
@@ -272,7 +379,7 @@ const upsertManagedProjectBlock = (params: {
   workspacePath: string
 }) => {
   const strippedManagedContent = normalizeTomlContent(params.currentContent)
-    .replace(MANAGED_PROJECT_BLOCK_PATTERN, '')
+    .replace(MANAGED_PROJECT_MARKER_LINES_PATTERN, '')
     .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
   const sections = splitTomlSections(strippedManagedContent)
   const preservedProjectBodyLines: string[] = []


### PR DESCRIPTION
## Summary
- dedupe managed Codex project config blocks by parsing TOML sections instead of only stripping a narrow trust block
- normalize CRLF config content before rewriting managed blocks so existing workspace tables are not duplicated
- preserve existing workspace project settings and nested project subtables while rewriting the managed trust block
- add regression tests for CRLF configs and existing workspace project subtables

## Verification
- `pnpm exec vitest run packages/adapters/codex/__tests__/init.spec.ts`
- `pnpm exec eslint packages/adapters/codex/src/runtime/config.ts packages/adapters/codex/__tests__/init.spec.ts`
- `pnpm exec dprint check packages/adapters/codex/src/runtime/config.ts packages/adapters/codex/__tests__/init.spec.ts`
- `pnpm tools adapter-e2e run codex-read-once --quiet`