### PR TITLE
fix(cli): default vf permission mode to bypassPermissions

### DIFF
--- a/.ai/docs/usage/cli.md
+++ b/.ai/docs/usage/cli.md
@@ -49,6 +49,38 @@
 - 如果没有设置，`vf` / `vf-mcp` / `vf-call-hook` / `vfui-server` / `vfui-client` 会从当前目录向上探测 `.ai`、`.ai.config.*`、`pnpm-workspace.yaml` 或 Git 根目录，因此可以在项目任意子目录下启动。
 - 配置文件默认会跟随这个解析后的 workspace 根目录读取；如果需要把 `.ai.config.*` 放到别的目录，可以显式设置 `__VF_PROJECT_CONFIG_DIR__`。
 
+## 默认权限模式
+
+`vf` / `vf run` 在没有显式传 `--permission-mode` 时，会默认以 `bypassPermissions` 启动。
+
+优先级从高到低：
+
+- CLI 显式 `--permission-mode`
+- 已缓存的 resume 权限模式
+- 配置 `permissions.defaultMode`
+- CLI 内建默认 `bypassPermissions`
+
+如果你想覆盖 CLI 内建默认，可以在配置里写：
+
+```yaml
+permissions:
+  defaultMode: plan
+```
+
+如果你想恢复 adapter 自身默认行为，而不是继续落到 `bypassPermissions`，显式配置：
+
+```yaml
+permissions:
+  defaultMode: default
+```
+
+也可以直接通过 CLI 写入：
+
+```bash
+vf config set general.permissions.defaultMode bypassPermissions --type string
+vf config set general.permissions.defaultMode default --type string
+```
+
 ## 内建 Skills
 
 `@vibe-forge/cli` 会默认注入 companion 插件 `@vibe-forge/plugin-cli-skills`，可直接通过 `--include-skill` 使用：
@@ -131,6 +163,7 @@ vf --resume <sessionId> --effort high --include-tool read_file
 说明：
 
 - `--resume` 会继续使用缓存里的 adapter、model、workspace 等启动参数。
+- 如果没有显式传 `--permission-mode`，CLI 会优先沿用缓存里的权限模式；缓存没有时再读取 `permissions.defaultMode`，最后回退到 `bypassPermissions`。
 - 如果只想调整下一次恢复时的权限模式，可以单独传 `--permission-mode <mode>`；新的模式会用于本次恢复，并写回该会话的 CLI cache，后续继续 `resume` 时沿用。
 
 ### 读取配置

