### PR TITLE
fix(client): keep session route when updating query params

### DIFF
--- a/apps/client/__tests__/message-utils.spec.ts
+++ b/apps/client/__tests__/message-utils.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@vibe-forge/core'
 
-import { getLastAssistantActionAnchorId } from '#~/components/chat/messages/message-action-utils'
+import {
+  getLastAssistantActionAnchorId,
+  getLastMessageAnchorId
+} from '#~/components/chat/messages/message-action-utils'
 import { processMessages } from '#~/components/chat/messages/message-utils'
 
 const createMessage = (
@@ -59,6 +62,42 @@ describe('message render utils', () => {
 
     expect(latestMessageAnchorId).toBeDefined()
     expect(getLastAssistantActionAnchorId(renderItems)).toBe(latestMessageAnchorId)
+  })
+
+  it('tracks the latest message bubble even when tool groups are rendered after it', () => {
+    const renderItems = processMessages([
+      createMessage('user-1', 'user', 'Run the checks.'),
+      createMessage('assistant-1', 'assistant', [
+        { type: 'text', text: 'I will run the checks now.' },
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'adapter:codex:Shell',
+          input: { cmd: 'pnpm test' }
+        }
+      ])
+    ])
+    let latestMessageAnchorId: string | undefined
+    for (let index = renderItems.length - 1; index >= 0; index -= 1) {
+      const item = renderItems[index]
+      if (item?.type === 'message') {
+        latestMessageAnchorId = item.anchorId
+        break
+      }
+    }
+
+    expect(latestMessageAnchorId).toBeDefined()
+    expect(getLastMessageAnchorId(renderItems)).toBe(latestMessageAnchorId)
+  })
+
+  it('returns the newest user message bubble when a user message is last', () => {
+    const renderItems = processMessages([
+      createMessage('user-1', 'user', 'Start.'),
+      createMessage('assistant-1', 'assistant', 'Done.'),
+      createMessage('user-2', 'user', 'One more thing.')
+    ])
+
+    expect(getLastMessageAnchorId(renderItems)).toBe('message-user-2')
   })
 
   it('preserves the existing latest assistant action when a user message follows it', () => {

--- a/apps/client/__tests__/use-query-params.spec.ts
+++ b/apps/client/__tests__/use-query-params.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildQueryParamNavigationTarget, resolveQueryParamPathname } from '#~/hooks/useQueryParams'
+
+describe('useQueryParams helpers', () => {
+  it('keeps the active session pathname when updating query params after navigation', () => {
+    expect(buildQueryParamNavigationTarget<{ senderHeader: string }>({
+      clientBase: '/ui',
+      currentHash: '',
+      currentPathname: '/ui/session/session-123',
+      currentSearch: '',
+      defaults: {
+        senderHeader: ''
+      },
+      keySet: new Set(['senderHeader']),
+      keys: ['senderHeader'],
+      omit: {
+        senderHeader: value => value === ''
+      },
+      patch: {
+        senderHeader: 'collapsed'
+      }
+    })).toEqual({
+      pathname: '/session/session-123',
+      search: '?senderHeader=collapsed',
+      hash: ''
+    })
+  })
+
+  it('preserves unrelated query params and hash fragments', () => {
+    expect(buildQueryParamNavigationTarget<{ senderHeader: string }>({
+      clientBase: '/ui',
+      currentHash: '#message-1',
+      currentPathname: '/ui/session/session-123',
+      currentSearch: '?layout=workspace',
+      defaults: {
+        senderHeader: ''
+      },
+      keySet: new Set(['senderHeader']),
+      keys: ['senderHeader'],
+      omit: {
+        senderHeader: value => value === ''
+      },
+      patch: {
+        senderHeader: 'collapsed'
+      }
+    })).toEqual({
+      pathname: '/session/session-123',
+      search: '?senderHeader=collapsed&layout=workspace',
+      hash: '#message-1'
+    })
+  })
+
+  it('returns null when the query payload does not change', () => {
+    expect(buildQueryParamNavigationTarget<{ senderHeader: string }>({
+      clientBase: '/ui',
+      currentHash: '',
+      currentPathname: '/ui/session/session-123',
+      currentSearch: '?senderHeader=collapsed',
+      defaults: {
+        senderHeader: ''
+      },
+      keySet: new Set(['senderHeader']),
+      keys: ['senderHeader'],
+      omit: {
+        senderHeader: value => value === ''
+      },
+      patch: {
+        senderHeader: 'collapsed'
+      }
+    })).toBeNull()
+  })
+
+  it('normalizes a basename-prefixed pathname into an app-relative route', () => {
+    expect(resolveQueryParamPathname('/ui/session/session-123', '/ui')).toBe('/session/session-123')
+    expect(resolveQueryParamPathname('/ui', '/ui')).toBe('/')
+    expect(resolveQueryParamPathname('/session/session-123', '/ui')).toBe('/session/session-123')
+  })
+})

--- a/apps/client/src/components/chat/ChatHistoryView.tsx
+++ b/apps/client/src/components/chat/ChatHistoryView.tsx
@@ -42,7 +42,7 @@ import { QueuedMessagesCard } from './QueuedMessagesCard'
 import { MessageItem } from './messages/MessageItem'
 import { MessageStatusNotice } from './messages/MessageStatusNotice'
 import type { ChatHistoryStatusNotice } from './messages/build-chat-history-status-notices'
-import { getLastAssistantActionAnchorId } from './messages/message-action-utils'
+import { getLastAssistantActionAnchorId, getLastMessageAnchorId } from './messages/message-action-utils'
 import { buildMessageTurns } from './messages/message-turns'
 import { processMessages } from './messages/message-utils'
 import { SenderInteractionPanel } from './sender/@components/sender-interaction-panel/SenderInteractionPanel'
@@ -402,7 +402,9 @@ export function ChatHistoryView({
       hashAnchorId: hashAnchorId !== '' ? hashAnchorId : targetAnchorId,
       keepLastTurnExpanded: isCreating || session?.status === 'running' || session?.status === 'waiting_input'
     }), [expandedTurnIds, hashAnchorId, isCreating, renderItems, session?.status, targetAnchorId])
