### PR TITLE
[codex] Keep managed adapter configs inside project mock homes

### DIFF
--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -228,6 +228,31 @@ describe('initCodexAdapter', () => {
     expect(configContent).toContain('# BEGIN VIBE FORGE MANAGED CODEX PROJECT CONFIG')
   })
 
+  it('still writes the managed config into the workspace mock home when HOME points at the workspace root', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: workspace
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(join(mockHome, '.codex', 'config.toml'), 'utf8')
+    expect(configContent).toContain('check_for_update_on_startup = false')
+    await expect(readFile(join(workspace, '.codex', 'config.toml'), 'utf8')).rejects.toThrow()
+  })
+
   it('preserves unmanaged config content and replaces the managed block with user overrides', async () => {
     const workspace = await createWorkspace()
     const mockHome = join(workspace, '.ai', '.mock')

--- a/packages/adapters/codex/__tests__/native-hooks.spec.ts
+++ b/packages/adapters/codex/__tests__/native-hooks.spec.ts
@@ -209,4 +209,40 @@ describe('ensureCodexNativeHooksInstalled', () => {
     expect(hooks.hooks?.SessionStart).toHaveLength(1)
     await expect(readFile(join(realHome, '.codex', 'hooks.json'), 'utf8')).rejects.toThrow()
   })
+
+  it('prefers the workspace mock home when HOME accidentally points at the workspace root', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+
+    const ctx = {
+      cwd: workspace,
+      env: {
+        HOME: workspace
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: [
+          {
+            id: 'hookPlugin:project:logger'
+          }
+        ]
+      }
+    } as any
+
+    const installed = await ensureCodexNativeHooksInstalled(ctx)
+    const hooks = JSON.parse(
+      await readFile(join(mockHome, '.codex', 'hooks.json'), 'utf8')
+    ) as {
+      hooks?: Record<string, Array<{ matcher?: string }>>
+    }
+
+    expect(installed).toBe(true)
+    expect(hooks.hooks?.SessionStart).toHaveLength(1)
+    await expect(readFile(join(workspace, '.codex', 'hooks.json'), 'utf8')).rejects.toThrow()
+  })
 })

