### PR TITLE
feat(config): reload external changes with conflict prompts

### DIFF
--- a/apps/client/AGENTS.md
+++ b/apps/client/AGENTS.md
@@ -4,6 +4,8 @@
 - `src/routes/`：页面级 route 入口，只处理 URL、路由参数、页面装配和少量 route 级数据获取。
 - `src/components/layout/`：全局布局组件，当前放置 `AppShell` 这类应用骨架。
 - `src/components/`：可复用视图组件和页面内部面板，不承担路由匹配职责。
+- `src/components/config/`：配置页编辑器、worktree environment 面板与配置冲突处理逻辑。
+  - 涉及配置页自动保存、热更新、外部配置变更或冲突提示时，先读 `src/components/config/AGENTS.md`。
 - `src/components/chat/`：聊天页子视图，包含 header、history、timeline、settings、sender 和工具渲染。
   - 消息级 `编辑 / 撤回 / 分叉 / 复制原文` 的更细维护说明见 `src/components/chat/AGENTS.md`。
 - `src/hooks/`：跨页面通用 hooks；`src/hooks/chat/` 专门承载聊天会话相关状态和交互逻辑。
@@ -38,6 +40,7 @@
 - 页面级列表或详情拉取优先放在 route 或对应页面 hook 中，不要散落在纯展示组件内。
 - API 请求统一走 `src/api/`，避免在组件里直接手写 `fetch`。
 - 能复用的状态逻辑优先抽到 hooks，不在 route 和 view 间复制业务逻辑。
+- 配置页收到 `config_updated` 后，订阅层只负责刷新缓存；本地草稿和远端配置的冲突判断必须留在配置编辑器内部完成，避免静默覆盖用户正在编辑的内容。
 
 组件与 hook 归档约定：
 

--- a/apps/client/__tests__/config-conflict.spec.ts
+++ b/apps/client/__tests__/config-conflict.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getConfigDraftKey,
+  resolveRemoteConfigChangeAction,
+  serializeComparableConfigValue
+} from '#~/components/config/configConflict'
+
+describe('config conflict helpers', () => {
+  it('builds stable draft keys for section sources', () => {
+    expect(getConfigDraftKey('general', 'project')).toBe('project:general')
+    expect(getConfigDraftKey('models', 'user')).toBe('user:models')
+  })
+
+  it('normalizes object keys before comparing values', () => {
+    const first = serializeComparableConfigValue({
+      general: {
+        env: {
+          API_KEY: 'demo',
+          REGION: 'cn'
+        }
+      }
+    })
+    const second = serializeComparableConfigValue({
+      general: {
+        env: {
+          REGION: 'cn',
+          API_KEY: 'demo'
+        }
+      }
+    })
+
+    expect(first).toBe(second)
+  })
+
+  it('syncs the draft when only the remote copy changed', () => {
+    expect(resolveRemoteConfigChangeAction({
+      baseSerialized: serializeComparableConfigValue({ retries: 1 }),
+      draftSerialized: serializeComparableConfigValue({ retries: 1 }),
+      serverSerialized: serializeComparableConfigValue({ retries: 2 })
+    })).toBe('sync-remote')
+  })
+
+  it('reports a conflict when both local and remote copies changed', () => {
+    expect(resolveRemoteConfigChangeAction({
+      baseSerialized: serializeComparableConfigValue({ retries: 1 }),
+      draftSerialized: serializeComparableConfigValue({ retries: 3 }),
+      serverSerialized: serializeComparableConfigValue({ retries: 2 })
+    })).toBe('conflict')
+  })
+
+  it('does not flag a conflict once the local draft already matches the server', () => {
+    expect(resolveRemoteConfigChangeAction({
+      baseSerialized: serializeComparableConfigValue({ retries: 1 }),
+      draftSerialized: serializeComparableConfigValue({ retries: 2 }),
+      serverSerialized: serializeComparableConfigValue({ retries: 2 })
+    })).toBe('none')
+  })
+})

--- a/apps/client/__tests__/session-subscription-cache.spec.ts
+++ b/apps/client/__tests__/session-subscription-cache.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isConfigRelatedDerivedCacheKey, revalidateConfigRelatedCaches } from '#~/hooks/session-subscription-cache'
+
+describe('session subscription config cache helpers', () => {
+  it('matches adapter and worktree-environment caches that depend on config', () => {
+    expect(isConfigRelatedDerivedCacheKey('worktree-environments')).toBe(false)
+    expect(isConfigRelatedDerivedCacheKey(['worktree-environment', 'user', 'demo'])).toBe(true)
+    expect(isConfigRelatedDerivedCacheKey(['/api/adapters', 'codex', 'gpt-5.4'])).toBe(true)
+    expect(isConfigRelatedDerivedCacheKey('/api/adapters/codex/accounts')).toBe(true)
+    expect(isConfigRelatedDerivedCacheKey('/api/sessions')).toBe(false)
+  })
+
+  it('revalidates config and derived caches after a config update event', async () => {
+    const mutate = vi.fn().mockResolvedValue(undefined)
+
+    await revalidateConfigRelatedCaches(mutate)
+
+    expect(mutate).toHaveBeenCalledTimes(3)
+    expect(mutate).toHaveBeenNthCalledWith(1, '/api/config')
+    expect(mutate).toHaveBeenNthCalledWith(2, 'worktree-environments')
+    expect(typeof mutate.mock.calls[2]?.[0]).toBe('function')
+  })
+})

