### PR TITLE
fix(register): link git config into mock home

### DIFF
--- a/apps/client/cli.cjs
+++ b/apps/client/cli.cjs
@@ -9,12 +9,14 @@ const {
   resolveProjectAiBaseDir,
   resolveProjectWorkspaceFolder
 } = require('@vibe-forge/register/dotenv')
+const { linkRealHomeGitConfig } = require('@vibe-forge/register/mock-home-git')
 const { startPreviewServer } = require('./preview-server.cjs')
 
 process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
 process.env.__VF_PROJECT_PACKAGE_DIR__ = __dirname
 process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
 process.env.HOME = resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
+linkRealHomeGitConfig()
 
 const cwd = realpathSync(resolve(__dirname, './'))
 const clientMode = (process.env.__VF_PROJECT_AI_CLIENT_MODE__ ?? '').trim().toLowerCase()

--- a/apps/server/src/cli-runtime.ts
+++ b/apps/server/src/cli-runtime.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { resolveProjectAiBaseDir, resolveProjectWorkspaceFolder } from '@vibe-forge/register/dotenv'
+import { linkRealHomeGitConfig } from '@vibe-forge/register/mock-home-git'
 
 const nodeRequire = createRequire(__filename)
 
@@ -121,6 +122,10 @@ export const applyServerRuntimeEnv = (params: ApplyServerRuntimeEnvOptions) => {
   nextEnv.__VF_PROJECT_PACKAGE_DIR__ = params.packageDir
   nextEnv.__VF_PROJECT_REAL_HOME__ = nextEnv.__VF_PROJECT_REAL_HOME__ ?? nextEnv.HOME ?? ''
   nextEnv.HOME = resolve(resolveProjectAiBaseDir(workspaceFolder, nextEnv), '.mock')
+  linkRealHomeGitConfig({
+    realHome: nextEnv.__VF_PROJECT_REAL_HOME__,
+    mockHome: nextEnv.HOME
+  })
 
   return nextEnv
 }

--- a/packages/adapters/codex/__tests__/accounts.spec.ts
+++ b/packages/adapters/codex/__tests__/accounts.spec.ts
@@ -1,0 +1,42 @@
+import { mkdir, mkdtemp, readlink, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { prepareCodexSessionHome } from '#~/runtime/accounts.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('prepareCodexSessionHome', () => {
+  it('links real home git config into the isolated Codex session home', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'vf-codex-session-home-'))
+    const realHome = join(workspace, 'real-home')
+    const mockHome = join(workspace, '.ai', '.mock')
+    tempDirs.push(workspace)
+
+    await mkdir(join(realHome, '.config', 'git'), { recursive: true })
+    await writeFile(join(realHome, '.gitconfig'), '[user]\n\tname = real\n')
+    await writeFile(join(realHome, '.config', 'git', 'config'), '[alias]\n\tco = checkout\n')
+
+    const result = await prepareCodexSessionHome({
+      ctx: {
+        cwd: workspace,
+        env: {
+          HOME: mockHome,
+          __VF_PROJECT_REAL_HOME__: realHome
+        },
+        ctxId: 'ctx',
+        configs: []
+      },
+      sessionId: 'session'
+    })
+
+    expect(await readlink(join(result.homeDir, '.gitconfig'))).toBe(join(realHome, '.gitconfig'))
+    expect(await readlink(join(result.homeDir, '.config', 'git'))).toBe(join(realHome, '.config', 'git'))
+  })
+})

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -83,6 +83,7 @@
     "@vibe-forge/config": "workspace:*",
     "@vibe-forge/core": "workspace:*",
     "@vibe-forge/hooks": "workspace:*",
+    "@vibe-forge/register": "workspace:*",
     "@vibe-forge/types": "workspace:*",
     "@vibe-forge/utils": "workspace:*",
     "zod": "^3.24.1"

--- a/packages/adapters/codex/src/runtime/accounts.ts
+++ b/packages/adapters/codex/src/runtime/accounts.ts
@@ -7,6 +7,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path'
 import process from 'node:process'
 
 import { resolveMockHome } from '@vibe-forge/hooks'
