### PR TITLE
fix(bootstrap): refine launch diagnostics

### DIFF
--- a/apps/bootstrap/__tests__/cli.spec.ts
+++ b/apps/bootstrap/__tests__/cli.spec.ts
@@ -117,4 +117,48 @@ describe('bootstrap cli', () => {
       forwardedArgs: ['--help']
     })
   })
+
+  it('strips --debug before forwarding and enables bootstrap debug mode', async () => {
+    const launchDesktopApp = vi.fn(async () => {})
+    const launchInstalledPackage = vi.fn(async () => 0)
+    const cli = createBootstrapCli({
+      launchDesktopApp,
+      launchInstalledPackage
+    })
+    const originalDebug = process.env.VF_BOOTSTRAP_DEBUG
+
+    delete process.env.VF_BOOTSTRAP_DEBUG
+    await cli.parseAsync(['node', 'vibe-forge-bootstrap', 'web', '--debug', '--help'])
+
+    expect(launchInstalledPackage).toHaveBeenCalledWith({
+      packageName: '@vibe-forge/web',
+      commandName: 'vibe-forge-web',
+      forwardedArgs: ['--help']
+    })
+    expect(process.env.VF_BOOTSTRAP_DEBUG).toBe('1')
+
+    if (originalDebug == null) {
+      delete process.env.VF_BOOTSTRAP_DEBUG
+    } else {
+      process.env.VF_BOOTSTRAP_DEBUG = originalDebug
+    }
+  })
+
+  it('prints app help without launching the desktop app', async () => {
+    const launchDesktopApp = vi.fn(async () => {})
+    const launchInstalledPackage = vi.fn(async () => 0)
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    const cli = createBootstrapCli({
+      launchDesktopApp,
+      launchInstalledPackage
+    })
+
+    await cli.parseAsync(['node', 'vibe-forge-bootstrap', 'app', '--help'])
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: vibe-forge-bootstrap app'))
+    expect(launchDesktopApp).not.toHaveBeenCalled()
+    expect(launchInstalledPackage).not.toHaveBeenCalled()
+
+    writeSpy.mockRestore()
+  })
 })

--- a/apps/bootstrap/__tests__/desktop-release.spec.ts
+++ b/apps/bootstrap/__tests__/desktop-release.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { toDesktopRelease } from '../src/desktop-release'
+
+describe('desktop release metadata', () => {
+  it('normalizes GitHub snake_case release fields', () => {
+    const release = toDesktopRelease({
+      assets: [
+        {
+          browser_download_url: 'https://example.com/vibe-forge.zip',
+          name: 'vibe-forge-0.1.7-mac-arm64.zip',
+          url: 'https://api.github.com/assets/1'
+        }
+      ],
+      tag_name: 'desktop-v0.1.7'
+    })
+
+    expect(release.tagName).toBe('desktop-v0.1.7')
+    expect(release.assets[0]?.browser_download_url).toBe('https://example.com/vibe-forge.zip')
+  })
+})