--- a/apps/cli/__tests__/run.spec.ts
+++ b/apps/cli/__tests__/run.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { resolveConfiguredPluginInstances } from '@vibe-forge/utils/plugin-resolver'
 
 import {
+  CLI_DEFAULT_PERMISSION_MODE,
   createAdapterOption,
   createSessionExitController,
   getAdapterErrorMessage,
@@ -20,6 +21,7 @@ import {
   normalizeCliAdapterOptionValue,
   parseCliInputControlEvent,
   registerRunCommand,
+  resolveCliPermissionModeFromSources,
   resolveDefaultVibeForgeMcpServerOption,
   resolveInjectDefaultSystemPromptOption,
   resolvePrintableStopText,
@@ -220,6 +222,31 @@ describe('run command print output', () => {
   it('keeps direct mode for shorthand runs when print behavior is inferred separately', () => {
     expect(resolveRunMode(false, 'default', 'direct')).toBe('direct')
     expect(resolveRunMode(false, 'default', 'stream')).toBe('stream')
+  })
+
+  it('falls back to the CLI built-in bypassPermissions default when no source provides a mode', () => {
+    expect(resolveCliPermissionModeFromSources({})).toBe(CLI_DEFAULT_PERMISSION_MODE)
+  })
+
+  it('resolves permission mode priority as cli > cache > config > built-in default', () => {
+    expect(resolveCliPermissionModeFromSources({
+      cliPermissionMode: 'dontAsk',
+      cachedPermissionMode: 'plan',
+      configuredPermissionMode: 'acceptEdits'
+    })).toBe('dontAsk')
+    expect(resolveCliPermissionModeFromSources({
+      cachedPermissionMode: 'plan',
+      configuredPermissionMode: 'acceptEdits'
+    })).toBe('plan')
+    expect(resolveCliPermissionModeFromSources({
+      configuredPermissionMode: 'acceptEdits'
+    })).toBe('acceptEdits')
+  })
+
+  it('preserves an explicit default mode from config instead of falling through to bypassPermissions', () => {
+    expect(resolveCliPermissionModeFromSources({
+      configuredPermissionMode: 'default'
+    })).toBe('default')
   })
 
   it('rejects startup-only flags when resuming a cached session', () => {

--- a/apps/cli/__tests__/workspace.spec.ts
+++ b/apps/cli/__tests__/workspace.spec.ts
@@ -14,6 +14,14 @@ import { listCliSessions, writeCliSessionRecord } from '#~/session-cache.js'
 import { readCliSessionPermissionRecovery, writeCliSessionPermissionRecovery } from '#~/session-permission-cache.js'
 import { resolveCliWorkspaceCwd } from '#~/workspace.js'
 
+const configMocks = vi.hoisted(() => ({
+  loadConfigState: vi.fn(async () => ({ mergedConfig: {} })),
+  loadInjectDefaultSystemPromptValue: vi.fn(async () => undefined),
+  mergeSystemPrompts: vi.fn(({ generatedSystemPrompt, userSystemPrompt }) => (
+    userSystemPrompt ?? generatedSystemPrompt
+  ))
+}))
+
 vi.mock('@vibe-forge/app-runtime', () => ({
   generateAdapterQueryOptions: vi.fn(async () => [
     {},
@@ -36,10 +44,9 @@ vi.mock('@vibe-forge/app-runtime', () => ({
 }))
 
 vi.mock('@vibe-forge/config', () => ({
-  loadInjectDefaultSystemPromptValue: vi.fn(async () => undefined),
-  mergeSystemPrompts: vi.fn(({ generatedSystemPrompt, userSystemPrompt }) => (
-    userSystemPrompt ?? generatedSystemPrompt
-  ))
+  loadConfigState: configMocks.loadConfigState,
+  loadInjectDefaultSystemPromptValue: configMocks.loadInjectDefaultSystemPromptValue,
+  mergeSystemPrompts: configMocks.mergeSystemPrompts
 }))
 
 vi.mock('@vibe-forge/hooks', () => ({
@@ -74,6 +81,7 @@ const runGit = (cwd: string, args: string[]) => {
 afterEach(async () => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
+  configMocks.loadConfigState.mockResolvedValue({ mergedConfig: {} })
   process.chdir(originalCwd)
   delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
   delete process.env.__VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__
@@ -109,6 +117,97 @@ describe('cli workspace resolution', () => {
         cwd: workspaceDir
       }),
       expect.any(Object)
+    )
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('defaults create runs to bypassPermissions when no CLI flag or config default is set', async () => {
+    const { workspaceDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    process.chdir(workspaceDir)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync(['run', '--print', 'smoke'], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.objectContaining({
+        type: 'create',
+        permissionMode: 'bypassPermissions'
+      })
+    )
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('lets config defaultMode override the CLI built-in permission default for create runs', async () => {
+    const { workspaceDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    configMocks.loadConfigState.mockResolvedValue({
+      mergedConfig: {
+        permissions: {
+          defaultMode: 'plan'
+        }
+      }
+    })
+
+    process.chdir(workspaceDir)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync(['run', '--print', 'smoke'], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.objectContaining({
+        type: 'create',
+        permissionMode: 'plan'
+      })
+    )
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('preserves a config defaultMode of default instead of falling back to bypassPermissions', async () => {
+    const { workspaceDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    configMocks.loadConfigState.mockResolvedValue({
+      mergedConfig: {
+        permissions: {
+          defaultMode: 'default'
+        }
+      }
+    })
+
+    process.chdir(workspaceDir)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync(['run', '--print', 'smoke'], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.objectContaining({
+        type: 'create',
+        permissionMode: 'default'
+      })
     )
 
     logSpy.mockRestore()
@@ -262,6 +361,125 @@ describe('cli workspace resolution', () => {
     const resumed = records.find(record => record.resume?.sessionId === 'session-demo')
     expect(resumed?.resume?.adapterOptions.permissionMode).toBe('bypassPermissions')
     await expect(readCliSessionPermissionRecovery(workspaceDir, 'ctx-demo', 'session-demo')).resolves.toBeUndefined()
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('defaults resumed runs to bypassPermissions when cache and config do not provide a mode', async () => {
+    const { workspaceDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await writeCliSessionRecord(workspaceDir, 'ctx-demo', 'session-demo', {
+      resume: {
+        version: 1,
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        cwd: workspaceDir,
+        description: 'Resume with built-in default permission mode',
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAdapter: 'codex',
+        taskOptions: {
+          adapter: 'codex',
+          cwd: workspaceDir,
+          ctxId: 'ctx-demo'
+        },
+        adapterOptions: {
+          runtime: 'cli',
+          sessionId: 'session-demo',
+          mode: 'direct'
+        },
+        outputFormat: 'text'
+      }
+    })
+
+    process.chdir(workspaceDir)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync([
+      'run',
+      '--resume',
+      'session-demo'
+    ], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.objectContaining({
+        type: 'resume',
+        permissionMode: 'bypassPermissions'
+      })
+    )
+
+    const records = await listCliSessions(workspaceDir)
+    const resumed = records.find(record => record.resume?.sessionId === 'session-demo')
+    expect(resumed?.resume?.adapterOptions.permissionMode).toBe('bypassPermissions')
+
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('keeps the cached resume permission mode ahead of the config default', async () => {
+    const { workspaceDir } = await createWorkspaceFixture()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    configMocks.loadConfigState.mockResolvedValue({
+      mergedConfig: {
+        permissions: {
+          defaultMode: 'bypassPermissions'
+        }
+      }
+    })
+
+    await writeCliSessionRecord(workspaceDir, 'ctx-demo', 'session-demo', {
+      resume: {
+        version: 1,
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        cwd: workspaceDir,
+        description: 'Resume with cached permission mode',
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAdapter: 'codex',
+        taskOptions: {
+          adapter: 'codex',
+          cwd: workspaceDir,
+          ctxId: 'ctx-demo'
+        },
+        adapterOptions: {
+          runtime: 'cli',
+          sessionId: 'session-demo',
+          mode: 'direct',
+          permissionMode: 'plan'
+        },
+        outputFormat: 'text'
+      }
+    })
+
+    process.chdir(workspaceDir)
+
+    const program = new Command()
+    registerRunCommand(program)
+    await program.parseAsync([
+      'run',
+      '--resume',
+      'session-demo'
+    ], { from: 'user' })
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: workspaceDir
+      }),
+      expect.objectContaining({
+        type: 'resume',
+        permissionMode: 'plan'
+      })
+    )
 
     logSpy.mockRestore()
     errorSpy.mockRestore()

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -3,6 +3,10 @@ import { createAdapterOption, normalizeCliAdapterOptionValue } from './@core/ada
 import { registerRunCommand } from './run/command'
 import { parseCliInputControlEvent } from './run/input-control'
 import {
+  CLI_DEFAULT_PERMISSION_MODE,
+  resolveCliPermissionModeFromSources
+} from './run/permission-mode'
+import {
   getDisallowedResumeFlags,
   resolveDefaultVibeForgeMcpServerOption,
   resolveInjectDefaultSystemPromptOption,
@@ -23,6 +27,7 @@ import { RUN_INPUT_FORMATS, RUN_OUTPUT_FORMATS } from './run/types'
 export {
   RUN_INPUT_FORMATS,
   RUN_OUTPUT_FORMATS,
+  CLI_DEFAULT_PERMISSION_MODE,
   createAdapterOption,
   createSessionExitController,
   getAdapterErrorMessage,
@@ -35,6 +40,7 @@ export {
   normalizeCliAdapterOptionValue,
   parseCliInputControlEvent,
   registerRunCommand,
+  resolveCliPermissionModeFromSources,
   resolveDefaultVibeForgeMcpServerOption,
   resolveInjectDefaultSystemPromptOption,
   resolvePrintableStopText,

--- a/apps/cli/src/commands/run/command.ts
+++ b/apps/cli/src/commands/run/command.ts
@@ -47,6 +47,7 @@ import {
   shouldApplyPermissionDecision,
   shouldClearPermissionRecoveryCache
 } from './permission-decision'
+import { resolveCliPermissionModeForWorkspace } from './permission-mode'
 import {
   PERMISSION_DECISION_CANCEL,
   PERMISSION_RECOVERY_CONTINUE_PROMPT,
@@ -123,6 +124,7 @@ Notes:
   --adapter also supports -A and simplified ids like claude / adapter-codex.
   When using --resume, startup-only flags like --adapter, --system-prompt, --spec and --workspace are loaded from cache and cannot be set again.
   --permission-mode is the exception: it overrides the cached permission mode for the resumed run and is saved for later resumes.
+  When omitted, CLI defaults to bypassPermissions. Set general.permissions.defaultMode to override, or use default to restore adapter defaults.
   Resume still allows overriding --model, --effort, --include-tool and --exclude-tool for the next turn.
   The resolved adapter is pinned in cache, so later default adapter changes do not affect resume.
   Default CLI skills shipped via @vibe-forge/plugin-cli-skills: ${getCliDefaultSkillNames().join(', ')}.
@@ -194,9 +196,15 @@ Notes:
         const pendingPermissionRecovery = await readCliSessionPermissionRecovery(cwd, ctxId, sessionId)
         const cachedResumePermissionMode = cachedSession?.resume?.adapterOptions.permissionMode
         const resolvedResumePermissionMode = isResume
-          ? (opts.permissionMode ?? cachedResumePermissionMode)
-          : opts.permissionMode
-        const permissionRecoveryMode = pendingPermissionRecovery?.permissionMode ?? cachedResumePermissionMode
+          ? await resolveCliPermissionModeForWorkspace({
+            cwd: resolvedTaskCwd,
+            cliPermissionMode: opts.permissionMode,
+            cachedPermissionMode: cachedResumePermissionMode
+          })
+          : undefined
+        const permissionRecoveryMode = pendingPermissionRecovery?.permissionMode ??
+          cachedResumePermissionMode ??
+          resolvedResumePermissionMode
         const resumePermissionModeChanged = isResume &&
           opts.permissionMode != null &&
           opts.permissionMode !== permissionRecoveryMode
@@ -316,6 +324,10 @@ Notes:
                 currentCommand.getOptionValueSource('injectDefaultSystemPrompt')
               )
             )
+            const resolvedCreatePermissionMode = await resolveCliPermissionModeForWorkspace({
+              cwd: resolvedTaskCwd,
+              cliPermissionMode: opts.permissionMode
+            })
 
             return {
               type: 'create' as const,
@@ -329,7 +341,7 @@ Notes:
                 userSystemPrompt: opts.systemPrompt,
                 injectDefaultSystemPrompt
               }),
-              permissionMode: opts.permissionMode,
+              permissionMode: resolvedCreatePermissionMode,
               mode: resolveRunMode(
                 opts.print,
                 printSource,

--- a/apps/cli/src/commands/run/permission-mode.ts
+++ b/apps/cli/src/commands/run/permission-mode.ts
@@ -1,0 +1,35 @@
+import { loadConfigState } from '@vibe-forge/config'
+
+import type { RunOptions } from './types'
+
+export const CLI_DEFAULT_PERMISSION_MODE: NonNullable<RunOptions['permissionMode']> = 'bypassPermissions'
+
+export const resolveCliPermissionModeFromSources = (params: {
+  cliPermissionMode?: RunOptions['permissionMode']
+  cachedPermissionMode?: RunOptions['permissionMode']
+  configuredPermissionMode?: RunOptions['permissionMode']
+}) => (
+  params.cliPermissionMode ??
+  params.cachedPermissionMode ??
+  params.configuredPermissionMode ??
+  CLI_DEFAULT_PERMISSION_MODE
+)
+
+export const resolveCliPermissionModeForWorkspace = async (params: {
+  cwd: string
+  cliPermissionMode?: RunOptions['permissionMode']
+  cachedPermissionMode?: RunOptions['permissionMode']
+}) => {
+  if (params.cliPermissionMode != null) {
+    return params.cliPermissionMode
+  }
+
+  if (params.cachedPermissionMode != null) {
+    return params.cachedPermissionMode
+  }
+
+  const { mergedConfig } = await loadConfigState({ cwd: params.cwd })
+  return resolveCliPermissionModeFromSources({
+    configuredPermissionMode: mergedConfig.permissions?.defaultMode
+  })
+}


### PR DESCRIPTION
## Summary
- default `vf` / `vf run` to `bypassPermissions` when `--permission-mode` is omitted
- keep `permissions.defaultMode` as the workspace override, while preserving explicit `default` to restore adapter behavior
- add CLI tests and docs covering create/resume precedence so the behavior applies consistently across CLI-supported code agents

## Testing
- `pnpm exec vitest run apps/cli/__tests__/run.spec.ts apps/cli/__tests__/workspace.spec.ts`
- `pnpm exec eslint apps/cli/src/commands/run/permission-mode.ts apps/cli/src/commands/run.ts apps/cli/src/commands/run/command.ts apps/cli/__tests__/run.spec.ts apps/cli/__tests__/workspace.spec.ts`