### PR TITLE
chore(release): publish mock home git config fix

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe-forge/client",
   "type": "module",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "imports": {
     "#~/*": [
       "./src/*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vibe Forge server",
   "imports": {
     "#~/*.js": {

--- a/changelog/3.0.1/adapter-codex.md
+++ b/changelog/3.0.1/adapter-codex.md
@@ -1,0 +1,5 @@
+# @vibe-forge/adapter-codex 3.0.1
+
+## Changes
+
+- Link real HOME Git configuration into isolated Codex session homes so Git commands keep user config under mock HOME.

--- a/changelog/3.0.1/cli-helper.md
+++ b/changelog/3.0.1/cli-helper.md
@@ -1,0 +1,5 @@
+# @vibe-forge/cli-helper 3.0.1
+
+## Changes
+
+- Link real HOME Git configuration into the project mock HOME before launching managed CLI entrypoints.

--- a/changelog/3.0.1/client.md
+++ b/changelog/3.0.1/client.md
@@ -1,0 +1,5 @@
+# @vibe-forge/client 3.0.1
+
+## Changes
+
+- Preserve real HOME Git configuration when launching the packaged Vibe Forge client with a mock HOME.

--- a/changelog/3.0.1/hooks.md
+++ b/changelog/3.0.1/hooks.md
@@ -1,0 +1,5 @@
+# @vibe-forge/hooks 3.0.1
+
+## Changes
+
+- Preserve real HOME Git configuration for managed hook processes running under Vibe Forge mock HOME.

--- a/changelog/3.0.1/register.md
+++ b/changelog/3.0.1/register.md
@@ -1,0 +1,5 @@
+# @vibe-forge/register 3.0.1
+
+## Changes
+
+- Add a shared mock-home Git config linker that mirrors real HOME Git configuration into isolated Vibe Forge homes without overwriting project-local mock files.

--- a/changelog/3.0.1/server.md
+++ b/changelog/3.0.1/server.md
@@ -1,0 +1,5 @@
+# @vibe-forge/server 3.0.1
+
+## Changes
+
+- Preserve real HOME Git configuration when server runtime commands switch to Vibe Forge mock HOME.

--- a/changelog/3.0.2/cli.md
+++ b/changelog/3.0.2/cli.md
@@ -1,0 +1,5 @@
+# @vibe-forge/cli 3.0.2
+
+## Changes
+
+- Update packaged dependencies so CLI launches inherit the mock-home Git configuration fix from `@vibe-forge/register` and `@vibe-forge/cli-helper`.

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-codex",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Codex App Server Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/cli-helper/package.json
+++ b/packages/cli-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli-helper",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "exports": {
     ".": "./loader.js",
     "./entry": "./entry.js",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/register",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "exports": {
     "./dotenv": {
       "types": "./dotenv.d.ts",


### PR DESCRIPTION
## Summary
- bump mock-home Git config fix packages for release
- publish @vibe-forge/register, cli-helper, hooks, adapter-codex, client, server to 3.0.1
- publish @vibe-forge/cli to 3.0.2 so installed CLI resolves the fixed helper/register packages

## Verification
- pnpm exec dprint check <changed release files>
- pnpm exec vitest run --workspace vitest.workspace.ts --project bundler packages/register/__tests__/mock-home-git.spec.ts packages/cli-helper/__tests__/loader.spec.ts packages/adapters/codex/__tests__/accounts.spec.ts
- pnpm typecheck
- npm view target packages current versions
- npm pack --dry-run for all target packages