--- a/packages/adapters/copilot/__tests__/init.spec.ts
+++ b/packages/adapters/copilot/__tests__/init.spec.ts
@@ -96,6 +96,35 @@ describe('initCopilotAdapter', () => {
     await expect(lstat(keychainsPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('still writes keychain links into the workspace mock home when HOME points at the workspace root', async () => {
+    const workspace = await createWorkspace()
+    const realHome = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const keychainsPath = join(mockHome, 'Library', 'Keychains')
+
+    await mkdir(join(realHome, 'Library', 'Keychains'), { recursive: true })
+    await writeFile(join(realHome, 'Library', 'Keychains', 'login.keychain-db'), '')
+
+    await initCopilotAdapter({
+      cwd: workspace,
+      env: {
+        HOME: workspace,
+        __VF_PROJECT_REAL_HOME__: realHome,
+        __VF_PROJECT_AI_ADAPTER_COPILOT_CLI_PATH__: '/bin/copilot'
+      },
+      configs: [undefined, undefined],
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      }
+    } as any)
+
+    expect((await lstat(keychainsPath)).isSymbolicLink()).toBe(true)
+    await expect(lstat(join(workspace, 'Library', 'Keychains'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
   it('keeps concurrent keychain sync idempotent when multiple vf processes initialize Copilot together', async () => {
     const workspace = await createWorkspace()
     const realHome = await createWorkspace()

--- a/packages/adapters/copilot/src/runtime/init.ts
+++ b/packages/adapters/copilot/src/runtime/init.ts
@@ -3,15 +3,15 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import type { AdapterCtx } from '@vibe-forge/types'
+import { resolveProjectMockHome } from '@vibe-forge/utils'
 import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
 import { COPILOT_CLI_PACKAGE, COPILOT_CLI_VERSION, resolveCopilotBinaryPath } from '#~/paths.js'
 import { resolveAdapterConfig, syncCopilotManagedSymlink } from './shared'
 
-const resolveCopilotMockHome = (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => {
-  const explicitHome = ctx.env.HOME?.trim() || process.env.HOME?.trim()
-  return explicitHome ? resolve(explicitHome) : resolve(ctx.cwd, '.ai', '.mock')
-}
+const resolveCopilotMockHome = (ctx: Pick<AdapterCtx, 'cwd' | 'env'>) => (
+  resolveProjectMockHome(ctx.cwd, ctx.env)
+)
 
 const syncCopilotMockHomeSymlink = async (params: {
   sourcePath: string

--- a/packages/adapters/gemini/__tests__/init.spec.ts
+++ b/packages/adapters/gemini/__tests__/init.spec.ts
@@ -47,8 +47,10 @@ describe('initGeminiAdapter', () => {
     await initGeminiAdapter({
       cwd: workspace,
       env: {
-        HOME: mockHome
+        HOME: mockHome,
+        __VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__: '/bin/gemini'
       },
+      configs: [undefined, undefined],
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -79,8 +81,10 @@ describe('initGeminiAdapter', () => {
     await initGeminiAdapter({
       cwd: workspace,
       env: {
-        HOME: mockHome
+        HOME: mockHome,
+        __VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__: '/bin/gemini'
       },
+      configs: [undefined, undefined],
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -158,8 +162,10 @@ describe('initGeminiAdapter', () => {
       const ctx = {
         cwd: workspace,
         env: {
-          HOME: mockHome
+          HOME: mockHome,
+          __VF_PROJECT_AI_ADAPTER_GEMINI_CLI_PATH__: '/bin/gemini'
         },
+        configs: [undefined, undefined],
         logger: {
           info: vi.fn(),
           warn: vi.fn(),

--- a/packages/adapters/opencode/__tests__/init.spec.ts
+++ b/packages/adapters/opencode/__tests__/init.spec.ts
@@ -126,4 +126,37 @@ describe('initOpenCodeAdapter', () => {
       vi.resetModules()
     }
   })
+
+  it('still stages auth links in the workspace mock home when HOME points at the workspace root', async () => {
+    const workspace = await createWorkspace()
+    const realHome = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+
+    await mkdir(join(realHome, '.local', 'share', 'opencode'), { recursive: true })
+    await writeFile(join(realHome, '.local', 'share', 'opencode', 'auth.json'), '{}\n')
+    await writeFile(join(realHome, '.local', 'share', 'opencode', 'mcp-auth.json'), '{}\n')
+
+    await initOpenCodeAdapter({
+      cwd: workspace,
+      env: {
+        HOME: workspace,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const authPath = join(mockHome, '.local', 'share', 'opencode', 'auth.json')
+    expect((await lstat(authPath)).isSymbolicLink()).toBe(true)
+    await expect(lstat(join(workspace, '.local', 'share', 'opencode', 'auth.json'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
 })

--- a/packages/adapters/opencode/src/runtime/init.ts
+++ b/packages/adapters/opencode/src/runtime/init.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 
 import type { AdapterCtx } from '@vibe-forge/types'
-import { syncSymlinkTarget } from '@vibe-forge/utils'
+import { resolveProjectMockHome, syncSymlinkTarget } from '@vibe-forge/utils'
 import { ensureManagedNpmCli } from '@vibe-forge/utils/managed-npm-cli'
 
 import { OPENCODE_CLI_PACKAGE, OPENCODE_CLI_VERSION, resolveOpenCodeBinaryPath } from '#~/paths.js'
@@ -30,8 +30,8 @@ export const initOpenCodeAdapter = async (ctx: AdapterCtx) => {
     logger: ctx.logger
   })
 
-  const realHome = process.env.__VF_PROJECT_REAL_HOME__
-  const aiHome = process.env.HOME
+  const realHome = ctx.env.__VF_PROJECT_REAL_HOME__?.trim() || process.env.__VF_PROJECT_REAL_HOME__?.trim()
+  const aiHome = resolveProjectMockHome(ctx.cwd, ctx.env)
 
   if (realHome && aiHome) {
     await ensureSymlink(

--- a/packages/adapters/opencode/src/runtime/native-hooks.ts
+++ b/packages/adapters/opencode/src/runtime/native-hooks.ts
@@ -233,7 +233,7 @@ const resolveSourceConfigDir = (ctx: Pick<AdapterCtx, 'env'>) => {
   const explicit = ctx.env.OPENCODE_CONFIG_DIR?.trim() || process.env.OPENCODE_CONFIG_DIR?.trim()
   if (explicit) return resolve(explicit)
 
-  const realHome = process.env.__VF_PROJECT_REAL_HOME__?.trim()
+  const realHome = ctx.env.__VF_PROJECT_REAL_HOME__?.trim() || process.env.__VF_PROJECT_REAL_HOME__?.trim()
   return realHome ? resolve(realHome, '.config', 'opencode') : undefined
 }
 

--- a/packages/hooks/src/native.ts
+++ b/packages/hooks/src/native.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
 
-import { resolveProjectAiPath } from '@vibe-forge/utils'
+import { resolveProjectMockHome } from '@vibe-forge/utils'
 
 export interface NativeHookHandlerConfig {
   type: 'command'
@@ -37,20 +37,7 @@ export const hasManagedHookPlugins = (
 export const resolveMockHome = (
   cwd: string,
   env: Record<string, string | null | undefined>
-) => {
-  const fallbackMockHome = resolveProjectAiPath(cwd, env, '.mock')
-  const explicitHome = env.HOME?.trim() || process.env.HOME?.trim()
-  const realHome = env.__VF_PROJECT_REAL_HOME__?.trim() || process.env.__VF_PROJECT_REAL_HOME__?.trim()
-  const resolvedExplicitHome = explicitHome ? resolve(explicitHome) : undefined
-  const resolvedRealHome = realHome ? resolve(realHome) : undefined
-
-  if (resolvedExplicitHome == null) return fallbackMockHome
-  if (resolvedRealHome != null && resolvedExplicitHome === resolvedRealHome) {
-    return fallbackMockHome
-  }
-
-  return resolvedExplicitHome
-}
+) => resolveProjectMockHome(cwd, env)
 
 export const resolveManagedHookPackageDir = () => {
   try {

--- a/packages/utils/__tests__/ai-path.spec.ts
+++ b/packages/utils/__tests__/ai-path.spec.ts
@@ -8,7 +8,8 @@ import {
   resolveProjectAiBaseDirName,
   resolveProjectAiEntitiesDir,
   resolveProjectAiEntitiesDirName,
-  resolveProjectConfigDir
+  resolveProjectConfigDir,
+  resolveProjectMockHome
 } from '#~/ai-path.js'
 
 describe('ai path utils', () => {
@@ -52,5 +53,24 @@ describe('ai path utils', () => {
     expect(resolvePrimaryWorkspaceFolder('/tmp/project', {
       [PROJECT_PRIMARY_WORKSPACE_FOLDER_ENV]: '/tmp/project'
     })).toBeUndefined()
+  })
+
+  it('falls back to the managed mock home when HOME points inside the workspace', () => {
+    expect(resolveProjectMockHome('/tmp/project', {
+      HOME: '/tmp/project',
+      __VF_PROJECT_REAL_HOME__: '/tmp/home'
+    })).toBe('/tmp/project/.ai/.mock')
+
+    expect(resolveProjectMockHome('/tmp/project', {
+      HOME: '/tmp/project/.codex',
+      __VF_PROJECT_REAL_HOME__: '/tmp/home'
+    })).toBe('/tmp/project/.ai/.mock')
+  })
+
+  it('keeps an explicit external HOME when it does not target the real home or workspace', () => {
+    expect(resolveProjectMockHome('/tmp/project', {
+      HOME: '/tmp/custom-home',
+      __VF_PROJECT_REAL_HOME__: '/tmp/home'
+    })).toBe('/tmp/custom-home')
   })
 })

--- a/packages/utils/src/ai-path.ts
+++ b/packages/utils/src/ai-path.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { isAbsolute, resolve } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import process from 'node:process'
 
 export const PROJECT_LAUNCH_CWD_ENV = '__VF_PROJECT_LAUNCH_CWD__'
@@ -34,6 +34,11 @@ const resolvePathFromBase = (
 }
 
 const toPathSegments = (value: string) => value.split(/[\\/]+/).filter(Boolean)
+
+const isPathInside = (parentPath: string, targetPath: string) => {
+  const relativePath = relative(parentPath, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
 
 export const resolveProjectLaunchCwd = (
   cwd: string,
@@ -129,6 +134,28 @@ export const resolveProjectAiPath = (
   env: Record<string, string | null | undefined> = process.env,
   ...segments: string[]
 ) => resolve(resolveProjectAiBaseDir(cwd, env), ...segments)
+
+export const resolveProjectMockHome = (
+  cwd: string,
+  env: Record<string, string | null | undefined> = process.env
+) => {
+  const fallbackMockHome = resolveProjectAiPath(cwd, env, '.mock')
+  const explicitHome = normalizeDirPath(env.HOME ?? process.env.HOME)
+  const realHome = normalizeDirPath(env.__VF_PROJECT_REAL_HOME__ ?? process.env.__VF_PROJECT_REAL_HOME__)
+  const resolvedExplicitHome = explicitHome == null ? undefined : resolve(explicitHome)
+  const resolvedRealHome = realHome == null ? undefined : resolve(realHome)
+  const workspaceFolder = resolveProjectWorkspaceFolder(cwd, env)
+
+  if (resolvedExplicitHome == null) return fallbackMockHome
+  if (resolvedRealHome != null && resolvedExplicitHome === resolvedRealHome) {
+    return fallbackMockHome
+  }
+  if (isPathInside(workspaceFolder, resolvedExplicitHome) && resolvedExplicitHome !== fallbackMockHome) {
+    return fallbackMockHome
+  }
+
+  return resolvedExplicitHome
+}
 
 export const resolveProjectAiEntitiesDir = (
   cwd: string,


### PR DESCRIPTION
## Summary
- centralize project mock-home resolution so managed agent files fall back to `.ai/.mock` whenever `HOME` accidentally points inside the workspace
- keep Claude/Codex/Gemini managed config and hook writes on the shared mock-home path
- update OpenCode and Copilot init flows to reuse the same mock-home guard instead of trusting a workspace-scoped `HOME`
- add regression coverage for the shared helper and the affected adapter init paths

## Root Cause
Managed adapter bootstrap code was not consistently treating workspace-scoped `HOME` values as invalid mock-home targets. Some paths already used the shared hooks helper, while others had adapter-local mock-home resolution. If `vf` startup inherited `HOME` values like the workspace root or repo-local agent directories, managed config, hooks, auth, or keychain links could be written into repository-local agent roots instead of the isolated project mock home.

## Impact
- managed adapter config no longer leaks into repo-local agent roots such as `./.codex`
- Codex, Claude Code, and Gemini now share the same guarded mock-home fallback
- OpenCode and Copilot custom init flows now respect the same project mock-home boundary
- Kimi was audited and still only mutates session-local copied config, so no runtime change was needed there

## Validation
- `npx vitest run packages/utils/__tests__/ai-path.spec.ts packages/adapters/copilot/__tests__/init.spec.ts packages/adapters/opencode/__tests__/init.spec.ts packages/adapters/opencode/__tests__/native-hooks.spec.ts packages/adapters/codex/__tests__/init.spec.ts packages/adapters/codex/__tests__/native-hooks.spec.ts packages/adapters/claude-code/__tests__/init.spec.ts packages/adapters/gemini/__tests__/init.spec.ts`
- `pnpm exec eslint packages/utils/src/ai-path.ts packages/hooks/src/native.ts packages/adapters/copilot/src/runtime/init.ts packages/adapters/opencode/src/runtime/init.ts packages/adapters/opencode/src/runtime/native-hooks.ts packages/utils/__tests__/ai-path.spec.ts packages/adapters/copilot/__tests__/init.spec.ts packages/adapters/opencode/__tests__/init.spec.ts packages/adapters/gemini/__tests__/init.spec.ts`