--- a/apps/bootstrap/__tests__/package-launcher.spec.ts
+++ b/apps/bootstrap/__tests__/package-launcher.spec.ts
@@ -1,0 +1,137 @@
+import process from 'node:process'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const resolveInstalledPackageBin = vi.fn()
+const resolvePublishedPackageVersion = vi.fn()
+const installPublishedPackage = vi.fn()
+const resolvePackageBinEntrypoint = vi.fn()
+const runNodeEntrypoint = vi.fn()
+
+vi.mock('../src/installed-package', () => ({
+  resolveInstalledPackageBin
+}))
+
+vi.mock('../src/npm-package', () => ({
+  installPublishedPackage,
+  resolvePackageBinEntrypoint,
+  resolvePublishedPackageVersion
+}))
+
+vi.mock('../src/process-utils', () => ({
+  runNodeEntrypoint
+}))
+
+const { launchInstalledPackage } = await import('../src/package-launcher')
+
+const originalLookupBase = process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE
+const originalDebug = process.env.VF_BOOTSTRAP_DEBUG
+
+afterEach(() => {
+  vi.clearAllMocks()
+
+  if (originalLookupBase == null) {
+    delete process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE
+  } else {
+    process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE = originalLookupBase
+  }
+
+  if (originalDebug == null) {
+    delete process.env.VF_BOOTSTRAP_DEBUG
+  } else {
+    process.env.VF_BOOTSTRAP_DEBUG = originalDebug
+  }
+})
+
+describe('package launcher', () => {
+  it('does not print bootstrap source logs by default', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE = '/tmp/harness'
+    resolveInstalledPackageBin.mockReturnValue('/tmp/harness/node_modules/.bin/vibe-forge-web')
+    runNodeEntrypoint.mockResolvedValue(0)
+
+    await launchInstalledPackage({
+      packageName: '@vibe-forge/web',
+      commandName: 'vibe-forge-web',
+      forwardedArgs: ['--help']
+    })
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('prints bootstrap source logs when debug is enabled', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.env.VF_BOOTSTRAP_DEBUG = '1'
+    process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE = '/tmp/harness'
+    resolveInstalledPackageBin.mockReturnValue('/tmp/harness/node_modules/.bin/vibe-forge-web')
+    runNodeEntrypoint.mockResolvedValue(0)
+
+    await launchInstalledPackage({
+      packageName: '@vibe-forge/web',
+      commandName: 'vibe-forge-web',
+      forwardedArgs: ['--help']
+    })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[bootstrap] using installed @vibe-forge/web from /tmp/harness'
+    )
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('prefers a locally installed package when lookup base is configured', async () => {
+    process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE = '/tmp/harness'
+    resolveInstalledPackageBin.mockReturnValue('/tmp/harness/node_modules/.bin/vibe-forge-web')
+    runNodeEntrypoint.mockResolvedValue(0)
+
+    const exitCode = await launchInstalledPackage({
+      packageName: '@vibe-forge/web',
+      commandName: 'vibe-forge-web',
+      forwardedArgs: ['--help']
+    })
+
+    expect(resolveInstalledPackageBin).toHaveBeenCalledWith(
+      '@vibe-forge/web',
+      '/tmp/harness',
+      'vibe-forge-web'
+    )
+    expect(runNodeEntrypoint).toHaveBeenCalledWith(
+      '/tmp/harness/node_modules/.bin/vibe-forge-web',
+      ['--help']
+    )
+    expect(resolvePublishedPackageVersion).not.toHaveBeenCalled()
+    expect(exitCode).toBe(0)
+  })
+
+  it('falls back to the published package flow when local resolution fails', async () => {
+    process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE = '/tmp/harness'
+    resolveInstalledPackageBin.mockImplementation(() => {
+      throw new Error('missing local install')
+    })
+    resolvePublishedPackageVersion.mockResolvedValue('2.0.0')
+    installPublishedPackage.mockResolvedValue({
+      packageDir: '/tmp/bootstrap-cache/node_modules/@vibe-forge/cli',
+      version: '2.0.0'
+    })
+    resolvePackageBinEntrypoint.mockResolvedValue('/tmp/bootstrap-cache/node_modules/@vibe-forge/cli/cli.js')
+    runNodeEntrypoint.mockResolvedValue(0)
+
+    const exitCode = await launchInstalledPackage({
+      packageName: '@vibe-forge/cli',
+      commandName: 'vibe-forge',
+      forwardedArgs: ['run', 'hi']
+    })
+
+    expect(resolvePublishedPackageVersion).toHaveBeenCalledWith('@vibe-forge/cli')
+    expect(installPublishedPackage).toHaveBeenCalledWith('@vibe-forge/cli', '2.0.0')
+    expect(resolvePackageBinEntrypoint).toHaveBeenCalledWith(
+      '/tmp/bootstrap-cache/node_modules/@vibe-forge/cli',
+      'vibe-forge'
+    )
+    expect(runNodeEntrypoint).toHaveBeenCalledWith(
+      '/tmp/bootstrap-cache/node_modules/@vibe-forge/cli/cli.js',
+      ['run', 'hi']
+    )
+    expect(exitCode).toBe(0)
+  })
+})

--- a/apps/bootstrap/package.json
+++ b/apps/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/bootstrap",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Vibe Forge bootstrap launcher",
   "vibeForge": {
     "runtimeTranspile": true

--- a/apps/bootstrap/src/bootstrap-flags.ts
+++ b/apps/bootstrap/src/bootstrap-flags.ts
@@ -1,0 +1,42 @@
+export const APP_HELP_TEXT = `Usage: vibe-forge-bootstrap app [cache] [--no-cache]
+
+Launch the Vibe Forge desktop app.
+
+Options:
+  cache       Force launch from the bootstrap cache and remember the choice
+  --no-cache  Force launch from the user install location and remember the choice
+  --debug     Print bootstrap routing and launch details
+  -h, --help  Show app help
+`
+
+export const BOOTSTRAP_HELP_TEXT = `
+Top-level flags:
+  --help, -h     Show bootstrap help
+  --debug        Print bootstrap routing and launch details
+  --version, -V  Print bootstrap version
+
+Examples:
+  npx @vibe-forge/bootstrap run "summarize the repo"
+  npx @vibe-forge/bootstrap web --port 8787
+  npx @vibe-forge/bootstrap server --host 0.0.0.0 --allow-cors
+  npx @vibe-forge/bootstrap app
+  npx @vibe-forge/bootstrap app cache
+  npx @vibe-forge/bootstrap app --no-cache
+`
+
+export const extractBootstrapFlags = (args: string[]) => {
+  let debug = false
+  const forwardedArgs = args.filter((arg) => {
+    if (arg !== '--debug') {
+      return true
+    }
+
+    debug = true
+    return false
+  })
+
+  return {
+    debug,
+    forwardedArgs
+  }
+}

--- a/apps/bootstrap/src/debug.ts
+++ b/apps/bootstrap/src/debug.ts
@@ -1,0 +1,26 @@
+import process from 'node:process'
+
+export const BOOTSTRAP_DEBUG_ENV_NAME = 'VF_BOOTSTRAP_DEBUG'
+
+const isTruthyDebugValue = (value: string | undefined) => {
+  if (value == null) {
+    return false
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+export const isBootstrapDebugEnabled = (
+  env: NodeJS.ProcessEnv = process.env
+) => isTruthyDebugValue(env[BOOTSTRAP_DEBUG_ENV_NAME])
+
+export const logBootstrapDebug = (
+  message: string,
+  env: NodeJS.ProcessEnv = process.env
+) => {
+  if (!isBootstrapDebugEnabled(env)) {
+    return
+  }
+
+  console.error(message)
+}

--- a/apps/bootstrap/src/desktop-app.ts
+++ b/apps/bootstrap/src/desktop-app.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 
+import { logBootstrapDebug } from './debug'
 import { ensureDesktopInstall } from './desktop-install'
 import type { DesktopInstallMode } from './desktop-mode'
 import { readDesktopPreference, resolveInstallMode } from './desktop-mode'
@@ -21,7 +22,7 @@ export const launchDesktopApp = async (options: LaunchDesktopAppOptions) => {
   })
   const install = await ensureDesktopInstall(installMode)
   const workspaceFolder = process.cwd()
-  console.error(`[bootstrap] launching desktop app from ${install.installedPath} (${installMode})`)
+  logBootstrapDebug(`[bootstrap] launching desktop app from ${install.installedPath} (${installMode})`)
 
   const child = spawn(install.executablePath, options.forwardedArgs, {
     cwd: workspaceFolder,

--- a/apps/bootstrap/src/desktop-release.ts
+++ b/apps/bootstrap/src/desktop-release.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import process from 'node:process'
 
 interface GitHubReleaseAsset {
+  browser_download_url?: string
   digest?: string
   name: string
   url: string
@@ -14,6 +15,7 @@ interface GitHubReleaseAsset {
 
 interface GitHubReleaseResponse {
   assets?: GitHubReleaseAsset[]
+  tag_name?: string
   tagName?: string
 }
 
@@ -60,18 +62,24 @@ const requestJson = async <T>(url: string) => (
   })
 )
 
+export const toDesktopRelease = (release: GitHubReleaseResponse): DesktopRelease => {
+  const tagName = release.tagName ?? release.tag_name
+  if (!tagName || !Array.isArray(release.assets)) {
+    throw new Error('Invalid desktop release metadata returned by GitHub.')
+  }
+
+  return {
+    assets: release.assets,
+    tagName
+  }
+}
+
 export const fetchDesktopRelease = async (): Promise<DesktopRelease> => {
   const url = RELEASE_TAG_OVERRIDE
     ? `${GITHUB_RELEASES_API}/tags/${encodeURIComponent(RELEASE_TAG_OVERRIDE)}`
     : `${GITHUB_RELEASES_API}/latest`
   const release = await requestJson<GitHubReleaseResponse>(url)
-  if (!release.tagName || !Array.isArray(release.assets)) {
-    throw new Error('Invalid desktop release metadata returned by GitHub.')
-  }
-  return {
-    assets: release.assets,
-    tagName: release.tagName
-  }
+  return toDesktopRelease(release)
 }
 
 export const selectDesktopAsset = (release: DesktopRelease, runtime: {
@@ -96,13 +104,18 @@ export const selectDesktopAsset = (release: DesktopRelease, runtime: {
 
 export const downloadReleaseAsset = async (asset: GitHubReleaseAsset, destinationPath: string) => {
   await ensureDirectory(path.dirname(destinationPath))
+  const downloadUrl = asset.browser_download_url ?? asset.url
+  if (!downloadUrl) {
+    throw new Error(`Missing download URL for desktop asset ${asset.name}.`)
+  }
 
   return await new Promise<void>((resolve, reject) => {
     const hash = createHash('sha256')
     const file = createWriteStream(destinationPath)
 
-    const request = https.get(asset.url, {
+    const request = https.get(downloadUrl, {
       headers: {
+        Accept: 'application/octet-stream',
         'User-Agent': 'vibe-forge-bootstrap'
       }
     }, (response) => {
@@ -114,7 +127,8 @@ export const downloadReleaseAsset = async (asset: GitHubReleaseAsset, destinatio
         void unlink(destinationPath).catch(() => {})
         downloadReleaseAsset({
           ...asset,
-          url: new URL(redirectLocation, asset.url).toString()
+          browser_download_url: new URL(redirectLocation, downloadUrl).toString(),
+          url: new URL(redirectLocation, downloadUrl).toString()
         }, destinationPath).then(resolve, reject)
         return
       }

--- a/apps/bootstrap/src/installed-package.ts
+++ b/apps/bootstrap/src/installed-package.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+
+interface PackageJsonWithBin {
+  bin?: string | Record<string, string>
+}
+
+const requireFromInstalledPackage = createRequire(import.meta.url)
+
+export const resolveInstalledPackageBin = (
+  packageName: string,
+  lookupBase: string,
+  binName?: string
+) => {
+  const packageJsonPath = requireFromInstalledPackage.resolve(
+    `${packageName}/package.json`,
+    {
+      paths: [lookupBase]
+    }
+  )
+  const packageJson = requireFromInstalledPackage(packageJsonPath) as PackageJsonWithBin
+  const { bin } = packageJson
+  const binPath = typeof bin === 'string'
+    ? bin
+    : (
+        typeof binName === 'string'
+          ? bin?.[binName]
+          : Object.values(bin ?? {}).find(
+              (value): value is string => typeof value === 'string'
+            )
+      )
+
+  if (typeof binPath !== 'string') {
+    throw new TypeError(
+      `Cannot resolve installed bin for package "${packageName}".`
+    )
+  }
+
+  return resolve(dirname(packageJsonPath), binPath)
+}

--- a/apps/bootstrap/src/package-launcher.ts
+++ b/apps/bootstrap/src/package-launcher.ts
@@ -1,3 +1,7 @@
+import process from 'node:process'
+
+import { logBootstrapDebug } from './debug'
+import { resolveInstalledPackageBin } from './installed-package'
 import { installPublishedPackage, resolvePackageBinEntrypoint, resolvePublishedPackageVersion } from './npm-package'
 import { runNodeEntrypoint } from './process-utils'
 
@@ -7,9 +11,29 @@ export interface LaunchInstalledPackageOptions {
   packageName: string
 }
 
+const resolveLookupBase = () => {
+  const value = process.env.VF_BOOTSTRAP_PACKAGE_LOOKUP_BASE?.trim()
+  return value === '' ? undefined : value
+}
+
 export const launchInstalledPackage = async (input: LaunchInstalledPackageOptions) => {
+  const lookupBase = resolveLookupBase()
+  if (lookupBase != null) {
+    try {
+      const localEntryPath = resolveInstalledPackageBin(
+        input.packageName,
+        lookupBase,
+        input.commandName
+      )
+      logBootstrapDebug(`[bootstrap] using installed ${input.packageName} from ${lookupBase}`)
+      return await runNodeEntrypoint(localEntryPath, input.forwardedArgs)
+    } catch {
+      // Fall through to the published package cache path.
+    }
+  }
+
   const version = await resolvePublishedPackageVersion(input.packageName)
-  console.error(`[bootstrap] using ${input.packageName}@${version}`)
+  logBootstrapDebug(`[bootstrap] using ${input.packageName}@${version}`)
   const installedPackage = await installPublishedPackage(input.packageName, version)
   const entryPath = await resolvePackageBinEntrypoint(installedPackage.packageDir, input.commandName)
   return await runNodeEntrypoint(entryPath, input.forwardedArgs)

--- a/apps/bootstrap/src/program.ts
+++ b/apps/bootstrap/src/program.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander'
 import process from 'node:process'
 
+import { APP_HELP_TEXT, BOOTSTRAP_HELP_TEXT, extractBootstrapFlags } from './bootstrap-flags'
+import { BOOTSTRAP_DEBUG_ENV_NAME } from './debug'
 import { launchDesktopApp } from './desktop-app'
 import type { DesktopInstallMode, LaunchDesktopAppOptions } from './desktop-app'
 import { getBootstrapDescription, getBootstrapVersion } from './package-config'
@@ -122,30 +124,26 @@ export const createBootstrapCli = (inputDeps: Partial<BootstrapCliDeps> = {}) =>
     .showHelpAfterError()
     .addHelpText(
       'after',
-      `
-Top-level flags:
-  --help, -h     Show bootstrap help
-  --version, -V  Print bootstrap version
-
-Examples:
-  npx @vibe-forge/bootstrap run "summarize the repo"
-  npx @vibe-forge/bootstrap web --port 8787
-  npx @vibe-forge/bootstrap server --host 0.0.0.0 --allow-cors
-  npx @vibe-forge/bootstrap app
-  npx @vibe-forge/bootstrap app cache
-  npx @vibe-forge/bootstrap app --no-cache
-  cd ~/work/project-a && npx @vibe-forge/bootstrap app
-  cd ~/work/project-b && npx @vibe-forge/bootstrap app
-`
+      BOOTSTRAP_HELP_TEXT
     )
     .action(async (command: string | undefined, args: string[] = []) => {
-      const target = routeBootstrapCommand(command, args)
+      const { debug, forwardedArgs } = extractBootstrapFlags(args)
+      if (debug) {
+        process.env[BOOTSTRAP_DEBUG_ENV_NAME] = '1'
+      }
+
+      const target = routeBootstrapCommand(command, forwardedArgs)
       if (target == null) {
         program.outputHelp()
         return
       }
 
       if (target.kind === 'desktop') {
+        if (target.forwardedArgs.includes('--help') || target.forwardedArgs.includes('-h')) {
+          process.stdout.write(`${APP_HELP_TEXT}\n`)
+          return
+        }
+
         await deps.launchDesktopApp({
           forwardedArgs: target.forwardedArgs,
           installMode: target.installMode,
@@ -170,7 +168,12 @@ Examples:
 
 export const runBootstrapCli = async (argv = process.argv) => {
   const command = createBootstrapCli()
-  const userArgs = argv.slice(2)
+  const { debug, forwardedArgs } = extractBootstrapFlags(argv.slice(2))
+  const userArgs = forwardedArgs
+  if (debug) {
+    process.env[BOOTSTRAP_DEBUG_ENV_NAME] = '1'
+  }
+
   if (userArgs.length === 0 || (userArgs.length === 1 && ['-h', '--help'].includes(userArgs[0] ?? ''))) {
     command.outputHelp()
     return
@@ -181,5 +184,5 @@ export const runBootstrapCli = async (argv = process.argv) => {
     return
   }
 
-  await command.parseAsync(argv)
+  await command.parseAsync([argv[0] ?? 'node', argv[1] ?? 'vibe-forge-bootstrap', ...userArgs])
 }


### PR DESCRIPTION
## Summary
- only print bootstrap source diagnostics when `--debug` is enabled
- keep `--debug` as a bootstrap-only flag instead of forwarding it downstream
- add coverage for debug flag handling and installed-package resolution

## Testing
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/bootstrap/__tests__/cli.spec.ts apps/bootstrap/__tests__/package-launcher.spec.ts apps/bootstrap/__tests__/desktop-release.spec.ts
- pnpm exec eslint apps/bootstrap/src/debug.ts apps/bootstrap/src/bootstrap-flags.ts apps/bootstrap/src/package-launcher.ts apps/bootstrap/src/desktop-app.ts apps/bootstrap/src/program.ts apps/bootstrap/__tests__/cli.spec.ts apps/bootstrap/__tests__/package-launcher.spec.ts
