### PR TITLE
fix: address skills install review feedback

### DIFF
--- a/apps/cli/__tests__/skills-command.spec.ts
+++ b/apps/cli/__tests__/skills-command.spec.ts
@@ -103,6 +103,54 @@ describe('skills command', () => {
     ])
   })
 
+  it('treats semantically identical configured skills as duplicates even when key order differs', async () => {
+    const cwd = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vf-skills-command-')))
+    tempDirs.push(cwd)
+    process.chdir(cwd)
+
+    await writeFile(
+      path.join(cwd, '.ai.config.json'),
+      JSON.stringify(
+        {
+          skills: [
+            {
+              source: 'example-source/default/public',
+              rename: 'internal-review',
+              name: 'design-review'
+            }
+          ]
+        },
+        null,
+        2
+      )
+    )
+
+    mocks.installProjectSkill.mockResolvedValue({
+      dirName: 'internal-review',
+      installDir: path.join(cwd, '.ai/skills/internal-review'),
+      name: 'internal-review',
+      ref: 'example-source/default/public@design-review',
+      skillPath: path.join(cwd, '.ai/skills/internal-review/SKILL.md')
+    })
+
+    const program = new Command()
+    registerSkillsCommand(program)
+
+    await program.parseAsync([
+      'skills',
+      'add',
+      'design-review',
+      '--source',
+      'example-source/default/public',
+      '--rename',
+      'internal-review'
+    ], { from: 'user' })
+
+    const config = JSON.parse(await readFile(path.join(cwd, '.ai.config.json'), 'utf8'))
+    expect(config.skills).toHaveLength(1)
+    expect(mocks.installProjectSkill).toHaveBeenCalledTimes(1)
+  })
+
   it('installs configured skills by default and forces updates for the update command', async () => {
     const cwd = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vf-skills-command-')))
     tempDirs.push(cwd)

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -159,7 +159,19 @@ const buildGeneralSkillsUpdateValue = (
 const isSameDeclaredSkill = (
   left: string | ConfiguredSkillInstallConfig,
   right: string | ConfiguredSkillInstallConfig
-) => JSON.stringify(left) === JSON.stringify(right)
+) => {
+  const normalizedLeft = normalizeProjectSkillInstall(left)
+  const normalizedRight = normalizeProjectSkillInstall(right)
+
+  if (normalizedLeft != null && normalizedRight != null) {
+    return normalizedLeft.ref === normalizedRight.ref &&
+      normalizedLeft.targetName === normalizedRight.targetName &&
+      normalizedLeft.rename === normalizedRight.rename &&
+      normalizedLeft.source === normalizedRight.source
+  }
+
+  return left === right
+}
 
 const matchesSkillSelector = (selector: string, value: string | ConfiguredSkillInstallConfig) => {
   const normalized = normalizeProjectSkillInstall(value)

--- a/apps/server/__tests__/services/skill-hub-skills-cli.spec.ts
+++ b/apps/server/__tests__/services/skill-hub-skills-cli.spec.ts
@@ -190,4 +190,39 @@ describe('skills CLI skill hub source flow', () => {
       readFile(path.join(workspace, '.ai', 'skills', 'internal-review', 'notes.md'), 'utf8')
     ).resolves.toContain('supporting file')
   })
+
+  it('reports the force flag name when the target skill is already installed', async () => {
+    await mkdir(path.join(workspace, '.ai', 'skills', 'internal-review'), { recursive: true })
+    await writeFile(
+      path.join(workspace, '.ai', 'skills', 'internal-review', 'SKILL.md'),
+      '---\nname: internal-review\n---\nReview skill body\n'
+    )
+
+    createExecImplementation(async (args, options) => {
+      if (!args.includes('--skill')) {
+        return new Error(`Unexpected skills CLI args: ${args.join(' ')}`)
+      }
+
+      const skillDir = path.join(String(options.cwd), '.agents', 'skills', 'internal-review')
+      await mkdir(skillDir, { recursive: true })
+      await writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        '---\nname: internal-review\n---\nReview skill body\n'
+      )
+
+      return {
+        stdout: 'installed\n'
+      }
+    })
+
+    const { installSkillsCliSkill } = await import('#~/services/skill-hub/skills-cli.js')
+    await expect(installSkillsCliSkill({
+      config: {
+        registry: 'https://registry.example.com'
+      },
+      skill: 'internal-review',
+      source: 'example-source/default/public',
+      workspaceFolder: workspace
+    })).rejects.toThrow('Use --force to replace it.')
+  })
 })