+  const isSessionBusy = isCreating || session?.status === 'running' || session?.status === 'waiting_input'
   const lastAssistantActionAnchorId = useMemo(() => getLastAssistantActionAnchorId(renderItems), [renderItems])
+  const lastMessageAnchorId = useMemo(() => getLastMessageAnchorId(renderItems), [renderItems])
   const handleEditQueuedMessage = async (item: SessionQueuedMessage) => {
     const removed = await removeQueuedContent(item.id)
     if (!removed) {
@@ -604,8 +606,8 @@ export function ChatHistoryView({
           isEditing={editingMessageId === item.originalMessage.id}
           isCompactLayout={isCompactLayout}
           isTouchInteraction={isTouchInteraction}
-          isSessionBusy={isCreating || session?.status === 'running' ||
-            session?.status === 'waiting_input'}
+          isSessionBusy={isSessionBusy}
+          hideActionButtons={isSessionBusy && item.anchorId === lastMessageAnchorId}
           showAssistantActions={item.anchorId === lastAssistantActionAnchorId}
           onEditMessage={editMessage}
           onForkMessage={forkMessage}

--- a/apps/client/src/components/chat/messages/MessageItem.tsx
+++ b/apps/client/src/components/chat/messages/MessageItem.tsx
@@ -29,6 +29,7 @@ interface MessageItemProps {
   sessionId?: string
   sessionInfo?: SessionInfo | null
   isSessionBusy: boolean
+  hideActionButtons: boolean
   isEditing: boolean
   isCompactLayout: boolean
   isTouchInteraction: boolean
@@ -54,6 +55,7 @@ function MessageItemComponent({
   sessionId,
   sessionInfo,
   isSessionBusy,
+  hideActionButtons,
   isEditing,
   isCompactLayout,
   isTouchInteraction,
@@ -83,9 +85,11 @@ function MessageItemComponent({
   const canRecall = isPersistedMessage && !isSessionBusy && isUser
   const canFork = isPersistedMessage && !isSessionBusy && isUser
   const canCopy = copyableText != null
-  const shouldShowAssistantActions = !isUser && showAssistantActions
+  const shouldShowAssistantActions = !hideActionButtons && !isUser && showAssistantActions
   const showCompactActionMenu = isCompactLayout || isTouchInteraction
-  const shouldShowCompactActionMenu = showCompactActionMenu && (isUser || shouldShowAssistantActions)
+  const shouldShowCompactActionMenu = !hideActionButtons &&
+    showCompactActionMenu &&
+    (isUser || shouldShowAssistantActions)
 
   useEffect(() => {
     setIsSubmitting(false)
@@ -114,6 +118,15 @@ function MessageItemComponent({
       setPendingConfirmAction(null)
     }
   }, [isActionsVisible])
+
+  useEffect(() => {
+    if (!hideActionButtons) {
+      return
+    }
+
+    setIsActionsVisible(false)
+    setPendingConfirmAction(null)
+  }, [hideActionButtons])
 
   useEffect(() => {
     if (pendingConfirmAction == null) {
@@ -277,7 +290,7 @@ function MessageItemComponent({
   }
 
   const handleActionsPointerEnter = () => {
-    if (!isUser || isEditing) {
+    if (!isUser || isEditing || hideActionButtons) {
       return
     }
 
@@ -297,7 +310,7 @@ function MessageItemComponent({
   }
 
   const handleActionsPointerLeave = () => {
-    if (!isUser) {
+    if (!isUser || hideActionButtons) {
       return
     }
 
@@ -448,7 +461,7 @@ function MessageItemComponent({
         onPointerLeave={handleActionsPointerLeave}
       >
         <div className={`message-body-container ${isEditing ? 'is-editing' : ''}`}>
-          {isUser && !isEditing && !showCompactActionMenu && (
+          {isUser && !isEditing && !showCompactActionMenu && !hideActionButtons && (
             <div className='message-side-actions'>
               {actionButtons}
             </div>
@@ -496,6 +509,7 @@ const areMessageItemPropsEqual = (prev: MessageItemProps, next: MessageItemProps
     prev.isFirstInGroup === next.isFirstInGroup &&
     prev.isTargeted === next.isTargeted &&
     prev.isSessionBusy === next.isSessionBusy &&
+    prev.hideActionButtons === next.hideActionButtons &&
     prev.isEditing === next.isEditing &&
     prev.isCompactLayout === next.isCompactLayout &&
     prev.isTouchInteraction === next.isTouchInteraction &&

--- a/apps/client/src/components/chat/messages/message-action-utils.ts
+++ b/apps/client/src/components/chat/messages/message-action-utils.ts
@@ -1,5 +1,16 @@
 import type { ChatRenderItem } from './message-utils'
 
+export function getLastMessageAnchorId(renderItems: ChatRenderItem[]) {
+  for (let index = renderItems.length - 1; index >= 0; index -= 1) {
+    const item = renderItems[index]
+    if (item?.type === 'message') {
+      return item.anchorId
+    }
+  }
+
+  return null
+}
+
 export function getLastAssistantActionAnchorId(renderItems: ChatRenderItem[]) {
   const lastItem = renderItems[renderItems.length - 1]
   if (lastItem?.type === 'tool-group') {

--- a/apps/client/src/hooks/useQueryParams.ts
+++ b/apps/client/src/hooks/useQueryParams.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { getClientBase } from '#~/runtime-config.js'
 
 type QueryParamKey<T> = Extract<keyof T, string>
 
@@ -9,12 +11,79 @@ interface QueryParamConfig<T extends Record<string, string>> {
   omit?: Partial<Record<QueryParamKey<T>, (value: string) => boolean>>
 }
 
+export const resolveQueryParamPathname = (rawPathname: string, clientBase: string) => {
+  if (!rawPathname.startsWith(clientBase)) {
+    return rawPathname === '' ? '/' : rawPathname
+  }
+
+  const relativePath = rawPathname.slice(clientBase.length)
+  if (relativePath === '') {
+    return '/'
+  }
+
+  return relativePath.startsWith('/') ? relativePath : `/${relativePath}`
+}
+
+export const buildQueryParamNavigationTarget = <T extends Record<string, string>>({
+  clientBase,
+  currentHash,
+  currentPathname,
+  currentSearch,
+  defaults,
+  keySet,
+  keys,
+  omit,
+  patch
+}: {
+  clientBase: string
+  currentHash: string
+  currentPathname: string
+  currentSearch: string
+  defaults?: Partial<T>
+  keySet: Set<string>
+  keys: QueryParamKey<T>[]
+  omit?: Partial<Record<QueryParamKey<T>, (value: string) => boolean>>
+  patch: Partial<T>
+}) => {
+  const currentSearchParams = new URLSearchParams(currentSearch)
+  const nextParams = new URLSearchParams()
+  const merged = keys.reduce((acc, key) => {
+    const raw = currentSearchParams.get(key)
+    const fallback = defaults?.[key] ?? ''
+    acc[key] = (raw ?? fallback) as T[QueryParamKey<T>]
+    return acc
+  }, {} as T)
+
+  Object.assign(merged, patch)
+
+  keys.forEach((key) => {
+    const value = merged[key] ?? ''
+    const shouldOmit = value === '' || (omit?.[key] ? omit[key]!(value) : false)
+    if (!shouldOmit) nextParams.set(key, value)
+  })
+
+  for (const [key, value] of currentSearchParams.entries()) {
+    if (!keySet.has(key)) nextParams.append(key, value)
+  }
+
+  if (nextParams.toString() === currentSearchParams.toString()) {
+    return null
+  }
+
+  return {
+    pathname: resolveQueryParamPathname(currentPathname, clientBase),
+    search: nextParams.toString() === '' ? '' : `?${nextParams.toString()}`,
+    hash: currentHash
+  }
+}
+
 export const useQueryParams = <T extends Record<string, string>>({
   keys,
   defaults,
   omit
 }: QueryParamConfig<T>) => {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const keySet = useMemo(() => new Set<string>(keys), [keys])
 
   const values = useMemo(() => {
@@ -27,30 +96,29 @@ export const useQueryParams = <T extends Record<string, string>>({
   }, [defaults, keys, searchParams])
 
   const update = useCallback((patch: Partial<T>) => {
-    const nextParams = new URLSearchParams()
-    const merged = keys.reduce((acc, key) => {
-      const raw = searchParams.get(key)
-      const fallback = defaults?.[key] ?? ''
-      acc[key] = (raw ?? fallback) as T[QueryParamKey<T>]
-      return acc
-    }, {} as T)
-
-    Object.assign(merged, patch)
-
-    keys.forEach((key) => {
-      const value = merged[key] ?? ''
-      const shouldOmit = value === '' || (omit?.[key] ? omit[key]!(value) : false)
-      if (!shouldOmit) nextParams.set(key, value)
+    const currentLocation = typeof window === 'undefined'
+      ? {
+        hash: '',
+        pathname: '/',
+        search: searchParams.toString() === '' ? '' : `?${searchParams.toString()}`
+      }
+      : window.location
+    const target = buildQueryParamNavigationTarget<T>({
+      clientBase: getClientBase(),
+      currentHash: currentLocation.hash,
+      currentPathname: currentLocation.pathname,
+      currentSearch: currentLocation.search,
+      defaults,
+      keySet,
+      keys,
+      omit,
+      patch
     })
 
-    for (const [key, value] of searchParams.entries()) {
-      if (!keySet.has(key)) nextParams.append(key, value)
+    if (target != null) {
+      void navigate(target, { replace: true })
     }
-
-    if (nextParams.toString() !== searchParams.toString()) {
-      setSearchParams(nextParams, { replace: true })
-    }
-  }, [defaults, keySet, keys, omit, searchParams, setSearchParams])
+  }, [defaults, keySet, keys, navigate, omit, searchParams])
 
   return { values, update, searchParams }
 }

--- a/apps/client/src/routes/ChatRoute.scss
+++ b/apps/client/src/routes/ChatRoute.scss
@@ -279,6 +279,68 @@
     padding-bottom .4s cubic-bezier(.4, 0, .2, 1);
 }
 
+.chat-thinking-indicator {
+  display: flex;
+  justify-content: flex-start;
+  padding: 4px 0 2px;
+  min-width: 0;
+  width: 100%;
+}
+
+.chat-thinking-indicator__text {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  max-width: min(90%, 100%);
+  font-size: 14px;
+  line-height: 1.6;
+  font-weight: 400;
+  white-space: nowrap;
+  text-align: left;
+  color: var(--text-color);
+}
+
+.chat-thinking-indicator__text::after {
+  content: '';
+  position: absolute;
+  inset: -1px -20%;
+  border-radius: 999px;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent 18%,
+    rgba(255, 255, 255, 0) 34%,
+    rgba(255, 255, 255, .08) 42%,
+    rgba(255, 255, 255, .82) 50%,
+    rgba(255, 255, 255, .08) 58%,
+    rgba(255, 255, 255, 0) 66%,
+    transparent 82%
+  );
+  mix-blend-mode: screen;
+  transform: translate3d(-180%, 0, 0);
+  animation: chat-thinking-indicator-scan 2s ease-in-out infinite;
+}
+
+@keyframes chat-thinking-indicator-scan {
+  from {
+    transform: translate3d(-180%, 0, 0);
+  }
+
+  to {
+    transform: translate3d(180%, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-thinking-indicator__text::after {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 .chat-composer-stack {
   flex: 0;
   min-width: 0;

--- a/apps/client/src/routes/ChatRoute.scss
+++ b/apps/client/src/routes/ChatRoute.scss
@@ -282,7 +282,7 @@
 .chat-thinking-indicator {
   display: flex;
   justify-content: flex-start;
-  padding: 4px 0 2px;
+  padding: 0;
   min-width: 0;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- keep query param updates anchored to the current route instead of a stale relative location
- preserve the active session path when collapsing the sender header after session creation
- add regression coverage for session-path-preserving query updates

## Verification
- pnpm exec vitest run apps/client/__tests__/use-query-params.spec.ts
- pnpm exec eslint apps/client/src/hooks/useQueryParams.ts apps/client/__tests__/use-query-params.spec.ts
- pnpm typecheck web
- pnpm typecheck web:test