### PR TITLE
fix(cli): respect forwarded resume command prefix

### DIFF
--- a/apps/cli/__tests__/session-cache.spec.ts
+++ b/apps/cli/__tests__/session-cache.spec.ts
@@ -17,6 +17,7 @@ import {
 
 const tempDirs: string[] = []
 const originalCwd = process.cwd()
+const originalResumeCommandPrefix = process.env.__VF_CLI_RESUME_COMMAND_PREFIX__
 
 const createTempDir = async () => {
   const cwd = await fs.mkdtemp(path.join(tmpdir(), 'vf-session-cache-'))
@@ -28,6 +29,11 @@ afterEach(async () => {
   vi.restoreAllMocks()
   process.chdir(originalCwd)
   delete process.env.__VF_PROJECT_WORKSPACE_FOLDER__
+  if (originalResumeCommandPrefix == null) {
+    delete process.env.__VF_CLI_RESUME_COMMAND_PREFIX__
+  } else {
+    process.env.__VF_CLI_RESUME_COMMAND_PREFIX__ = originalResumeCommandPrefix
+  }
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { force: true, recursive: true })))
 })
 
@@ -78,6 +84,13 @@ describe('session cache utilities', () => {
     expect(resolved.resume?.ctxId).toBe('ctx-alpha')
     expect(resolveCliSessionAdapter(resolved)).toBe('codex')
     expect(formatResumeCommand('session-alpha')).toBe('vf --resume session-alpha')
+  })
+
+  it('uses the forwarded cli resume command prefix when present', () => {
+    process.env.__VF_CLI_RESUME_COMMAND_PREFIX__ = 'npx ai run'
+
+    expect(formatResumeCommand('session-alpha')).toBe('npx ai run --resume session-alpha')
+    expect(formatResumeCommand('session-alpha', 'dyai')).toBe('dyai --resume session-alpha')
   })
 
   it('reports ambiguous prefix matches clearly', async () => {
@@ -236,6 +249,63 @@ describe('list command', () => {
         Kill: 'vf kill session-demo'
       })
     ])
+  })
+
+  it('prints forwarded resume commands in list rows and hints', async () => {
+    const cwd = await createTempDir()
+    const tableSpy = vi.spyOn(console, 'table').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    process.env.__VF_CLI_RESUME_COMMAND_PREFIX__ = 'ai'
+
+    await writeCliSessionRecord(cwd, 'ctx-demo', 'session-demo', {
+      resume: {
+        version: 1,
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        cwd,
+        description: 'Review CLI resume flow',
+        createdAt: 10,
+        updatedAt: 20,
+        resolvedAdapter: 'codex',
+        taskOptions: {
+          adapter: 'codex',
+          cwd,
+          ctxId: 'ctx-demo'
+        },
+        adapterOptions: {
+          runtime: 'cli',
+          sessionId: 'session-demo',
+          mode: 'direct',
+          model: 'gpt-5.4'
+        },
+        outputFormat: 'text'
+      },
+      detail: {
+        ctxId: 'ctx-demo',
+        sessionId: 'session-demo',
+        status: 'completed',
+        startTime: 10,
+        endTime: 20,
+        description: 'Review CLI resume flow',
+        adapter: 'codex',
+        model: 'gpt-5.4'
+      }
+    })
+
+    process.chdir(cwd)
+    const program = new Command()
+    registerListCommand(program)
+    await program.parseAsync(['list', '--view', 'full'], { from: 'user' })
+
+    expect(tableSpy.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({
+        Resume: 'ai --resume session-demo'
+      })
+    ])
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Resume latest: ai --resume session-demo')
+    )
   })
 
   it('supports filtering to running sessions only', async () => {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/cli/src/session-cache.ts
+++ b/apps/cli/src/session-cache.ts
@@ -59,7 +59,13 @@ const getRecordUpdatedAt = (record: CliSessionRecord) =>
 
 const isSessionDirNameMatch = (value: string, target: string) => value === target || value.startsWith(target)
 
-export const formatResumeCommand = (sessionId: string) => `vf --resume ${sessionId}`
+const normalizeResumeCommandPrefix = (prefix: string | undefined) => {
+  const normalizedPrefix = prefix?.trim()
+  return normalizedPrefix == null || normalizedPrefix === '' ? 'vf' : normalizedPrefix
+}
+
+export const formatResumeCommand = (sessionId: string, prefix = process.env.__VF_CLI_RESUME_COMMAND_PREFIX__) =>
+  `${normalizeResumeCommandPrefix(prefix)} --resume ${sessionId}`
 export const formatStopCommand = (sessionId: string) => `vf stop ${sessionId}`
 export const formatKillCommand = (sessionId: string) => `vf kill ${sessionId}`
 export const formatListCommand = (params?: {

--- a/changelog/3.0.1/cli.md
+++ b/changelog/3.0.1/cli.md
@@ -1,0 +1,5 @@
+# @vibe-forge/cli 3.0.1
+
+## Changes
+
+- Respect forwarded CLI resume command prefixes when rendering resume hints and `vf list` helper commands.


### PR DESCRIPTION
## Summary
- respect `__VF_CLI_RESUME_COMMAND_PREFIX__` when rendering CLI resume commands
- make `list --view full` rows and tips show the forwarded outer CLI command
- publish `@vibe-forge/cli@3.0.1` to npm latest

## Verification
- `pnpm exec vitest run apps/cli/__tests__/session-cache.spec.ts apps/cli/__tests__/cli.spec.ts`
- `npm pack --dry-run` in `apps/cli`
- `npm view @vibe-forge/cli version dist-tags --json` -> latest `3.0.1`

Note: release tag `pkg/vibe-forge-cli/v3.0.1` is prepared locally but not pushed before PR merge.