+import { linkRealHomeGitConfig } from '@vibe-forge/register/mock-home-git'
 import type {
   AdapterAccountActionDescriptor,
   AdapterAccountCredentialArtifact,
@@ -1679,6 +1680,10 @@ export const prepareCodexSessionHome = async (params: {
 
   const homeDir = resolveCodexSessionHomeDir(ctx, sessionId)
   await mkdir(join(homeDir, '.codex'), { recursive: true })
+  linkRealHomeGitConfig({
+    realHome: ctx.env.__VF_PROJECT_REAL_HOME__ ?? undefined,
+    mockHome: homeDir
+  })
   await syncSharedCodexSessionHomeFiles(ctx, homeDir)
   await syncSymlinkTarget({
     sourcePath: selectedAccount?.authFilePath ?? join(homeDir, MISSING_AUTH_SENTINEL_FILE),

--- a/packages/cli-helper/__tests__/loader.spec.ts
+++ b/packages/cli-helper/__tests__/loader.spec.ts
@@ -45,9 +45,14 @@ describe('cli-helper loader wrapper', () => {
 
     const nestedCwd = resolve(workspaceDir, 'packages/demo/src')
     const packageDir = resolve(workspaceDir, 'packages/fake-cli')
+    const realHome = await mkdtemp(resolve(tmpdir(), 'vf-cli-helper-real-home-'))
+    tempDirs.push(realHome)
     await mkdir(nestedCwd, { recursive: true })
     await mkdir(packageDir, { recursive: true })
+    await mkdir(resolve(realHome, '.config/git'), { recursive: true })
     await writeFile(resolve(workspaceDir, '.ai.config.json'), '{}\n')
+    await writeFile(resolve(realHome, '.gitconfig'), '[user]\\n\\tname = real\\n')
+    await writeFile(resolve(realHome, '.config/git/config'), '[alias]\\n\\tco = checkout\\n')
     const realWorkspaceDir = await realpath(workspaceDir)
     const entryPath = resolve(process.cwd(), 'packages/cli-helper/entry.js')
     const result = spawnSync(
@@ -68,11 +73,15 @@ Module._load = function(request, parent, isMain) {
   }
 
   if (request === './loader' && parent?.filename === entryPath) {
+    const fs = require('node:fs')
+    const path = require('node:path')
     process.stdout.write(JSON.stringify({
       workspaceFolder: process.env.__VF_PROJECT_WORKSPACE_FOLDER__,
       packageDir: process.env.__VF_PROJECT_PACKAGE_DIR__,
       realHome: process.env.__VF_PROJECT_REAL_HOME__,
       home: process.env.HOME,
+      gitConfigLink: fs.readlinkSync(path.join(process.env.HOME, '.gitconfig')),
+      gitConfigDirLink: fs.readlinkSync(path.join(process.env.HOME, '.config/git')),
       sourceEntry: process.env.__VF_PROJECT_CLI_BIN_SOURCE_ENTRY__,
       distEntry: process.env.__VF_PROJECT_CLI_BIN_DIST_ENTRY__
     }))
@@ -93,7 +102,7 @@ require(entryPath).runCliPackageEntrypoint({
         cwd: nestedCwd,
         env: {
           ...process.env,
-          HOME: '/tmp/original-home'
+          HOME: realHome
         },
         encoding: 'utf8'
       }
@@ -105,8 +114,10 @@ require(entryPath).runCliPackageEntrypoint({
     expect(JSON.parse(result.stdout)).toEqual({
       workspaceFolder: realWorkspaceDir,
       packageDir,
-      realHome: '/tmp/original-home',
+      realHome,
       home: resolve(realWorkspaceDir, '.ai/.mock'),
+      gitConfigLink: resolve(realHome, '.gitconfig'),
+      gitConfigDirLink: resolve(realHome, '.config/git'),
       sourceEntry: './src/custom-cli',
       distEntry: './dist/custom-cli.js'
     })

--- a/packages/cli-helper/entry.js
+++ b/packages/cli-helper/entry.js
@@ -16,11 +16,13 @@ const runCliPackageEntrypoint = (options) => {
     resolveProjectAiBaseDir,
     resolveProjectWorkspaceFolder
   } = require('@vibe-forge/register/dotenv')
+  const { linkRealHomeGitConfig } = require('@vibe-forge/register/mock-home-git')
 
   process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
   process.env.__VF_PROJECT_PACKAGE_DIR__ = packageDir
   process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
   process.env.HOME = path.resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
+  linkRealHomeGitConfig()
   process.env.__VF_PROJECT_CLI_BIN_SOURCE_ENTRY__ = sourceEntry
   process.env.__VF_PROJECT_CLI_BIN_DIST_ENTRY__ = distEntry
 

--- a/packages/hooks/call-hook.js
+++ b/packages/hooks/call-hook.js
@@ -47,10 +47,13 @@ const {
   resolveProjectAiBaseDir,
   resolveProjectWorkspaceFolder
 } = require('@vibe-forge/register/dotenv')
+const { linkRealHomeGitConfig } = require('@vibe-forge/register/mock-home-git')
 
 process.env.__VF_PROJECT_WORKSPACE_FOLDER__ = resolveProjectWorkspaceFolder(process.cwd(), process.env)
 process.env.__VF_PROJECT_PACKAGE_DIR__ = process.env.__VF_PROJECT_PACKAGE_DIR__ ?? __dirname
+process.env.__VF_PROJECT_REAL_HOME__ = process.env.__VF_PROJECT_REAL_HOME__ ?? process.env.HOME ?? ''
 process.env.HOME = path.resolve(resolveProjectAiBaseDir(process.cwd(), process.env), '.mock')
+linkRealHomeGitConfig()
 
 const sourceEntrypoint = path.resolve(__dirname, './src/entry.ts')
 const distEntrypoint = path.resolve(__dirname, './dist/entry.js')

--- a/packages/register/__tests__/mock-home-git.spec.ts
+++ b/packages/register/__tests__/mock-home-git.spec.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, readFile, readlink, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('linkRealHomeGitConfig', () => {
+  it('links real home git config entries into the mock home', async () => {
+    const realHome = await mkdtemp(path.join(os.tmpdir(), 'vf-real-home-'))
+    const mockHome = await mkdtemp(path.join(os.tmpdir(), 'vf-mock-home-'))
+    tempDirs.push(realHome, mockHome)
+
+    await mkdir(path.join(realHome, '.config', 'git'), { recursive: true })
+    await writeFile(path.join(realHome, '.gitconfig'), '[user]\n\tname = real\n')
+    await writeFile(path.join(realHome, '.gitconfig.local'), '[credential]\n\thelper = store\n')
+    await writeFile(path.join(realHome, '.config', 'git', 'config'), '[alias]\n\tco = checkout\n')
+    await writeFile(path.join(realHome, '.git-credentials'), 'https://example.invalid\n')
+
+    const { linkRealHomeGitConfig } = require('../mock-home-git.js') as typeof import('../mock-home-git')
+    linkRealHomeGitConfig({ realHome, mockHome })
+
+    expect(await readlink(path.join(mockHome, '.gitconfig'))).toBe(path.join(realHome, '.gitconfig'))
+    expect(await readlink(path.join(mockHome, '.gitconfig.local'))).toBe(path.join(realHome, '.gitconfig.local'))
+    expect(await readlink(path.join(mockHome, '.config', 'git'))).toBe(path.join(realHome, '.config', 'git'))
+    expect(await readlink(path.join(mockHome, '.git-credentials'))).toBe(path.join(realHome, '.git-credentials'))
+  })
+
+  it('does not overwrite existing mock home git config files', async () => {
+    const realHome = await mkdtemp(path.join(os.tmpdir(), 'vf-real-home-'))
+    const mockHome = await mkdtemp(path.join(os.tmpdir(), 'vf-mock-home-'))
+    tempDirs.push(realHome, mockHome)
+
+    await writeFile(path.join(realHome, '.gitconfig'), '[user]\n\tname = real\n')
+    await writeFile(path.join(mockHome, '.gitconfig'), '[user]\n\tname = mock\n')
+
+    const { linkRealHomeGitConfig } = require('../mock-home-git.js') as typeof import('../mock-home-git')
+    linkRealHomeGitConfig({ realHome, mockHome })
+
+    expect(await readFile(path.join(mockHome, '.gitconfig'), 'utf8')).toBe('[user]\n\tname = mock\n')
+  })
+})

--- a/packages/register/index.d.ts
+++ b/packages/register/index.d.ts
@@ -12,6 +12,15 @@ declare module '@vibe-forge/register/dotenv' {
   export const resolveProjectAiBaseDir: (cwd?: string, env?: NodeJS.ProcessEnv) => string
 }
 
+declare module '@vibe-forge/register/mock-home-git' {
+  export interface LinkRealHomeGitConfigOptions {
+    realHome?: string
+    mockHome?: string
+  }
+
+  export const linkRealHomeGitConfig: (options?: LinkRealHomeGitConfigOptions) => void
+}
+
 declare module '@vibe-forge/register/esbuild' {}
 
 declare module '@vibe-forge/register/preload' {}

--- a/packages/register/mock-home-git.d.ts
+++ b/packages/register/mock-home-git.d.ts
@@ -1,0 +1,6 @@
+export interface LinkRealHomeGitConfigOptions {
+  realHome?: string
+  mockHome?: string
+}
+
+export declare const linkRealHomeGitConfig: (options?: LinkRealHomeGitConfigOptions) => void

--- a/packages/register/mock-home-git.js
+++ b/packages/register/mock-home-git.js
@@ -1,0 +1,76 @@
+const { lstatSync, mkdirSync, readdirSync, statSync, symlinkSync } = require('node:fs')
+const path = require('node:path')
+const process = require('node:process')
+
+const GIT_HOME_ENTRIES = [
+  '.git-credentials',
+  '.git-credential',
+  '.git-credential-cache',
+  path.join('.config', 'git')
+]
+
+const normalizeHome = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : ''
+  return trimmed ? path.resolve(trimmed) : undefined
+}
+
+const pathExistsOrSymlink = (targetPath) => {
+  try {
+    lstatSync(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const resolveSymlinkType = (sourcePath) => {
+  try {
+    const stat = statSync(sourcePath)
+    if (stat.isDirectory()) {
+      return process.platform === 'win32' ? 'junction' : 'dir'
+    }
+  } catch {}
+
+  return 'file'
+}
+
+const collectGitHomeEntries = (realHome) => {
+  const entries = new Set(GIT_HOME_ENTRIES)
+
+  try {
+    for (const entry of readdirSync(realHome)) {
+      if (entry.startsWith('.gitconfig')) {
+        entries.add(entry)
+      }
+    }
+  } catch {}
+
+  return [...entries]
+}
+
+const linkRealHomeGitConfig = (options = {}) => {
+  const realHome = normalizeHome(options.realHome ?? process.env.__VF_PROJECT_REAL_HOME__)
+  const mockHome = normalizeHome(options.mockHome ?? process.env.HOME)
+
+  if (realHome == null || mockHome == null || realHome === mockHome) {
+    return
+  }
+
+  for (const entry of collectGitHomeEntries(realHome)) {
+    const sourcePath = path.join(realHome, entry)
+    const targetPath = path.join(mockHome, entry)
+
+    try {
+      if (!pathExistsOrSymlink(sourcePath) || pathExistsOrSymlink(targetPath)) {
+        continue
+      }
+
+      mkdirSync(path.dirname(targetPath), { recursive: true })
+      symlinkSync(sourcePath, targetPath, resolveSymlinkType(sourcePath))
+    } catch {}
+  }
+}
+
+module.exports = {
+  linkRealHomeGitConfig
+}

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -6,6 +6,10 @@
       "types": "./dotenv.d.ts",
       "default": "./dotenv.js"
     },
+    "./mock-home-git": {
+      "types": "./mock-home-git.d.ts",
+      "default": "./mock-home-git.js"
+    },
     "./esbuild": {
       "types": "./esbuild.d.ts",
       "default": "./esbuild.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@vibe-forge/hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@vibe-forge/register':
+        specifier: workspace:*
+        version: link:../../register
       '@vibe-forge/types':
         specifier: workspace:*
         version: link:../../types


### PR DESCRIPTION
## Summary
- add a register helper that symlinks real HOME Git config files/directories into mock HOME without overwriting existing mock files
- apply the helper to CLI/client/hooks/server startup and Codex isolated session HOME
- cover root mock HOME and Codex session HOME with unit tests

## Verification
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/register/__tests__/mock-home-git.spec.ts packages/cli-helper/__tests__/loader.spec.ts packages/adapters/codex/__tests__/accounts.spec.ts
- pnpm typecheck
- real CLI entry smoke: node apps/cli/cli.js --help with temp HOME and verified .ai/.mock/.gitconfig symlink
- git config smoke: temp mock HOME reads real HOME .gitconfig and .config/git/config