### PR TITLE
chore(release): prepare 2.0.2

### DIFF
--- a/apps/bootstrap/package.json
+++ b/apps/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/bootstrap",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Vibe Forge bootstrap launcher",
   "vibeForge": {
     "runtimeTranspile": true

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe-forge/client",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "imports": {
     "#~/*": [
       "./src/*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vibe Forge server",
   "imports": {
     "#~/*.js": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vibe Forge integrated web app",
   "vibeForge": {
     "runtimeTranspile": true

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-claude-code",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code Adapter for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-codex",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Codex App Server Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-copilot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "GitHub Copilot CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/gemini/package.json
+++ b/packages/adapters/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-gemini",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Gemini CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/kimi/package.json
+++ b/packages/adapters/kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-kimi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Kimi CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-opencode",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenCode Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/app-runtime",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "App-facing runtime facade for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/benchmark",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Benchmark discovery and execution for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/channels/lark/package.json
+++ b/packages/channels/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/channel-lark",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/cli-helper/package.json
+++ b/packages/cli-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli-helper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     ".": "./loader.js",
     "./entry": "./entry.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/config",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Shared config IO for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/definition-core/package.json
+++ b/packages/definition-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared definition-domain helpers for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/definition-loader/package.json
+++ b/packages/definition-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared definition loading utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/managed-plugins/package.json
+++ b/packages/managed-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/managed-plugins",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Managed native plugin installation and sync for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vibe Forge MCP server",
   "imports": {
     "#~/*.js": {

--- a/packages/plugins/chrome-devtools/package.json
+++ b/packages/plugins/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-chrome-devtools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/cli-skills/package.json
+++ b/packages/plugins/cli-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-cli-skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     "./package.json": "./package.json"
   }

--- a/packages/plugins/logger/package.json
+++ b/packages/plugins/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/standard-dev/package.json
+++ b/packages/plugins/standard-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-standard-dev",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     "./package.json": "./package.json"
   }

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/register",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     "./dotenv": {
       "types": "./dotenv.d.ts",

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/task",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Task runtime for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/tsconfigs/package.json
+++ b/packages/tsconfigs/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vibe-forge/tsconfigs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TSConfig for Vibe Forge"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/types",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared types for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared runtime utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared runtime utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/workspace-assets/package.json
+++ b/packages/workspace-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/workspace-assets",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Workspace asset resolution and adapter asset planning for Vibe Forge",
   "imports": {
     "#~/*.js": {


### PR DESCRIPTION
## Summary
- prepare vibe-forge patch releases 2.0.1 and 2.0.2
- include the latest master changes, including #192
- publish updated cli and utils packages