--- a/apps/server/src/services/skill-hub/skills-cli.ts
+++ b/apps/server/src/services/skill-hub/skills-cli.ts
@@ -150,7 +150,7 @@ export const installSkillsCliSkill = async (params: {
     if (params.force === true) {
       await rm(installDir, { recursive: true, force: true })
     } else if (await pathExists(installDir)) {
-      throw new Error(`Skill "${installedSkill.name}" is already installed. Use force to replace it.`)
+      throw new Error(`Skill "${installedSkill.name}" is already installed. Use --force to replace it.`)
     }
 
     await copyRegularFiles(installedSkill.sourcePath, installDir)

--- a/apps/server/src/services/skill-hub/vercel-skills-install.ts
+++ b/apps/server/src/services/skill-hub/vercel-skills-install.ts
@@ -67,7 +67,7 @@ export const installVercelSkill = async (params: {
   if (params.force === true) {
     await rm(installDir, { recursive: true, force: true })
   } else if (await pathExists(installDir)) {
-    throw new Error(`Skill "${target.skill}" is already installed. Use force to replace it.`)
+    throw new Error(`Skill "${target.skill}" is already installed. Use --force to replace it.`)
   }
 
   for (const file of files) {

--- a/packages/utils/__tests__/project-skills-install.spec.ts
+++ b/packages/utils/__tests__/project-skills-install.spec.ts
@@ -1,0 +1,123 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findSkillsCli: vi.fn(),
+  installSkillsCliRefToTemp: vi.fn(),
+  installSkillsCliSkillToTemp: vi.fn()
+}))
+
+vi.mock('#~/skills-cli.js', async () => {
+  const actual = await vi.importActual<typeof import('#~/skills-cli.js')>('#~/skills-cli.js')
+  return {
+    ...actual,
+    findSkillsCli: mocks.findSkillsCli,
+    installSkillsCliRefToTemp: mocks.installSkillsCliRefToTemp,
+    installSkillsCliSkillToTemp: mocks.installSkillsCliSkillToTemp
+  }
+})
+
+const tempDirs: string[] = []
+
+const pathExists = async (targetPath: string) => {
+  try {
+    await access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('project skill installs', () => {
+  let installProjectSkill: typeof import('#~/project-skills.js').installProjectSkill
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+  })
+
+  it('replaces existing installed files via a temp directory swap and rewrites the local name', async () => {
+    ;({ installProjectSkill } = await import('#~/project-skills.js'))
+    const cwd = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vf-project-skills-install-')))
+    tempDirs.push(cwd)
+
+    const existingDir = path.join(cwd, '.ai', 'skills', 'internal-review')
+    await mkdir(existingDir, { recursive: true })
+    await writeFile(path.join(existingDir, 'SKILL.md'), '---\nname: stale-review\n---\nOld skill\n')
+    await writeFile(path.join(existingDir, 'stale.txt'), 'stale file\n')
+
+    const tempDir = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vf-project-skills-install-src-')))
+    tempDirs.push(tempDir)
+    const sourceDir = path.join(tempDir, 'design-review')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(
+      path.join(sourceDir, 'SKILL.md'),
+      '---\nname: design-review\ndescription: Review code\n---\nReview skill body\n'
+    )
+    await writeFile(path.join(sourceDir, 'notes.md'), 'new supporting file\n')
+
+    mocks.installSkillsCliSkillToTemp.mockResolvedValue({
+      tempDir,
+      installedSkill: {
+        dirName: 'design-review',
+        name: 'design-review',
+        sourcePath: sourceDir
+      }
+    })
+
+    await expect(installProjectSkill({
+      force: true,
+      skill: {
+        name: 'design-review',
+        rename: 'internal-review',
+        source: 'example-source/default/public'
+      },
+      workspaceFolder: cwd
+    })).resolves.toEqual(expect.objectContaining({
+      dirName: 'internal-review',
+      name: 'internal-review',
+      ref: 'example-source/default/public@design-review'
+    }))
+
+    await expect(readFile(path.join(existingDir, 'SKILL.md'), 'utf8')).resolves.toContain('name: internal-review')
+    await expect(readFile(path.join(existingDir, 'notes.md'), 'utf8')).resolves.toContain('new supporting file')
+    await expect(pathExists(path.join(existingDir, 'stale.txt'))).resolves.toBe(false)
+  })
+
+  it('reuses an already installed target without re-downloading when force is disabled', async () => {
+    ;({ installProjectSkill } = await import('#~/project-skills.js'))
+    const cwd = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vf-project-skills-install-')))
+    tempDirs.push(cwd)
+
+    const existingDir = path.join(cwd, '.ai', 'skills', 'internal-review')
+    await mkdir(existingDir, { recursive: true })
+    await writeFile(
+      path.join(existingDir, 'SKILL.md'),
+      '---\nname: internal-review\ndescription: Review code\n---\nReview skill body\n'
+    )
+
+    await expect(installProjectSkill({
+      force: false,
+      skill: {
+        name: 'design-review',
+        rename: 'internal-review',
+        source: 'example-source/default/public'
+      },
+      workspaceFolder: cwd
+    })).resolves.toEqual(expect.objectContaining({
+      dirName: 'internal-review',
+      name: 'internal-review',
+      skillPath: path.join(existingDir, 'SKILL.md')
+    }))
+
+    expect(mocks.installSkillsCliSkillToTemp).not.toHaveBeenCalled()
+    expect(mocks.installSkillsCliRefToTemp).not.toHaveBeenCalled()
+    expect(mocks.findSkillsCli).not.toHaveBeenCalled()
+  })
+})

--- a/packages/utils/__tests__/skills-cli-cache.spec.ts
+++ b/packages/utils/__tests__/skills-cli-cache.spec.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  ensureManagedNpmCli: vi.fn(),
+  execFile: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: mocks.execFile
+}))
+
+vi.mock('#~/managed-npm-cli.js', () => ({
+  ensureManagedNpmCli: mocks.ensureManagedNpmCli
+}))
+
+const createExecImplementation = (
+  callback: (args: string[]) => { stderr?: string; stdout?: string }
+) => {
+  mocks.execFile.mockImplementation(
+    ((...invokeArgs: any[]) => {
+      const args = invokeArgs[1] as string[]
+      const done = invokeArgs[3] as ((error: Error | null, stdout: string, stderr: string) => void)
+      const result = callback(args)
+      done(null, result.stdout ?? '', result.stderr ?? '')
+      return {} as any
+    }) as any
+  )
+}
+
+describe('skills CLI cache pruning', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-22T00:00:00Z'))
+    vi.clearAllMocks()
+    mocks.ensureManagedNpmCli.mockResolvedValue('/mock/bin/skills')
+    const { clearSkillsCliCachesForTest } = await import('#~/skills-cli.js')
+    clearSkillsCliCachesForTest()
+  })
+
+  afterEach(async () => {
+    const { clearSkillsCliCachesForTest } = await import('#~/skills-cli.js')
+    clearSkillsCliCachesForTest()
+    vi.useRealTimers()
+  })
+
+  it('prunes expired find cache entries before storing a new query result', async () => {
+    createExecImplementation(args => ({
+      stdout: `${args[1]}/source@${args[1]} 1 install\n`
+    }))
+
+    const { findSkillsCli, getSkillsCliCacheSizesForTest } = await import('#~/skills-cli.js')
+
+    await findSkillsCli({ query: 'alpha' })
+    expect(getSkillsCliCacheSizesForTest()).toEqual({
+      find: 1,
+      list: 0
+    })
+
+    vi.advanceTimersByTime(60_001)
+
+    await findSkillsCli({ query: 'beta' })
+    expect(getSkillsCliCacheSizesForTest()).toEqual({
+      find: 1,
+      list: 0
+    })
+    expect(mocks.execFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('prunes expired list cache entries before storing a new source listing', async () => {
+    createExecImplementation(args => ({
+      stdout: `  ${args[1]}-skill - Listed skill\n`
+    }))
+
+    const { getSkillsCliCacheSizesForTest, listSkillsCliSource } = await import('#~/skills-cli.js')
+
+    await listSkillsCliSource({ source: 'example-source/default/public' })
+    expect(getSkillsCliCacheSizesForTest()).toEqual({
+      find: 0,
+      list: 1
+    })
+
+    vi.advanceTimersByTime(300_001)
+
+    await listSkillsCliSource({ source: 'example-source/default/private' })
+    expect(getSkillsCliCacheSizesForTest()).toEqual({
+      find: 0,
+      list: 1
+    })
+    expect(mocks.execFile).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/utils/src/project-skills.ts
+++ b/packages/utils/src/project-skills.ts
@@ -1,6 +1,7 @@
-import { access, copyFile, lstat, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { access, copyFile, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import process from 'node:process'
+import { setTimeout as delay } from 'node:timers/promises'
 
 import type { ConfiguredSkillInstallConfig, SkillsCliConfig } from '@vibe-forge/types'
 
@@ -30,6 +31,9 @@ export interface ResolvedProjectSkillPublishSpec {
   name?: string
 }
 
+const INSTALL_LOCK_TIMEOUT_MS = 30_000
+const INSTALL_LOCK_RETRY_MS = 100
+
 const normalizeNonEmptyString = (value: unknown) => (
   typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
 )
@@ -58,6 +62,30 @@ const pathExists = async (targetPath: string) => {
     return true
   } catch {
     return false
+  }
+}
+
+const withInstallLock = async <T>(lockDir: string, callback: () => Promise<T>) => {
+  const start = Date.now()
+  await mkdir(dirname(lockDir), { recursive: true })
+
+  while (true) {
+    try {
+      await mkdir(lockDir)
+      break
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+      if (Date.now() - start > INSTALL_LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for project skill install lock ${lockDir}`)
+      }
+      await delay(INSTALL_LOCK_RETRY_MS)
+    }
+  }
+
+  try {
+    return await callback()
+  } finally {
+    await rm(lockDir, { recursive: true, force: true })
   }
 }
 
@@ -191,6 +219,17 @@ const pickSearchResult = (results: Awaited<ReturnType<typeof findSkillsCli>>, na
   )) ?? results[0]
 }
 
+const buildInstalledSkillResult = (params: {
+  installDir: string
+  normalized: NormalizedProjectSkillInstall
+}) => ({
+  dirName: params.normalized.targetDirName,
+  installDir: params.installDir,
+  name: params.normalized.targetName,
+  ref: params.normalized.ref,
+  skillPath: join(params.installDir, 'SKILL.md')
+})
+
 const rewriteInstalledSkillName = async (skillPath: string, targetName: string) => {
   const content = await readFile(skillPath, 'utf8')
   const normalizedName = /^[\w./-]+$/.test(targetName)
@@ -285,55 +324,82 @@ export const installProjectSkill = async (params: {
   const projectSkillsDir = resolveProjectAiPath(params.workspaceFolder, process.env, 'skills')
   const installDir = join(projectSkillsDir, normalized.targetDirName)
   const skillPath = join(installDir, 'SKILL.md')
+  const tempInstallDir = resolveProjectAiPath(
+    params.workspaceFolder,
+    process.env,
+    'caches',
+    'project-skill-installs',
+    `${normalized.targetDirName}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  )
+  const lockDir = resolveProjectAiPath(
+    params.workspaceFolder,
+    process.env,
+    'caches',
+    'project-skill-installs',
+    'locks',
+    normalized.targetDirName
+  )
 
-  const installResult = normalized.source != null
-    ? await installSkillsCliSkillToTemp({
-      config: params.config,
-      registry: params.registry,
-      skill: normalized.name,
-      source: normalized.source
-    })
-    : await (async () => {
-      const searchResults = await findSkillsCli({
+  return await withInstallLock(lockDir, async () => {
+    if (params.force !== true && await pathExists(skillPath)) {
+      return buildInstalledSkillResult({
+        installDir,
+        normalized
+      })
+    }
+
+    const installResult = normalized.source != null
+      ? await installSkillsCliSkillToTemp({
         config: params.config,
         registry: params.registry,
-        query: normalized.name
+        skill: normalized.name,
+        source: normalized.source
       })
-      const selected = pickSearchResult(searchResults, normalized.name)
-      if (selected == null) {
-        throw new Error(`Skill ${normalized.name} was not found by the skills CLI search.`)
+      : await (async () => {
+        const searchResults = await findSkillsCli({
+          config: params.config,
+          registry: params.registry,
+          query: normalized.name
+        })
+        const selected = pickSearchResult(searchResults, normalized.name)
+        if (selected == null) {
+          throw new Error(`Skill ${normalized.name} was not found by the skills CLI search.`)
+        }
+
+        return await installSkillsCliRefToTemp({
+          config: params.config,
+          registry: params.registry,
+          installRef: selected.installRef
+        })
+      })()
+
+    try {
+      await rm(tempInstallDir, { recursive: true, force: true })
+      await mkdir(dirname(tempInstallDir), { recursive: true })
+      await mkdir(tempInstallDir, { recursive: true })
+      await copyRegularFiles(installResult.installedSkill.sourcePath, tempInstallDir)
+
+      const tempSkillPath = join(tempInstallDir, 'SKILL.md')
+      if (!await pathExists(tempSkillPath)) {
+        throw new Error(`Configured skill ${normalized.ref} did not include SKILL.md`)
       }
+      await rewriteInstalledSkillName(tempSkillPath, normalized.targetName)
 
-      return await installSkillsCliRefToTemp({
-        config: params.config,
-        registry: params.registry,
-        installRef: selected.installRef
-      })
-    })()
-
-  try {
-    if (params.force === true) {
       await rm(installDir, { recursive: true, force: true })
-    } else if (await pathExists(skillPath)) {
-      throw new Error(`Skill "${normalized.targetName}" is already installed. Use --force to replace it.`)
-    }
+      await mkdir(dirname(installDir), { recursive: true })
+      await rename(tempInstallDir, installDir)
 
-    await copyRegularFiles(installResult.installedSkill.sourcePath, installDir)
-    if (!await pathExists(skillPath)) {
-      throw new Error(`Configured skill ${normalized.ref} did not include SKILL.md`)
+      return buildInstalledSkillResult({
+        installDir,
+        normalized
+      })
+    } catch (error) {
+      await rm(tempInstallDir, { recursive: true, force: true })
+      throw error
+    } finally {
+      await rm(installResult.tempDir, { recursive: true, force: true })
     }
-    await rewriteInstalledSkillName(skillPath, normalized.targetName)
-  } finally {
-    await rm(installResult.tempDir, { recursive: true, force: true })
-  }
-
-  return {
-    dirName: normalized.targetDirName,
-    installDir,
-    name: normalized.targetName,
-    ref: normalized.ref,
-    skillPath
-  }
+  })
 }
 
 export const removeProjectSkill = async (params: {

--- a/packages/utils/src/skills-cli.ts
+++ b/packages/utils/src/skills-cli.ts
@@ -30,6 +30,30 @@ const listCache = new Map<string, {
   results: SkillsCliListedSkill[]
 }>()
 
+const pruneExpiredCacheEntries = <T>(
+  cache: Map<string, {
+    expiresAt: number
+    results: T
+  }>,
+  now = Date.now()
+) => {
+  for (const [cacheKey, entry] of cache.entries()) {
+    if (entry.expiresAt <= now) {
+      cache.delete(cacheKey)
+    }
+  }
+}
+
+export const clearSkillsCliCachesForTest = () => {
+  findCache.clear()
+  listCache.clear()
+}
+
+export const getSkillsCliCacheSizesForTest = () => ({
+  find: findCache.size,
+  list: listCache.size
+})
+
 export interface SkillsCliListedSkill {
   description?: string
   name: string
@@ -337,6 +361,7 @@ export const listSkillsCliSource = async (params: {
     input: `list:${source}`,
     registry: params.registry
   })
+  pruneExpiredCacheEntries(listCache)
   const cached = listCache.get(cacheKey)
   if (cached != null && cached.expiresAt > Date.now()) {
     return cached.results
@@ -382,6 +407,7 @@ export const findSkillsCli = async (params: {
     input: `find:${query}`,
     registry: params.registry
   })
+  pruneExpiredCacheEntries(findCache)
   const cached = findCache.get(cacheKey)
   if (cached != null && cached.expiresAt > Date.now()) {
     return cached.results


### PR DESCRIPTION
## Summary
- harden project skill installs with a per-skill lock and temp-dir swap before replacing `.ai/skills/<name>`
- prune expired `skills` CLI find/list cache entries so long-lived processes do not retain stale keys indefinitely
- compare declared skills by normalized semantics instead of raw JSON key order, and clarify `--force` error messaging

## Testing
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/utils/__tests__/project-skills-install.spec.ts packages/utils/__tests__/skills-cli-cache.spec.ts
- pnpm exec vitest run --workspace vitest.workspace.ts --project node apps/cli/__tests__/skills-command.spec.ts apps/server/__tests__/services/skill-hub-skills-cli.spec.ts
- pnpm typecheck
- pnpm exec dprint check
- pnpm exec eslint .
