### PR TITLE
feat(client): add chat thinking indicator

### DIFF
--- a/apps/bootstrap/src/installed-package.ts
+++ b/apps/bootstrap/src/installed-package.ts
@@ -23,12 +23,12 @@ export const resolveInstalledPackageBin = (
   const binPath = typeof bin === 'string'
     ? bin
     : (
-        typeof binName === 'string'
-          ? bin?.[binName]
-          : Object.values(bin ?? {}).find(
-              (value): value is string => typeof value === 'string'
-            )
-      )
+      typeof binName === 'string'
+        ? bin?.[binName]
+        : Object.values(bin ?? {}).find(
+          (value): value is string => typeof value === 'string'
+        )
+    )
 
   if (typeof binPath !== 'string') {
     throw new TypeError(

--- a/apps/client/src/components/ConfigView.tsx
+++ b/apps/client/src/components/ConfigView.tsx
@@ -16,12 +16,12 @@ import { getApiErrorMessage, getConfig, getConfigSchema, listWorktreeEnvironment
 import { useQueryParams } from '../hooks/useQueryParams'
 import { AboutSection, ConfigSectionPanel, ConfigSourceSwitch, DisplayValue } from './config'
 import { AppSettingsPanel } from './config/AppSettingsPanel'
+import { WorktreeEnvironmentPanel } from './config/WorktreeEnvironmentPanel'
 import {
   getConfigDraftKey,
   resolveRemoteConfigChangeAction,
   serializeComparableConfigValue
 } from './config/configConflict'
-import { WorktreeEnvironmentPanel } from './config/WorktreeEnvironmentPanel'
 import { cloneValue, getValueByPath, isEmptyValue } from './config/configUtils'
 import { toDisplayEnvironmentName, toEnvironmentReference } from './config/worktree-environment-panel-model'
 
@@ -411,7 +411,6 @@ export function ConfigView() {
       }
       return nextConflicts
     }
-
     ;(['project', 'user'] as const).forEach((source) => {
       const sourceData = data?.sources?.[source]
       if (sourceData == null) return

--- a/apps/client/src/components/chat/ChatHistoryView.tsx
+++ b/apps/client/src/components/chat/ChatHistoryView.tsx
@@ -154,10 +154,6 @@ export function ChatHistoryView({
     ...DEFAULT_CHAT_SESSION_WORKSPACE_DRAFT
   }))
   const [newSessionInitialContent, setNewSessionInitialContent] = useState<ChatMessageContent[] | undefined>(undefined)
-  const historyRenderCount = messages.length + historyStatusNotices.length
-  const { messagesEndRef, messagesContainerRef, messagesContentRef, showScrollBottom, scrollToBottom } = useChatScroll({
-    contentVersion: historyRenderCount
-  })
   const {
     isCreating,
     send,
@@ -183,6 +179,11 @@ export function ChatHistoryView({
     sessionTargetDraft,
     workspaceDraft,
     onClearMessages
+  })
+  const showThinkingIndicator = isCreating || session?.status === 'running'
+  const historyRenderCount = messages.length + historyStatusNotices.length + (showThinkingIndicator ? 1 : 0)
+  const { messagesEndRef, messagesContainerRef, messagesContentRef, showScrollBottom, scrollToBottom } = useChatScroll({
+    contentVersion: historyRenderCount
   })
   const initialScrollDoneRef = useRef(false)
   const handledHashAnchorIdRef = useRef('')
@@ -844,6 +845,11 @@ export function ChatHistoryView({
               }}
             />
           ))}
+          {showThinkingIndicator && (
+            <div className='chat-thinking-indicator' role='status' aria-live='polite'>
+              <span className='chat-thinking-indicator__text'>{t('chat.thinking')}</span>
+            </div>
+          )}
           <div ref={messagesEndRef} />
         </div>
 

--- a/apps/client/src/resources/locales/en.json
+++ b/apps/client/src/resources/locales/en.json
@@ -515,7 +515,7 @@
     "clickToEditTitle": "Click to edit title",
     "inputPlaceholder": "Type a message...",
     "send": "Send",
-    "thinking": "Thinking...",
+    "thinking": "Thinking",
     "stop": "Stop",
     "result": "Result",
     "sessionActive": "Session Active",

--- a/apps/client/src/resources/locales/zh.json
+++ b/apps/client/src/resources/locales/zh.json
@@ -516,7 +516,7 @@
     "clickToEditTitle": "点击编辑标题",
     "inputPlaceholder": "输入消息...",
     "send": "发送",
-    "thinking": "思考中...",
+    "thinking": "正在思考",
     "stop": "停止",
     "result": "结果",
     "sessionActive": "会话进行中",

--- a/apps/client/src/routes/ChatRoute.scss
+++ b/apps/client/src/routes/ChatRoute.scss
@@ -267,6 +267,59 @@
   }
 }
 
+.chat-thinking-indicator {
+  align-self: stretch;
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 2px;
+  min-width: 0;
+}
+
+.chat-thinking-indicator__text {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  font-size: 13px;
+  line-height: 1.45;
+  font-weight: 500;
+  letter-spacing: .02em;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--sub-text-color) 88%, var(--text-color) 12%);
+  background-image: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--sub-text-color) 88%, var(--text-color) 12%) 0%,
+    color-mix(in srgb, var(--sub-text-color) 88%, var(--text-color) 12%) 34%,
+    color-mix(in srgb, var(--text-color) 88%, white 12%) 50%,
+    color-mix(in srgb, var(--sub-text-color) 88%, var(--text-color) 12%) 66%,
+    color-mix(in srgb, var(--sub-text-color) 88%, var(--text-color) 12%) 100%
+  );
+  background-size: 220% 100%;
+  background-position: 120% 50%;
+  background-repeat: no-repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: chat-thinking-indicator-shimmer 1.7s linear infinite;
+}
+
+@keyframes chat-thinking-indicator-shimmer {
+  from {
+    background-position: 120% 50%;
+  }
+
+  to {
+    background-position: -120% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-thinking-indicator__text {
+    animation: none;
+    background-position: 50% 50%;
+  }
+}
+
 .sender-container {
   flex: 0;
   display: flex;
@@ -443,6 +496,10 @@
     width: min(100%, 320px);
     padding: 8px 12px;
     border-radius: 8px;
+  }
+
+  .chat-thinking-indicator__text {
+    font-size: 12px;
   }
 
   .chat-composer-stack {


### PR DESCRIPTION
## Summary
- show a persistent thinking label at the bottom of the chat message list while the session is still running
- add a left-to-right shimmer effect for the thinking text and keep it accessible with reduced-motion support
- update the localized thinking copy and count the indicator in chat scroll state so the bottom behavior stays consistent

## Validation
- pnpm exec eslint apps/client/src/components/chat/ChatHistoryView.tsx
- pnpm typecheck web