--- a/apps/client/src/components/ConfigView.tsx
+++ b/apps/client/src/components/ConfigView.tsx
@@ -16,13 +16,25 @@ import { getApiErrorMessage, getConfig, getConfigSchema, listWorktreeEnvironment
 import { useQueryParams } from '../hooks/useQueryParams'
 import { AboutSection, ConfigSectionPanel, ConfigSourceSwitch, DisplayValue } from './config'
 import { AppSettingsPanel } from './config/AppSettingsPanel'
+import {
+  getConfigDraftKey,
+  resolveRemoteConfigChangeAction,
+  serializeComparableConfigValue
+} from './config/configConflict'
 import { WorktreeEnvironmentPanel } from './config/WorktreeEnvironmentPanel'
 import { cloneValue, getValueByPath, isEmptyValue } from './config/configUtils'
 import { toDisplayEnvironmentName, toEnvironmentReference } from './config/worktree-environment-panel-model'
 
+interface ConfigDraftConflict {
+  draftKey: string
+  sectionKey: string
+  source: ConfigSource
+  remoteValue: unknown
+}
+
 export function ConfigView() {
   const { t } = useTranslation()
-  const { message } = App.useApp()
+  const { message, modal } = App.useApp()
   const { isCompactLayout, isTouchInteraction } = useResponsiveLayout()
   const { data, isLoading, error, mutate } = useSWR<ConfigResponse>('/api/config', getConfig)
   const { data: schemaData } = useSWR('/api/config/schema', getConfigSchema)
@@ -54,7 +66,12 @@ export function ConfigView() {
   const saveTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   const savingRef = useRef<Record<string, boolean>>({})
   const lastSavedRef = useRef<Record<string, string>>({})
+  const baseSnapshotsRef = useRef<Record<string, string>>({})
+  const blockedDraftKeysRef = useRef<Record<string, boolean>>({})
+  const pendingConflictsRef = useRef<Record<string, ConfigDraftConflict>>({})
   const compactSidebarBackgroundRefs = useMemo(() => [compactContentRegionRef], [])
+  const [pendingConflicts, setPendingConflicts] = useState<Record<string, ConfigDraftConflict>>({})
+  const [activeConflictKey, setActiveConflictKey] = useState<string | null>(null)
   const mergedModelServices = useMemo(() => data?.sources?.merged?.modelServices ?? {}, [
     data?.sources?.merged?.modelServices
   ])
@@ -264,6 +281,10 @@ export function ConfigView() {
   }, [drafts])
 
   useEffect(() => {
+    pendingConflictsRef.current = pendingConflicts
+  }, [pendingConflicts])
+
+  useEffect(() => {
     return () => {
       Object.values(saveTimersRef.current).forEach((timer) => {
         clearTimeout(timer)
@@ -271,7 +292,25 @@ export function ConfigView() {
     }
   }, [])
 
-  const getDraftKey = (sectionKey: string, source = sourceKey) => `${source}:${sectionKey}`
+  const clearSaveTimer = (draftKey: string) => {
+    const timer = saveTimersRef.current[draftKey]
+    if (timer == null) return
+    clearTimeout(timer)
+    delete saveTimersRef.current[draftKey]
+  }
+
+  const clearDraftConflict = (draftKey: string) => {
+    delete blockedDraftKeysRef.current[draftKey]
+    setPendingConflicts((prev) => {
+      if (prev[draftKey] == null) return prev
+      const next = { ...prev }
+      delete next[draftKey]
+      return next
+    })
+    setActiveConflictKey(prev => prev === draftKey ? null : prev)
+  }
+
+  const getDraftKey = (sectionKey: string, source = sourceKey) => getConfigDraftKey(sectionKey, source)
   const generalDraftValue = useMemo(() => {
     const draftKey = getDraftKey('general')
     return (drafts[draftKey] ?? cloneValue(currentSource?.general ?? {}) ?? {}) as Record<string, unknown>
@@ -293,30 +332,63 @@ export function ConfigView() {
     })) ?? []
   ), [t, worktreeEnvironmentData?.environments])
 
+  const persistDraftValue = async ({
+    draftKey,
+    sectionKey,
+    source,
+    value
+  }: {
+    draftKey: string
+    sectionKey: string
+    source: ConfigSource
+    value: unknown
+  }) => {
+    const serialized = serializeComparableConfigValue(value)
+
+    if (savingRef.current[draftKey]) {
+      throw new Error(`config draft ${draftKey} is already saving`)
+    }
+
+    savingRef.current[draftKey] = true
+    try {
+      await updateConfig(source, sectionKey, value)
+      lastSavedRef.current[draftKey] = serialized
+      baseSnapshotsRef.current[draftKey] = serialized
+      await mutate()
+    } catch (error) {
+      void message.error(getApiErrorMessage(error, t('config.saveFailed')))
+      throw error
+    } finally {
+      savingRef.current[draftKey] = false
+    }
+  }
+
   const scheduleSave = (sectionKey: string, source: ConfigSource, nextValue: unknown) => {
     const draftKey = getDraftKey(sectionKey, source)
-    const serialized = JSON.stringify(nextValue ?? {})
+    if (blockedDraftKeysRef.current[draftKey]) {
+      clearSaveTimer(draftKey)
+      return
+    }
+
+    const serialized = serializeComparableConfigValue(nextValue)
     if (lastSavedRef.current[draftKey] === serialized) {
       return
     }
-    if (saveTimersRef.current[draftKey]) {
-      clearTimeout(saveTimersRef.current[draftKey])
-    }
+    clearSaveTimer(draftKey)
     saveTimersRef.current[draftKey] = setTimeout(async () => {
+      if (blockedDraftKeysRef.current[draftKey]) return
       if (savingRef.current[draftKey]) return
       const currentValue = draftsRef.current[draftKey] ?? nextValue
-      const currentSerialized = JSON.stringify(currentValue ?? {})
+      const currentSerialized = serializeComparableConfigValue(currentValue)
       if (lastSavedRef.current[draftKey] === currentSerialized) return
-      savingRef.current[draftKey] = true
       try {
-        await updateConfig(source, sectionKey, currentValue)
-        lastSavedRef.current[draftKey] = currentSerialized
-        await mutate()
-      } catch (error) {
-        void message.error(getApiErrorMessage(error, t('config.saveFailed')))
-      } finally {
-        savingRef.current[draftKey] = false
-      }
+        await persistDraftValue({
+          draftKey,
+          sectionKey,
+          source,
+          value: currentValue
+        })
+      } catch {}
     }, 800)
   }
 
@@ -325,6 +397,183 @@ export function ConfigView() {
     setDrafts(prev => ({ ...prev, [draftKey]: nextValue }))
     scheduleSave(sectionKey, sourceKey, nextValue)
   }
+
+  useEffect(() => {
+    const nextDrafts: Record<string, unknown> = {}
+    let hasDraftUpdates = false
+    const previousConflicts = pendingConflictsRef.current
+    let nextConflicts = previousConflicts
+    let conflictsChanged = false
+    const ensureMutableConflicts = () => {
+      if (!conflictsChanged) {
+        nextConflicts = { ...previousConflicts }
+        conflictsChanged = true
+      }
+      return nextConflicts
+    }
+
+    ;(['project', 'user'] as const).forEach((source) => {
+      const sourceData = data?.sources?.[source]
+      if (sourceData == null) return
+
+      configTabKeys.forEach((sectionKey) => {
+        const draftKey = getConfigDraftKey(sectionKey, source)
+        const serverValue = cloneValue((sourceData as Record<string, unknown>)[sectionKey] ?? {}) ?? {}
+        const serverSerialized = serializeComparableConfigValue(serverValue)
+        const baseSerialized = baseSnapshotsRef.current[draftKey]
+
+        if (baseSerialized == null) {
+          baseSnapshotsRef.current[draftKey] = serverSerialized
+          lastSavedRef.current[draftKey] ??= serverSerialized
+          return
+        }
+
+        const currentDraft = draftsRef.current[draftKey]
+        if (currentDraft === undefined) {
+          baseSnapshotsRef.current[draftKey] = serverSerialized
+          lastSavedRef.current[draftKey] = serverSerialized
+          delete blockedDraftKeysRef.current[draftKey]
+          if (nextConflicts[draftKey] != null) {
+            delete ensureMutableConflicts()[draftKey]
+          }
+          return
+        }
+
+        const draftSerialized = serializeComparableConfigValue(currentDraft)
+        const action = resolveRemoteConfigChangeAction({
+          baseSerialized,
+          draftSerialized,
+          serverSerialized
+        })
+
+        if (action === 'sync-remote') {
+          clearSaveTimer(draftKey)
+          delete blockedDraftKeysRef.current[draftKey]
+          baseSnapshotsRef.current[draftKey] = serverSerialized
+          lastSavedRef.current[draftKey] = serverSerialized
+          nextDrafts[draftKey] = serverValue
+          hasDraftUpdates = true
+          if (nextConflicts[draftKey] != null) {
+            delete ensureMutableConflicts()[draftKey]
+          }
+          return
+        }
+
+        if (action === 'conflict') {
+          clearSaveTimer(draftKey)
+          blockedDraftKeysRef.current[draftKey] = true
+          const existingConflict = nextConflicts[draftKey]
+          const existingRemoteSerialized = existingConflict == null
+            ? undefined
+            : serializeComparableConfigValue(existingConflict.remoteValue)
+          if (
+            existingConflict?.sectionKey !== sectionKey ||
+            existingConflict?.source !== source ||
+            existingRemoteSerialized !== serverSerialized
+          ) {
+            ensureMutableConflicts()[draftKey] = {
+              draftKey,
+              sectionKey,
+              source,
+              remoteValue: serverValue
+            }
+          }
+          return
+        }
+
+        if (draftSerialized === serverSerialized) {
+          baseSnapshotsRef.current[draftKey] = serverSerialized
+          lastSavedRef.current[draftKey] = serverSerialized
+        }
+
+        delete blockedDraftKeysRef.current[draftKey]
+        if (nextConflicts[draftKey] != null) {
+          delete ensureMutableConflicts()[draftKey]
+        }
+      })
+    })
+
+    if (conflictsChanged) {
+      setPendingConflicts(nextConflicts)
+    }
+
+    if (!hasDraftUpdates) return
+
+    setDrafts((prev) => {
+      let changed = false
+      const next = { ...prev }
+      Object.entries(nextDrafts).forEach(([draftKey, value]) => {
+        const currentSerialized = serializeComparableConfigValue(prev[draftKey])
+        const nextSerialized = serializeComparableConfigValue(value)
+        if (currentSerialized === nextSerialized) return
+        next[draftKey] = value
+        changed = true
+      })
+      return changed ? next : prev
+    })
+  }, [configTabKeys, data?.sources?.project, data?.sources?.user])
+
+  useEffect(() => {
+    if (activeConflictKey != null) return
+
+    const nextConflict = Object.values(pendingConflicts)[0]
+    if (nextConflict == null) return
+
+    const draftKey = nextConflict.draftKey
+    setActiveConflictKey(draftKey)
+
+    const sourceLabel = t(`config.sources.${nextConflict.source}`)
+    const sectionLabel = t(`config.sections.${nextConflict.sectionKey}`, { defaultValue: nextConflict.sectionKey })
+
+    modal.confirm({
+      title: t('config.conflict.title'),
+      content: (
+        <div>
+          <div>
+            {t('config.conflict.description', {
+              source: sourceLabel,
+              target: sectionLabel
+            })}
+          </div>
+          <div>{t('config.conflict.instructions')}</div>
+        </div>
+      ),
+      okText: t('config.conflict.keepLocal'),
+      cancelText: t('config.conflict.useRemote'),
+      cancelButtonProps: { danger: true },
+      closable: false,
+      keyboard: false,
+      maskClosable: false,
+      onOk: async () => {
+        const currentConflict = pendingConflictsRef.current[draftKey]
+        const sectionKey = currentConflict?.sectionKey ?? nextConflict.sectionKey
+        const source = currentConflict?.source ?? nextConflict.source
+        const currentDraft = cloneValue(
+          draftsRef.current[draftKey] ?? currentConflict?.remoteValue ?? nextConflict.remoteValue ?? {}
+        ) ?? {}
+
+        await persistDraftValue({
+          draftKey,
+          sectionKey,
+          source,
+          value: currentDraft
+        })
+
+        clearDraftConflict(draftKey)
+      },
+      onCancel: () => {
+        const currentConflict = pendingConflictsRef.current[draftKey] ?? nextConflict
+        const remoteValue = cloneValue(currentConflict.remoteValue ?? {}) ?? {}
+        const remoteSerialized = serializeComparableConfigValue(remoteValue)
+
+        clearSaveTimer(draftKey)
+        baseSnapshotsRef.current[draftKey] = remoteSerialized
+        lastSavedRef.current[draftKey] = remoteSerialized
+        setDrafts(prev => ({ ...prev, [draftKey]: remoteValue }))
+        clearDraftConflict(draftKey)
+      }
+    })
+  }, [activeConflictKey, modal, pendingConflicts, t])
 
   const renderSidebarExpandButton = () => (
     <Tooltip title={resolveTooltipTitle(t('common.expand'))} placement='bottom'>

--- a/apps/client/src/components/config/AGENTS.md
+++ b/apps/client/src/components/config/AGENTS.md
@@ -1,0 +1,45 @@
+# Config 组件维护说明
+
+本目录承载配置页与 worktree environment 编辑器；涉及以下入口时，先读本文件：
+
+- `../ConfigView.tsx`
+- `WorktreeEnvironmentPanel.tsx`
+- `use-worktree-environment-auto-save.ts`
+- `configConflict.ts`
+- `../../hooks/use-session-subscription.ts`
+- `../../hooks/session-subscription-cache.ts`
+
+## 当前设计
+
+配置文件被 CLI、手动编辑或 extends 链路中的文件改动后，后端会通过 websocket 广播 `config_updated`。前端订阅层只负责刷新 `/api/config` 及其派生缓存，不直接覆盖本地草稿；真正的冲突处理留在配置编辑器内部完成。
+
+配置页和 worktree environment 编辑器都遵循相同的“三份状态”模型：
+
+- `base`：开始编辑时或上次成功保存后的远端基线。
+- `draft`：用户当前正在修改的本地草稿。
+- `server`：收到 `config_updated` 后重新拉取到的最新远端值。
+
+## 不变式
+
+- 不要在 `use-session-subscription.ts` 收到 `config_updated` 后直接覆盖本地编辑状态；订阅层只能触发 revalidate。
+- 主配置编辑器按 `source + section` 做冲突判断，不要退化成整页级别的统一提示。
+- `draft === base` 且 `server !== base` 时，说明用户未改动，可直接把草稿同步到远端最新值。
+- `draft !== base` 且 `server !== base` 且 `draft !== server` 时，必须视为真实冲突：暂停自动保存并要求用户显式选择。
+- 冲突出现时，不允许静默偏向本地或远端；必须通过确认框让用户选择“保留当前编辑”或“采用外部修改”。
+- 用户选择前，该草稿的自动保存必须保持阻断状态，避免背景定时器把另一份内容写回去。
+- `ConfigView.tsx` 与 `use-worktree-environment-auto-save.ts` 的行为需要保持一致；不要只修一条编辑链路，另一条继续静默覆盖。
+- `configConflict.ts` 负责共享比较逻辑；比较时需要归一化对象 key 顺序，避免仅因字段顺序不同而误判冲突。
+
+## 修改建议
+
+- 如果需要调整冲突交互，优先保留 “先拦截自动保存，再让用户选择” 这个顺序。
+- 如果需要新增配置编辑入口，接入同样的 `base / draft / server` 语义，而不是只复用自动保存逻辑。
+- 如果需要修改 websocket 或缓存刷新逻辑，确认配置草稿仍然只在编辑器内部合并，不要把合并责任上提到订阅层。
+
+## 最低验证
+
+修改这块后，至少验证：
+
+- `pnpm exec eslint apps/client/src/components/ConfigView.tsx apps/client/src/components/config/*.ts* apps/client/src/hooks/use-session-subscription.ts apps/client/src/hooks/session-subscription-cache.ts`
+- `pnpm exec vitest run --workspace vitest.workspace.ts apps/client/__tests__/config-conflict.spec.ts apps/client/__tests__/session-subscription-cache.spec.ts`
+- 如果改动了配置表单渲染，再补 `apps/client/__tests__/config-schema-form.spec.tsx`

--- a/apps/client/src/components/config/WorktreeEnvironmentPanel.tsx
+++ b/apps/client/src/components/config/WorktreeEnvironmentPanel.tsx
@@ -21,7 +21,7 @@ const getEnvironmentSource = (environment: WorktreeEnvironmentSummary | undefine
 )
 
 export function WorktreeEnvironmentPanel({ t }: { t: TranslationFn }) {
-  const { message } = App.useApp()
+  const { message, modal } = App.useApp()
   const [sourceKey, setSourceKey] = useState<ConfigSource>('project')
   const [selectedId, setSelectedId] = useState<string>()
   const [nameDraft, setNameDraft] = useState('')
@@ -55,6 +55,7 @@ export function WorktreeEnvironmentPanel({ t }: { t: TranslationFn }) {
     draftScripts,
     environments,
     message,
+    modal,
     nameDraft,
     selectedEnvironment,
     selectedId,

--- a/apps/client/src/components/config/configConflict.ts
+++ b/apps/client/src/components/config/configConflict.ts
@@ -1,0 +1,41 @@
+import type { ConfigSource } from '@vibe-forge/core'
+
+export type ConfigRemoteChangeAction = 'none' | 'sync-remote' | 'conflict'
+
+const normalizeComparableValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeComparableValue(item))
+  }
+
+  if (value != null && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((result, key) => {
+        result[key] = normalizeComparableValue((value as Record<string, unknown>)[key])
+        return result
+      }, {})
+  }
+
+  return value
+}
+
+export const getConfigDraftKey = (sectionKey: string, source: ConfigSource) => `${source}:${sectionKey}`
+
+export const serializeComparableConfigValue = (value: unknown) => (
+  JSON.stringify(normalizeComparableValue(value ?? {}))
+)
+
+export const resolveRemoteConfigChangeAction = ({
+  baseSerialized,
+  draftSerialized,
+  serverSerialized
+}: {
+  baseSerialized?: string
+  draftSerialized?: string
+  serverSerialized: string
+}): ConfigRemoteChangeAction => {
+  if (baseSerialized == null || draftSerialized == null) return 'none'
+  if (baseSerialized === serverSerialized || draftSerialized === serverSerialized) return 'none'
+  if (draftSerialized === baseSerialized) return 'sync-remote'
+  return 'conflict'
+}

--- a/apps/client/src/components/config/use-worktree-environment-auto-save.ts
+++ b/apps/client/src/components/config/use-worktree-environment-auto-save.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- auto-save and conflict resolution share one state machine here. */
 import { useEffect, useRef } from 'react'
 
 import type { ConfigSource } from '@vibe-forge/core'
@@ -9,6 +10,7 @@ import type {
 
 import { deleteWorktreeEnvironment, getApiErrorMessage, saveWorktreeEnvironment } from '#~/api'
 
+import { resolveRemoteConfigChangeAction, serializeComparableConfigValue } from './configConflict'
 import type { TranslationFn } from './configUtils'
 import {
   buildDraftScripts,
@@ -18,10 +20,33 @@ import {
 
 const AUTO_SAVE_DELAY_MS = 800
 
-const serializeDraftScripts = (scripts: Record<WorktreeEnvironmentScriptKey, string>) => JSON.stringify(scripts)
+const serializeDraftScripts = (scripts: Record<WorktreeEnvironmentScriptKey, string>) => (
+  serializeComparableConfigValue(scripts)
+)
+
+interface SyncedEnvironmentDraft {
+  id: string
+  name: string
+  scripts: string
+}
 
 interface MessageApi {
   error: (content: string) => unknown
+}
+
+interface ModalApi {
+  confirm: (options: {
+    title: string
+    content: string
+    okText: string
+    cancelText: string
+    cancelButtonProps?: { danger?: boolean }
+    closable?: boolean
+    keyboard?: boolean
+    maskClosable?: boolean
+    onOk?: () => unknown
+    onCancel?: () => unknown
+  }) => unknown
 }
 
 export function useWorktreeEnvironmentAutoSave({
@@ -29,6 +54,7 @@ export function useWorktreeEnvironmentAutoSave({
   draftScripts,
   environments,
   message,
+  modal,
   nameDraft,
   selectedEnvironment,
   selectedId,
@@ -45,6 +71,7 @@ export function useWorktreeEnvironmentAutoSave({
   draftScripts: Record<WorktreeEnvironmentScriptKey, string>
   environments: WorktreeEnvironmentSummary[]
   message: MessageApi
+  modal: ModalApi
   nameDraft: string
   selectedEnvironment?: WorktreeEnvironmentDetail
   selectedId?: string
@@ -58,37 +85,207 @@ export function useWorktreeEnvironmentAutoSave({
   t: TranslationFn
 }) {
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout>>()
-  const syncedDraftRef = useRef<{ id: string; name: string; scripts: string }>()
+  const syncedDraftRef = useRef<SyncedEnvironmentDraft>()
+  const pendingConflictRef = useRef<{
+    remoteDraft: SyncedEnvironmentDraft
+    remoteScripts: Record<WorktreeEnvironmentScriptKey, string>
+  }>()
+  const draftStateRef = useRef<{
+    id?: string
+    name: string
+    scripts: Record<WorktreeEnvironmentScriptKey, string>
+    serializedScripts: string
+  }>({
+    id: draftEnvironmentId,
+    name: nameDraft,
+    scripts: draftScripts,
+    serializedScripts: serializeDraftScripts(draftScripts)
+  })
+  const blockedRef = useRef(false)
+  const conflictModalOpenRef = useRef(false)
+
+  const clearAutoSaveTimer = () => {
+    if (autoSaveTimerRef.current == null) return
+    clearTimeout(autoSaveTimerRef.current)
+    autoSaveTimerRef.current = undefined
+  }
+
+  const applyRemoteDraft = ({
+    remoteDraft,
+    remoteScripts
+  }: {
+    remoteDraft: SyncedEnvironmentDraft
+    remoteScripts: Record<WorktreeEnvironmentScriptKey, string>
+  }) => {
+    setDraftEnvironmentId(remoteDraft.id)
+    setDraftScripts(remoteScripts)
+    setNameDraft(remoteDraft.name)
+    syncedDraftRef.current = remoteDraft
+  }
+
+  useEffect(() => {
+    draftStateRef.current = {
+      id: draftEnvironmentId,
+      name: nameDraft,
+      scripts: draftScripts,
+      serializedScripts: serializeDraftScripts(draftScripts)
+    }
+  }, [draftEnvironmentId, draftScripts, nameDraft])
 
   useEffect(() => {
     if (selectedEnvironment == null) {
+      clearAutoSaveTimer()
       setDraftEnvironmentId(undefined)
       setDraftScripts(buildDraftScripts())
       setNameDraft('')
       syncedDraftRef.current = undefined
+      pendingConflictRef.current = undefined
+      blockedRef.current = false
+      conflictModalOpenRef.current = false
       return
     }
 
-    const scripts = buildDraftScripts(selectedEnvironment)
-    const name = toDisplayEnvironmentName(selectedEnvironment.id)
-    setDraftEnvironmentId(selectedEnvironment.id)
-    setDraftScripts(scripts)
-    setNameDraft(name)
-    syncedDraftRef.current = {
+    const remoteScripts = buildDraftScripts(selectedEnvironment)
+    const remoteDraft: SyncedEnvironmentDraft = {
       id: selectedEnvironment.id,
-      name,
-      scripts: serializeDraftScripts(scripts)
+      name: toDisplayEnvironmentName(selectedEnvironment.id),
+      scripts: serializeDraftScripts(remoteScripts)
     }
-  }, [selectedEnvironment, setDraftEnvironmentId, setDraftScripts, setNameDraft])
+    const syncedDraft = syncedDraftRef.current
+
+    if (syncedDraft == null) {
+      applyRemoteDraft({ remoteDraft, remoteScripts })
+      return
+    }
+
+    if (
+      syncedDraft.id === remoteDraft.id &&
+      syncedDraft.name === remoteDraft.name &&
+      syncedDraft.scripts === remoteDraft.scripts
+    ) {
+      return
+    }
+
+    const currentDraft = draftStateRef.current
+    const currentSerialized = serializeComparableConfigValue({
+      id: currentDraft.id ?? '',
+      name: currentDraft.name,
+      scripts: currentDraft.serializedScripts
+    })
+    const syncedSerialized = serializeComparableConfigValue({
+      ...syncedDraft
+    })
+    const remoteSerialized = serializeComparableConfigValue({
+      ...remoteDraft
+    })
+    const action = resolveRemoteConfigChangeAction({
+      baseSerialized: syncedSerialized,
+      draftSerialized: currentSerialized,
+      serverSerialized: remoteSerialized
+    })
+
+    if (action === 'sync-remote') {
+      clearAutoSaveTimer()
+      blockedRef.current = false
+      pendingConflictRef.current = undefined
+      applyRemoteDraft({ remoteDraft, remoteScripts })
+      return
+    }
+
+    if (action === 'conflict') {
+      clearAutoSaveTimer()
+      blockedRef.current = true
+      pendingConflictRef.current = { remoteDraft, remoteScripts }
+
+      if (conflictModalOpenRef.current) {
+        return
+      }
+
+      conflictModalOpenRef.current = true
+      modal.confirm({
+        title: t('config.conflict.title'),
+        content: t('config.conflict.description', {
+          source: t(`config.environments.sources.${sourceKey}`),
+          target: remoteDraft.name
+        }),
+        okText: t('config.conflict.keepLocal'),
+        cancelText: t('config.conflict.useRemote'),
+        cancelButtonProps: { danger: true },
+        closable: false,
+        keyboard: false,
+        maskClosable: false,
+        onOk: async () => {
+          const currentDraftState = draftStateRef.current
+          const currentSelectedId = currentDraftState.id ?? selectedId
+          const nextId = toEnvironmentIdForSource(currentDraftState.name, sourceKey)
+
+          if (currentSelectedId == null || nextId === '') {
+            void message.error(t('config.environments.saveFailed'))
+            throw new Error('worktree environment draft is not ready to save')
+          }
+
+          const saved = await saveEnvironmentDraft({
+            draftScripts: currentDraftState.scripts,
+            message,
+            nextId,
+            refreshDetail,
+            refreshEnvironments,
+            selectedId: currentSelectedId,
+            serializedScripts: serializeDraftScripts(currentDraftState.scripts),
+            setSelectedId,
+            sourceKey,
+            t
+          })
+
+          if (!saved) {
+            throw new Error('failed to save worktree environment draft')
+          }
+
+          blockedRef.current = false
+          pendingConflictRef.current = undefined
+          conflictModalOpenRef.current = false
+        },
+        onCancel: () => {
+          const pendingConflict = pendingConflictRef.current
+          if (pendingConflict != null) {
+            applyRemoteDraft(pendingConflict)
+          }
+          blockedRef.current = false
+          pendingConflictRef.current = undefined
+          conflictModalOpenRef.current = false
+        }
+      })
+      return
+    }
+
+    syncedDraftRef.current = remoteDraft
+    blockedRef.current = false
+    pendingConflictRef.current = undefined
+  }, [
+    message,
+    modal,
+    refreshDetail,
+    refreshEnvironments,
+    selectedEnvironment,
+    selectedId,
+    setDraftEnvironmentId,
+    setDraftScripts,
+    setNameDraft,
+    setSelectedId,
+    sourceKey,
+    t
+  ])
 
   useEffect(() => () => {
-    if (autoSaveTimerRef.current != null) {
-      clearTimeout(autoSaveTimerRef.current)
-    }
+    clearAutoSaveTimer()
   }, [])
 
   useEffect(() => {
     if (selectedId == null || draftEnvironmentId !== selectedId) return
+    if (blockedRef.current) {
+      clearAutoSaveTimer()
+      return
+    }
     const nextId = toEnvironmentIdForSource(nameDraft, sourceKey)
     if (nextId === '') return
 
@@ -107,9 +304,10 @@ export function useWorktreeEnvironmentAutoSave({
     }
 
     if (autoSaveTimerRef.current != null) {
-      clearTimeout(autoSaveTimerRef.current)
+      clearAutoSaveTimer()
     }
     autoSaveTimerRef.current = setTimeout(() => {
+      if (blockedRef.current) return
       void saveEnvironmentDraft({
         draftScripts,
         message,
@@ -125,9 +323,7 @@ export function useWorktreeEnvironmentAutoSave({
     }, AUTO_SAVE_DELAY_MS)
 
     return () => {
-      if (autoSaveTimerRef.current != null) {
-        clearTimeout(autoSaveTimerRef.current)
-      }
+      clearAutoSaveTimer()
     }
   }, [
     draftEnvironmentId,
@@ -181,8 +377,10 @@ export function useWorktreeEnvironmentAutoSave({
       if (nextId === selectedId) {
         await refreshDetail()
       }
+      return true
     } catch (error) {
       void message.error(getApiErrorMessage(error, t('config.environments.saveFailed')))
+      return false
     }
   }
 }

--- a/apps/client/src/hooks/session-subscription-cache.ts
+++ b/apps/client/src/hooks/session-subscription-cache.ts
@@ -1,0 +1,25 @@
+import type { ScopedMutator } from 'swr'
+
+const isAdapterConfigCacheKey = (key: unknown) => {
+  if (Array.isArray(key)) {
+    return key[0] === '/api/adapters'
+  }
+
+  return typeof key === 'string' && key.startsWith('/api/adapters/')
+}
+
+export const isConfigRelatedDerivedCacheKey = (key: unknown) => {
+  if (Array.isArray(key)) {
+    return key[0] === 'worktree-environment' || key[0] === '/api/adapters'
+  }
+
+  return isAdapterConfigCacheKey(key)
+}
+
+export async function revalidateConfigRelatedCaches(mutate: ScopedMutator) {
+  await Promise.all([
+    mutate('/api/config'),
+    mutate('worktree-environments'),
+    mutate(isConfigRelatedDerivedCacheKey)
+  ])
+}

--- a/apps/client/src/hooks/use-session-subscription.ts
+++ b/apps/client/src/hooks/use-session-subscription.ts
@@ -3,6 +3,7 @@ import { useSWRConfig } from 'swr'
 
 import type { Session, WSEvent } from '@vibe-forge/core'
 
+import { revalidateConfigRelatedCaches } from '#~/hooks/session-subscription-cache'
 import { createSocket } from '#~/ws.js'
 
 interface SessionListResponse {
@@ -101,16 +102,24 @@ export function useSessionSubscription() {
 
       socket = createSocket({
         onMessage: (data: WSEvent) => {
-          if (disposed || data.type !== 'session_updated') return
-          const updatedSession = data.session as SessionUpdate
+          if (disposed) return
 
-          void mutate('/api/sessions', (prev: SessionListResponse | undefined) => {
-            return mergeSessionList(prev, updatedSession, 'active')
-          }, false)
+          if (data.type === 'session_updated') {
+            const updatedSession = data.session as SessionUpdate
 
-          void mutate('/api/sessions/archived', (prev: SessionListResponse | undefined) => {
-            return mergeSessionList(prev, updatedSession, 'archived')
-          }, false)
+            void mutate('/api/sessions', (prev: SessionListResponse | undefined) => {
+              return mergeSessionList(prev, updatedSession, 'active')
+            }, false)
+
+            void mutate('/api/sessions/archived', (prev: SessionListResponse | undefined) => {
+              return mergeSessionList(prev, updatedSession, 'archived')
+            }, false)
+            return
+          }
+
+          if (data.type === 'config_updated') {
+            void revalidateConfigRelatedCaches(mutate)
+          }
         },
         onClose: () => {
           if (disposed) return

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -1138,6 +1138,13 @@
       "format": "Format",
       "copy": "Copy"
     },
+    "conflict": {
+      "title": "Configuration changed elsewhere",
+      "description": "{{source}} / {{target}} was updated outside this page while you still have unsaved edits.",
+      "instructions": "Choose which version to keep before continuing so the two copies do not overwrite each other.",
+      "keepLocal": "Keep my edits",
+      "useRemote": "Use external change"
+    },
     "editor": {
       "addField": "Add Field",
       "addItem": "Add Item",

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -1139,6 +1139,13 @@
       "format": "格式化",
       "copy": "复制"
     },
+    "conflict": {
+      "title": "配置正在被其他地方修改",
+      "description": "{{source}} / {{target}} 在当前页面之外已经发生更新，而你这里还有未保存的编辑。",
+      "instructions": "请先选择保留哪一份，再继续编辑，避免两边互相覆盖。",
+      "keepLocal": "保留当前编辑",
+      "useRemote": "采用外部修改"
+    },
     "editor": {
       "addField": "添加字段",
       "addItem": "添加项",

--- a/apps/server/__tests__/services/config-watch.spec.ts
+++ b/apps/server/__tests__/services/config-watch.spec.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { resetConfigCache } from '@vibe-forge/config'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { acquireConfigWatchRuntime } from '#~/services/config/watch.js'
+import { sessionSubscriberSockets } from '#~/services/session/runtime.js'
+
+describe('config watch runtime', () => {
+  let workspaceDir: string
+
+  beforeEach(async () => {
+    workspaceDir = await mkdtemp(path.join(tmpdir(), 'vf-config-watch-'))
+    sessionSubscriberSockets.clear()
+    resetConfigCache()
+  })
+
+  afterEach(async () => {
+    sessionSubscriberSockets.clear()
+    resetConfigCache()
+    await rm(workspaceDir, { recursive: true, force: true })
+  })
+
+  it('broadcasts config updates when a new project config file is created', async () => {
+    const subscriberSocket = {
+      readyState: 1,
+      send: vi.fn()
+    }
+    sessionSubscriberSockets.add(subscriberSocket as any)
+
+    const watcher = await acquireConfigWatchRuntime(workspaceDir)
+
+    try {
+      await writeFile(
+        path.join(workspaceDir, '.ai.config.json'),
+        '{ "general": { "interfaceLanguage": "en" } }\n',
+        'utf8'
+      )
+
+      await vi.waitFor(() => {
+        expect(subscriberSocket.send).toHaveBeenCalled()
+      }, { timeout: 3000, interval: 50 })
+
+      const payload = JSON.parse(String(subscriberSocket.send.mock.calls.at(-1)?.[0]))
+      expect(payload).toMatchObject({
+        type: 'config_updated',
+        workspaceFolder: workspaceDir
+      })
+    } finally {
+      watcher.release()
+    }
+  })
+
+  it('broadcasts config updates when an extended config file changes', async () => {
+    const baseConfigPath = path.join(workspaceDir, 'base.yaml')
+    await writeFile(
+      baseConfigPath,
+      `
+general:
+  interfaceLanguage: zh
+`,
+      'utf8'
+    )
+    await writeFile(
+      path.join(workspaceDir, '.ai.config.json'),
+      JSON.stringify(
+        {
+          extend: './base.yaml'
+        },
+        null,
+        2
+      ),
+      'utf8'
+    )
+
+    const subscriberSocket = {
+      readyState: 1,
+      send: vi.fn()
+    }
+    sessionSubscriberSockets.add(subscriberSocket as any)
+
+    const watcher = await acquireConfigWatchRuntime(workspaceDir)
+
+    try {
+      await writeFile(
+        baseConfigPath,
+        `
+general:
+  interfaceLanguage: en
+`,
+        'utf8'
+      )
+
+      await vi.waitFor(() => {
+        expect(subscriberSocket.send).toHaveBeenCalled()
+      }, { timeout: 3000, interval: 50 })
+
+      const payload = JSON.parse(String(subscriberSocket.send.mock.calls.at(-1)?.[0]))
+      expect(payload).toMatchObject({
+        type: 'config_updated',
+        workspaceFolder: workspaceDir
+      })
+    } finally {
+      watcher.release()
+    }
+  })
+})

--- a/apps/server/__tests__/services/session-runtime.spec.ts
+++ b/apps/server/__tests__/services/session-runtime.spec.ts
@@ -4,6 +4,7 @@ import {
   adapterSessionStore,
   createSessionConnectionState,
   externalSessionStore,
+  notifyConfigUpdated,
   notifySessionUpdated,
   sessionSubscriberSockets,
   takeExternalSessionRuntime
@@ -46,6 +47,21 @@ describe('notifySessionUpdated', () => {
     expect(sessionSocket.send).toHaveBeenCalledOnce()
     expect(subscriberSocket.send).toHaveBeenCalledOnce()
     expect(String(sessionSocket.send.mock.calls[0]?.[0])).toContain('"type":"session_updated"')
+  })
+
+  it('broadcasts config updates to global subscribers', () => {
+    const subscriberSocket = {
+      readyState: 1,
+      send: vi.fn()
+    }
+
+    sessionSubscriberSockets.add(subscriberSocket as any)
+
+    notifyConfigUpdated('/workspace/demo')
+
+    expect(subscriberSocket.send).toHaveBeenCalledOnce()
+    expect(String(subscriberSocket.send.mock.calls[0]?.[0])).toContain('"type":"config_updated"')
+    expect(String(subscriberSocket.send.mock.calls[0]?.[0])).toContain('"/workspace/demo"')
   })
 
   it('can promote a passive runtime into an adapter runtime', () => {

--- a/apps/server/src/services/config/watch-plan.ts
+++ b/apps/server/src/services/config/watch-plan.ts
@@ -1,0 +1,107 @@
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+
+import {
+  resolvePrimaryWorkspaceFolder,
+  resolveProjectConfigDir,
+  resolveProjectWorkspaceFolder
+} from '@vibe-forge/utils'
+
+const PROJECT_CONFIG_RELATIVE_PATHS = [
+  '.ai.config.json',
+  'infra/.ai.config.json',
+  '.ai.config.yaml',
+  'infra/.ai.config.yaml',
+  '.ai.config.yml',
+  'infra/.ai.config.yml'
+] as const
+
+const USER_CONFIG_RELATIVE_PATHS = [
+  '.ai.dev.config.json',
+  'infra/.ai.dev.config.json',
+  '.ai.dev.config.yaml',
+  'infra/.ai.dev.config.yaml',
+  '.ai.dev.config.yml',
+  'infra/.ai.dev.config.yml'
+] as const
+
+const CONFIG_INFRA_DIR = 'infra'
+
+interface ConfigWatchSourceState {
+  configPath?: string
+  resolvedExtendPaths?: string[]
+}
+
+const addRelativeTargets = (
+  targets: Set<string>,
+  cwd: string,
+  relativePaths: readonly string[]
+) => {
+  for (const relativePath of relativePaths) {
+    targets.add(resolve(cwd, relativePath))
+  }
+}
+
+const collectBaseConfigTargets = (workspaceFolder: string) => {
+  const resolvedWorkspaceFolder = resolveProjectWorkspaceFolder(workspaceFolder, process.env)
+  const configCwd = resolveProjectConfigDir(workspaceFolder, process.env) ?? resolvedWorkspaceFolder
+  const primaryWorkspaceFolder = resolvePrimaryWorkspaceFolder(resolvedWorkspaceFolder, process.env)
+  const targets = new Set<string>()
+
+  addRelativeTargets(targets, configCwd, PROJECT_CONFIG_RELATIVE_PATHS)
+  addRelativeTargets(targets, configCwd, USER_CONFIG_RELATIVE_PATHS)
+  targets.add(resolve(configCwd, CONFIG_INFRA_DIR))
+
+  if (primaryWorkspaceFolder != null && resolve(primaryWorkspaceFolder) !== resolve(configCwd)) {
+    addRelativeTargets(targets, primaryWorkspaceFolder, USER_CONFIG_RELATIVE_PATHS)
+    targets.add(resolve(primaryWorkspaceFolder, CONFIG_INFRA_DIR))
+  }
+
+  return targets
+}
+
+export const buildDirectoryTargetPlan = (targets: Iterable<string>) => {
+  const plan = new Map<string, Set<string>>()
+
+  for (const target of targets) {
+    const targetPath = resolve(target)
+    const dir = dirname(targetPath)
+    const entry = plan.get(dir)
+    if (entry == null) {
+      plan.set(dir, new Set([targetPath]))
+      continue
+    }
+    entry.add(targetPath)
+  }
+
+  return plan
+}
+
+export const buildBaseConfigWatchPlan = (workspaceFolder: string) => (
+  buildDirectoryTargetPlan(collectBaseConfigTargets(workspaceFolder))
+)
+
+export const buildConfigWatchPlan = (
+  workspaceFolder: string,
+  sources: {
+    projectSource?: ConfigWatchSourceState
+    userSource?: ConfigWatchSourceState
+  }
+) => {
+  const targets = collectBaseConfigTargets(workspaceFolder)
+
+  for (
+    const target of [
+      sources.projectSource?.configPath,
+      sources.userSource?.configPath,
+      ...(sources.projectSource?.resolvedExtendPaths ?? []),
+      ...(sources.userSource?.resolvedExtendPaths ?? [])
+    ]
+  ) {
+    if (target != null && target !== '') {
+      targets.add(resolve(target))
+    }
+  }
+
+  return buildDirectoryTargetPlan(targets)
+}

--- a/apps/server/src/services/config/watch.ts
+++ b/apps/server/src/services/config/watch.ts
@@ -1,0 +1,212 @@
+/* eslint-disable max-lines -- config watcher keeps debounce, invalidation, and ref-counted lifecycle together. */
+import type { Buffer } from 'node:buffer'
+import { existsSync, statSync, watch } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { resetConfigCache } from '@vibe-forge/config'
+
+import { notifyConfigUpdated } from '#~/services/session/runtime.js'
+import { logger } from '#~/utils/logger.js'
+
+import { getWorkspaceFolder, loadConfigState } from './index.js'
+import { buildBaseConfigWatchPlan, buildConfigWatchPlan } from './watch-plan.js'
+const CONFIG_REFRESH_DEBOUNCE_MS = 120
+
+interface DirectoryWatchEntry {
+  controller: AbortController
+  targets: Set<string>
+}
+
+interface ConfigWatchRuntime {
+  workspaceFolder: string
+  directoryWatches: Map<string, DirectoryWatchEntry>
+  disposed: boolean
+  refreshInFlight: boolean
+  pendingRefresh: boolean
+  refreshTimer?: NodeJS.Timeout
+}
+
+interface ConfigWatchRegistryEntry {
+  refCount: number
+  runtime: ConfigWatchRuntime
+}
+
+const configWatchRegistry = new Map<string, ConfigWatchRegistryEntry>()
+
+const isDirectory = (value: string) => {
+  try {
+    return existsSync(value) && statSync(value).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+const shouldHandleDirectoryEvent = (
+  dir: string,
+  targets: Set<string>,
+  filename: string | Buffer | null | undefined
+) => {
+  if (filename == null) return true
+  return targets.has(resolve(dir, String(filename)))
+}
+
+const stopConfigWatchRuntime = (runtime: ConfigWatchRuntime) => {
+  runtime.disposed = true
+  if (runtime.refreshTimer != null) {
+    clearTimeout(runtime.refreshTimer)
+    runtime.refreshTimer = undefined
+  }
+
+  for (const entry of runtime.directoryWatches.values()) {
+    entry.controller.abort()
+  }
+  runtime.directoryWatches.clear()
+}
+
+const syncDirectoryWatches = (
+  runtime: ConfigWatchRuntime,
+  plan: Map<string, Set<string>>
+) => {
+  for (const [dir, watchEntry] of runtime.directoryWatches.entries()) {
+    if (!plan.has(dir) || !isDirectory(dir)) {
+      watchEntry.controller.abort()
+      runtime.directoryWatches.delete(dir)
+    }
+  }
+
+  for (const [dir, targets] of plan.entries()) {
+    if (!isDirectory(dir)) continue
+
+    const existing = runtime.directoryWatches.get(dir)
+    if (existing != null) {
+      existing.targets = targets
+      continue
+    }
+
+    const controller = new AbortController()
+    const watchEntry: DirectoryWatchEntry = {
+      controller,
+      targets
+    }
+    const watcher = watch(
+      dir,
+      { signal: controller.signal },
+      (_eventType, filename) => {
+        if (runtime.disposed) return
+        if (!shouldHandleDirectoryEvent(dir, watchEntry.targets, filename)) {
+          return
+        }
+        scheduleConfigWatchRefresh(runtime)
+      }
+    )
+    controller.signal.addEventListener('abort', () => {
+      watcher.close()
+    }, { once: true })
+    runtime.directoryWatches.set(dir, watchEntry)
+  }
+}
+
+const refreshConfigWatchRuntime = async (
+  runtime: ConfigWatchRuntime,
+  options: { broadcast: boolean }
+) => {
+  if (runtime.disposed) return
+
+  if (runtime.refreshInFlight) {
+    runtime.pendingRefresh = runtime.pendingRefresh || options.broadcast
+    return
+  }
+
+  runtime.refreshInFlight = true
+
+  try {
+    resetConfigCache()
+    const state = await loadConfigState(runtime.workspaceFolder)
+    const plan = buildConfigWatchPlan(runtime.workspaceFolder, state)
+    syncDirectoryWatches(runtime, plan)
+
+    if (options.broadcast) {
+      logger.info(
+        { workspaceFolder: runtime.workspaceFolder },
+        '[config] Detected config file change; reloading config cache'
+      )
+      notifyConfigUpdated(runtime.workspaceFolder)
+    }
+  } catch (error) {
+    resetConfigCache()
+    syncDirectoryWatches(runtime, buildBaseConfigWatchPlan(runtime.workspaceFolder))
+    logger.warn({
+      workspaceFolder: runtime.workspaceFolder,
+      error: error instanceof Error ? error.message : String(error)
+    }, '[config] Failed to refresh config watch targets after filesystem change')
+
+    if (options.broadcast) {
+      notifyConfigUpdated(runtime.workspaceFolder)
+    }
+  } finally {
+    runtime.refreshInFlight = false
+
+    if (runtime.pendingRefresh) {
+      runtime.pendingRefresh = false
+      void refreshConfigWatchRuntime(runtime, { broadcast: true })
+    }
+  }
+}
+
+const scheduleConfigWatchRefresh = (runtime: ConfigWatchRuntime) => {
+  if (runtime.disposed) return
+
+  if (runtime.refreshTimer != null) {
+    clearTimeout(runtime.refreshTimer)
+  }
+
+  runtime.refreshTimer = setTimeout(() => {
+    runtime.refreshTimer = undefined
+    void refreshConfigWatchRuntime(runtime, { broadcast: true })
+  }, CONFIG_REFRESH_DEBOUNCE_MS)
+}
+
+const createConfigWatchRuntime = async (workspaceFolder: string): Promise<ConfigWatchRuntime> => {
+  const runtime: ConfigWatchRuntime = {
+    workspaceFolder,
+    directoryWatches: new Map(),
+    disposed: false,
+    refreshInFlight: false,
+    pendingRefresh: false
+  }
+
+  await refreshConfigWatchRuntime(runtime, { broadcast: false })
+  return runtime
+}
+
+export async function acquireConfigWatchRuntime(workspaceFolder = getWorkspaceFolder()) {
+  const resolvedWorkspaceFolder = resolve(workspaceFolder)
+  let registryEntry = configWatchRegistry.get(resolvedWorkspaceFolder)
+
+  if (registryEntry == null) {
+    registryEntry = {
+      refCount: 0,
+      runtime: await createConfigWatchRuntime(resolvedWorkspaceFolder)
+    }
+    configWatchRegistry.set(resolvedWorkspaceFolder, registryEntry)
+  }
+
+  registryEntry.refCount += 1
+
+  let released = false
+  return {
+    release() {
+      if (released) return
+      released = true
+
+      const current = configWatchRegistry.get(resolvedWorkspaceFolder)
+      if (current == null) return
+
+      current.refCount -= 1
+      if (current.refCount > 0) return
+
+      stopConfigWatchRuntime(current.runtime)
+      configWatchRegistry.delete(resolvedWorkspaceFolder)
+    }
+  }
+}

--- a/apps/server/src/services/session/runtime.ts
+++ b/apps/server/src/services/session/runtime.ts
@@ -50,6 +50,15 @@ export const externalSessionStore = new Map<string, SessionConnectionState>()
 export const sessionSubscriberSockets = new Set<WebSocket>()
 export const pendingSessionInteractionStore = new Map<string, PendingSessionInteraction>()
 
+const sendEventToSockets = (sockets: Iterable<WebSocket>, event: WSEvent) => {
+  const payload = safeJsonStringify(event)
+  for (const socket of sockets) {
+    if (socket.readyState === WebSocketImpl.OPEN) {
+      socket.send(payload)
+    }
+  }
+}
+
 export function createSessionConnectionState(): SessionConnectionState {
   return {
     sockets: new Set<WebSocket>(),
@@ -145,12 +154,7 @@ export function emitRuntimeEvent(
     runtime.messages.push(event)
   }
 
-  const payload = safeJsonStringify(event)
-  for (const socket of runtime.sockets) {
-    if (socket.readyState === WebSocketImpl.OPEN) {
-      socket.send(payload)
-    }
-  }
+  sendEventToSockets(runtime.sockets, event)
 }
 
 export function broadcastSessionEvent(sessionId: string, event: WSEvent) {
@@ -167,20 +171,18 @@ export function broadcastSessionEvent(sessionId: string, event: WSEvent) {
 
 export function notifySessionUpdated(sessionId: string, session: Session | { id: string; isDeleted: boolean }) {
   const event: WSEvent = { type: 'session_updated', session }
-  const payload = safeJsonStringify(event)
   const runtime = getSessionConnectionState(sessionId)
 
-  for (const socket of runtime?.sockets ?? []) {
-    if (socket.readyState === WebSocketImpl.OPEN) {
-      socket.send(payload)
-    }
-  }
+  sendEventToSockets(runtime?.sockets ?? [], event)
+  sendEventToSockets(sessionSubscriberSockets, event)
+}
 
-  for (const socket of sessionSubscriberSockets) {
-    if (socket.readyState === WebSocketImpl.OPEN) {
-      socket.send(payload)
-    }
-  }
+export function notifyConfigUpdated(workspaceFolder: string) {
+  sendEventToSockets(sessionSubscriberSockets, {
+    type: 'config_updated',
+    workspaceFolder,
+    updatedAt: Date.now()
+  })
 }
 
 export function addSessionSubscriberSocket(socket: WebSocket) {

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -6,6 +6,7 @@ import Koa from 'koa'
 import { loadEnv } from '@vibe-forge/core'
 
 import { loadConfigState } from '#~/services/config/index.js'
+import { acquireConfigWatchRuntime } from '#~/services/config/watch.js'
 
 import { initChannels } from './channels'
 import { initMiddlewares } from './middlewares'
@@ -87,40 +88,50 @@ export async function startServer(options: StartServerOptions = {}): Promise<Ser
   const runtime = await createServerRuntime()
   const { app, env, server, configs } = runtime
   const entryKind = resolveEntryKind(options)
+  const configWatch = await acquireConfigWatchRuntime()
 
-  await initMiddlewares(app, env)
-  const { onListen: mountRoutesOnListen } = await mountRoutes(app, env, {
-    logClientMount: entryKind !== 'web'
-  })
-  setupWebSocket(server, env)
-  await initChannels(configs)
-
-  const {
-    __VF_PROJECT_AI_SERVER_HOST__: serverHost,
-    __VF_PROJECT_AI_SERVER_PORT__: serverPort,
-    __VF_PROJECT_AI_SERVER_WS_PATH__: serverWSPath
-  } = env
-
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject)
-    server.listen(serverPort, serverHost, () => {
-      server.off('error', reject)
-
-      const displayBaseUrl = resolveDisplayBaseUrl(env)
-      if (entryKind === 'web') {
-        logger.info(
-          `[web] ready at ${displayBaseUrl}${normalizeClientBase(env.__VF_PROJECT_AI_CLIENT_BASE__, '/')}`
-        )
-      } else {
-        const host = `${serverHost}:${serverPort}`
-        logger.info(`[server] listening on http://${host}`)
-        logger.info(`[server]              ws://${host}${serverWSPath}`)
-      }
-
-      mountRoutesOnListen(displayBaseUrl)
-      resolve()
+  try {
+    await initMiddlewares(app, env)
+    const { onListen: mountRoutesOnListen } = await mountRoutes(app, env, {
+      logClientMount: entryKind !== 'web'
     })
-  })
+    setupWebSocket(server, env)
+    await initChannels(configs)
 
-  return runtime
+    const {
+      __VF_PROJECT_AI_SERVER_HOST__: serverHost,
+      __VF_PROJECT_AI_SERVER_PORT__: serverPort,
+      __VF_PROJECT_AI_SERVER_WS_PATH__: serverWSPath
+    } = env
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(serverPort, serverHost, () => {
+        server.off('error', reject)
+
+        const displayBaseUrl = resolveDisplayBaseUrl(env)
+        if (entryKind === 'web') {
+          logger.info(
+            `[web] ready at ${displayBaseUrl}${normalizeClientBase(env.__VF_PROJECT_AI_CLIENT_BASE__, '/')}`
+          )
+        } else {
+          const host = `${serverHost}:${serverPort}`
+          logger.info(`[server] listening on http://${host}`)
+          logger.info(`[server]              ws://${host}${serverWSPath}`)
+        }
+
+        mountRoutesOnListen(displayBaseUrl)
+        resolve()
+      })
+    })
+
+    server.once('close', () => {
+      configWatch.release()
+    })
+
+    return runtime
+  } catch (error) {
+    configWatch.release()
+    throw error
+  }
 }

--- a/packages/config/__tests__/load.spec.ts
+++ b/packages/config/__tests__/load.spec.ts
@@ -246,6 +246,7 @@ notifications:
 
       expect(state.projectSource?.configPath).toBe(path.join(tempDir, '.ai.config.json'))
       expect(state.projectSource?.extendPaths).toEqual(['./base.yaml'])
+      expect(state.projectSource?.resolvedExtendPaths).toEqual([path.join(tempDir, 'base.yaml')])
       expect(state.projectSource?.rawConfig?.permissions?.allow).toEqual(['Edit'])
       expect(state.projectSource?.resolvedConfig?.permissions?.allow).toEqual(['Read', 'Edit'])
       expect(state.projectSource?.rawConfig?.notifications?.events?.completed).toEqual({

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -27,6 +27,7 @@ export interface ConfigSourceState {
   resolvedConfig?: Config
   configPath?: string
   extendPaths: string[]
+  resolvedExtendPaths: string[]
 }
 
 export interface ResolvedConfigState {
@@ -345,7 +346,9 @@ const loadResolvedConfigFileState = async (
   configPath: string,
   jsonVariables: Record<string, string | null | undefined>,
   loadingStack: Set<string>
-): Promise<Required<Pick<ConfigSourceState, 'rawConfig' | 'resolvedConfig' | 'extendPaths'>>> => {
+): Promise<
+  Required<Pick<ConfigSourceState, 'rawConfig' | 'resolvedConfig' | 'extendPaths' | 'resolvedExtendPaths'>>
+> => {
   if (loadingStack.has(configPath)) {
     throw new Error(`Circular config extend detected: ${
       [
@@ -368,6 +371,7 @@ const loadResolvedConfigFileState = async (
   nextLoadingStack.add(configPath)
 
   let mergedExtendedConfig: Config | undefined
+  const resolvedExtendPaths: string[] = []
   for (const extendPath of toExtendPaths(rawConfig.extend)) {
     const extendedConfigPath = resolveExistingExtendPath(configPath, extendPath)
     if (extendedConfigPath == null) {
@@ -380,6 +384,14 @@ const loadResolvedConfigFileState = async (
       nextLoadingStack
     )
     mergedExtendedConfig = mergeConfigs(mergedExtendedConfig, extendedConfig.resolvedConfig)
+    if (!resolvedExtendPaths.includes(extendedConfigPath)) {
+      resolvedExtendPaths.push(extendedConfigPath)
+    }
+    for (const nestedExtendPath of extendedConfig.resolvedExtendPaths) {
+      if (!resolvedExtendPaths.includes(nestedExtendPath)) {
+        resolvedExtendPaths.push(nestedExtendPath)
+      }
+    }
   }
 
   const rawEntryConfig = omitExtendField(rawConfig)
@@ -390,7 +402,8 @@ const loadResolvedConfigFileState = async (
       mergedExtendedConfig,
       rawEntryConfig
     ) ?? rawEntryConfig,
-    extendPaths: toExtendPaths(rawConfig.extend)
+    extendPaths: toExtendPaths(rawConfig.extend),
+    resolvedExtendPaths
   }
 }
 

--- a/packages/types/src/websocket.ts
+++ b/packages/types/src/websocket.ts
@@ -15,6 +15,7 @@ export type WSEvent<
   | { type: 'adapter_result'; result: any; usage?: any }
   | { type: 'adapter_event'; data: any }
   | { type: 'session_updated'; session: TSession }
+  | { type: 'config_updated'; workspaceFolder: string; updatedAt: number }
   | { type: 'session_queue_updated'; queue: SessionMessageQueueState }
   | { type: 'interaction_request'; id: string; payload: TInteractionPayload }
   | { type: 'interaction_response'; id: string; data: string | string[] }


### PR DESCRIPTION
## Summary
- watch workspace config files and extended config sources, then broadcast `config_updated` when they change
- revalidate config-related client caches and guard config/worktree environment editors with explicit conflict prompts
- document the conflict-handling invariants in the client AGENTS guidance

## Testing
- pnpm exec eslint apps/server/__tests__/services/config-watch.spec.ts apps/server/src/services/config/watch.ts apps/server/src/services/config/watch-plan.ts apps/client/src/hooks/use-session-subscription.ts apps/client/src/hooks/session-subscription-cache.ts apps/client/src/components/ConfigView.tsx apps/client/src/components/config/WorktreeEnvironmentPanel.tsx apps/client/src/components/config/use-worktree-environment-auto-save.ts apps/client/src/components/config/configConflict.ts apps/client/__tests__/config-conflict.spec.ts apps/client/__tests__/session-subscription-cache.spec.ts apps/server/src/services/session/runtime.ts apps/server/src/start-server.ts apps/server/__tests__/services/session-runtime.spec.ts packages/config/src/load.ts packages/config/__tests__/load.spec.ts packages/types/src/websocket.ts
- pnpm exec vitest run --workspace vitest.workspace.ts apps/server/__tests__/services/config-watch.spec.ts apps/server/__tests__/services/session-runtime.spec.ts apps/client/__tests__/session-subscription-cache.spec.ts apps/client/__tests__/config-conflict.spec.ts apps/client/__tests__/config-schema-form.spec.tsx
- pnpm exec vitest run --workspace vitest.workspace.ts packages/config/__tests__/load.spec.ts -t "exposes raw and resolved source config state for extended configs"
- pnpm exec tsc -b --pretty false 2>&1 | rg 'apps/server/__tests__/services/config-watch.spec.ts|apps/client/src/hooks/use-session-subscription.ts|apps/client/src/hooks/session-subscription-cache.ts|apps/client/src/components/ConfigView.tsx|apps/client/src/components/config/WorktreeEnvironmentPanel.tsx|apps/client/src/components/config/use-worktree-environment-auto-save.ts|apps/client/src/components/config/configConflict.ts|apps/server/src/services/config/watch.ts|apps/server/src/services/config/watch-plan.ts|apps/server/src/start-server.ts|packages/config/src/load.ts|packages/types/src/websocket.ts|apps/client/__tests__/config-conflict.spec.ts' || true
