### PR TITLE
fix(copilot): correct stop hook block reason

### DIFF
--- a/packages/adapters/copilot/__tests__/hook-bridge.spec.ts
+++ b/packages/adapters/copilot/__tests__/hook-bridge.spec.ts
@@ -157,6 +157,15 @@ describe('copilot native hook bridge helpers', () => {
     })
   })
 
+  it('uses a blocking fallback reason when Stop blocks without a stopReason', () => {
+    expect(mapVibeForgeHookOutputToCopilot('Stop', {
+      continue: false
+    })).toEqual({
+      decision: 'block',
+      reason: 'blocked by Vibe Forge Stop hook'
+    })
+  })
+
   it('limits native hook loader support to events Copilot handles natively here', () => {
     expect(supportsHookEvent('PreToolUse')).toBe(true)
     expect(supportsHookEvent('PostToolUse')).toBe(true)

--- a/packages/adapters/copilot/src/hook-bridge.ts
+++ b/packages/adapters/copilot/src/hook-bridge.ts
@@ -187,7 +187,7 @@ export const mapVibeForgeHookOutputToCopilot = (
       if (output.continue === false) {
         return {
           decision: 'block',
-          reason: blockReason(output.stopReason, 'continue after Vibe Forge Stop hook')
+          reason: blockReason(output.stopReason, 'blocked by Vibe Forge Stop hook')
         }
       }
       return {}


### PR DESCRIPTION
## Summary
- correct Copilot Stop hook fallback reason so blocked decisions no longer say they continue
- add a regression test for Stop blocking without `stopReason`

## Tests
- `npx vitest run packages/adapters/copilot/__tests__/hook-bridge.spec.ts`
- `pnpm exec dprint check packages/adapters/copilot/src/hook-bridge.ts packages/adapters/copilot/__tests__/hook-bridge.spec.ts`
- `pnpm exec eslint packages/adapters/copilot/src/hook-bridge.ts packages/adapters/copilot/__tests__/hook-bridge.spec.ts`
- `git diff --check`
