### PR TITLE
fix: scope adapter resume caches

### DIFF
--- a/apps/bootstrap/package-version-refresh-worker.cjs
+++ b/apps/bootstrap/package-version-refresh-worker.cjs
@@ -187,13 +187,19 @@ const writePublishedPackageVersionMetadata = async (packageName, version) => {
   const tempPath = `${metadataPath}.${process.pid}.${Date.now()}.tmp`
   await writeFile(
     tempPath,
-    `${JSON.stringify({
-      lookupKey,
-      packageName,
-      packageTag: resolvePackageTag(),
-      resolvedAt: new Date().toISOString(),
-      version
-    }, null, 2)}\n`,
+    `${
+      JSON.stringify(
+        {
+          lookupKey,
+          packageName,
+          packageTag: resolvePackageTag(),
+          resolvedAt: new Date().toISOString(),
+          version
+        },
+        null,
+        2
+      )
+    }\n`,
     'utf8'
   )
   await rename(tempPath, metadataPath)

--- a/apps/bootstrap/src/npm-package-cache.ts
+++ b/apps/bootstrap/src/npm-package-cache.ts
@@ -120,11 +120,11 @@ export const readPublishedPackageVersionMetadata = async (packageName: string) =
     const content = await readFile(metadataPath, 'utf8')
     const parsed = JSON.parse(content) as Partial<PublishedPackageVersionMetadata>
     if (
-      parsed.lookupKey === lookupKey
-      && parsed.packageName === packageName
-      && parsed.packageTag === resolvePackageTag()
-      && typeof parsed.version === 'string'
-      && parsed.version.trim()
+      parsed.lookupKey === lookupKey &&
+      parsed.packageName === packageName &&
+      parsed.packageTag === resolvePackageTag() &&
+      typeof parsed.version === 'string' &&
+      parsed.version.trim()
     ) {
       return {
         metadataPath,

--- a/apps/server/__tests__/services/session-start.spec.ts
+++ b/apps/server/__tests__/services/session-start.spec.ts
@@ -260,6 +260,38 @@ describe('startAdapterSession', () => {
     expect(mocks.run).toHaveBeenCalledTimes(1)
   })
 
+  it('uses the session id as the adapter cache context when resuming from a parent runtime', async () => {
+    process.env.__VF_PROJECT_AI_CTX_ID__ = 'parent-ctx'
+    const emit = vi.fn()
+    const kill = vi.fn()
+    mocks.run.mockResolvedValueOnce({
+      session: {
+        emit,
+        kill
+      }
+    })
+
+    try {
+      await startAdapterSession('sess-1', {
+        adapter: 'codex',
+        permissionMode: 'default'
+      })
+    } finally {
+      delete process.env.__VF_PROJECT_AI_CTX_ID__
+    }
+
+    expect(mocks.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          __VF_PROJECT_AI_CTX_ID__: 'sess-1'
+        })
+      }),
+      expect.objectContaining({
+        sessionId: 'sess-1'
+      })
+    )
+  })
+
   it('resolves the adapter cwd from the session workspace service', async () => {
     const emit = vi.fn()
     const kill = vi.fn()

--- a/apps/server/src/services/session/index.ts
+++ b/apps/server/src/services/session/index.ts
@@ -446,7 +446,7 @@ export async function startAdapterSession(
         promptCwd
       const env = {
         ...processEnv,
-        __VF_PROJECT_AI_CTX_ID__: processEnv.__VF_PROJECT_AI_CTX_ID__ ?? sessionId,
+        __VF_PROJECT_AI_CTX_ID__: sessionId,
         __VF_PROJECT_WORKSPACE_FOLDER__: adapterCwd,
         __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: primaryWorkspaceFolder
       }

--- a/packages/adapters/claude-code/__tests__/prepare.spec.ts
+++ b/packages/adapters/claude-code/__tests__/prepare.spec.ts
@@ -7,7 +7,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { prepareClaudeExecution } from '../src/claude/prepare'
 
 vi.mock('../src/ccr/paths', () => ({
+  CLAUDE_CODE_CLI_PACKAGE: '@anthropic-ai/claude-code',
+  CLAUDE_CODE_CLI_VERSION: '0.0.0-test',
   resolveClaudeCliPath: vi.fn(() => '/mock/claude')
+}))
+
+vi.mock('@vibe-forge/utils/managed-npm-cli', () => ({
+  ensureManagedNpmCli: vi.fn(async ({ bundledPath }: { bundledPath?: string }) => bundledPath ?? '/mock/claude')
 }))
 
 vi.mock('../src/ccr/daemon', () => ({

--- a/packages/adapters/codex/__tests__/accounts.spec.ts
+++ b/packages/adapters/codex/__tests__/accounts.spec.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
+import type { AdapterCtx } from '@vibe-forge/types'
+
 import { prepareCodexSessionHome } from '#~/runtime/accounts.js'
 
 const tempDirs: string[] = []
@@ -45,14 +47,14 @@ describe('prepareCodexSessionHome', () => {
     const mockHome = join(workspace, '.ai', '.mock')
     tempDirs.push(workspace)
 
-    const ctxBase = {
+    const ctxBase: Pick<AdapterCtx, 'cwd' | 'env' | 'ctxId' | 'configs'> = {
       cwd: workspace,
       env: {
         HOME: mockHome
       },
       ctxId: 'ctx',
       configs: []
-    } as const
+    }
 
     const first = await prepareCodexSessionHome({ ctx: ctxBase, sessionId: 'session-a' })
     const second = await prepareCodexSessionHome({ ctx: ctxBase, sessionId: 'session-b' })

--- a/packages/adapters/codex/__tests__/accounts.spec.ts
+++ b/packages/adapters/codex/__tests__/accounts.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readlink, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readlink, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -38,5 +38,64 @@ describe('prepareCodexSessionHome', () => {
 
     expect(await readlink(join(result.homeDir, '.gitconfig'))).toBe(join(realHome, '.gitconfig'))
     expect(await readlink(join(result.homeDir, '.config', 'git'))).toBe(join(realHome, '.config', 'git'))
+  })
+
+  it('shares Codex session storage across sessionIds via mockHome symlinks so resume can find prior rollouts', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'vf-codex-session-share-'))
+    const mockHome = join(workspace, '.ai', '.mock')
+    tempDirs.push(workspace)
+
+    const ctxBase = {
+      cwd: workspace,
+      env: {
+        HOME: mockHome
+      },
+      ctxId: 'ctx',
+      configs: []
+    } as const
+
+    const first = await prepareCodexSessionHome({ ctx: ctxBase, sessionId: 'session-a' })
+    const second = await prepareCodexSessionHome({ ctx: ctxBase, sessionId: 'session-b' })
+
+    expect(first.homeDir).not.toBe(second.homeDir)
+
+    const expectedSessionsDir = join(mockHome, '.codex', 'sessions')
+
+    expect(await readlink(join(first.homeDir, '.codex', 'sessions'))).toBe(expectedSessionsDir)
+    expect(await readlink(join(second.homeDir, '.codex', 'sessions'))).toBe(expectedSessionsDir)
+
+    const sessionsStat = await stat(expectedSessionsDir)
+    expect(sessionsStat.isDirectory()).toBe(true)
+
+    const rolloutBytes = '{"event":"start"}\n'
+    await writeFile(join(first.homeDir, '.codex', 'sessions', 'rollout.jsonl'), rolloutBytes)
+    expect(await readFile(join(second.homeDir, '.codex', 'sessions', 'rollout.jsonl'), 'utf8')).toBe(rolloutBytes)
+  })
+
+  it('migrates legacy vf-owned Codex rollouts before replacing isolated session storage', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'vf-codex-session-migrate-'))
+    const mockHome = join(workspace, '.ai', '.mock')
+    tempDirs.push(workspace)
+
+    const legacyHome = join(workspace, '.ai', 'caches', 'ctx', 'session-a', 'adapter-codex-home')
+    const legacyRollout = join(legacyHome, '.codex', 'sessions', 'rollout.jsonl')
+    const rolloutBytes = '{"event":"legacy"}\n'
+    await mkdir(join(legacyHome, '.codex', 'sessions'), { recursive: true })
+    await writeFile(legacyRollout, rolloutBytes)
+
+    const result = await prepareCodexSessionHome({
+      ctx: {
+        cwd: workspace,
+        env: {
+          HOME: mockHome
+        },
+        ctxId: 'ctx',
+        configs: []
+      },
+      sessionId: 'session-a'
+    })
+
+    expect(await readFile(join(mockHome, '.codex', 'sessions', 'rollout.jsonl'), 'utf8')).toBe(rolloutBytes)
+    expect(await readlink(join(result.homeDir, '.codex', 'sessions'))).toBe(join(mockHome, '.codex', 'sessions'))
   })
 })

--- a/packages/adapters/codex/src/runtime/accounts.ts
+++ b/packages/adapters/codex/src/runtime/accounts.ts
@@ -2,7 +2,7 @@
 import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { access, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { access, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import process from 'node:process'
 
@@ -131,6 +131,29 @@ const pathExists = async (targetPath: string) => {
     return true
   } catch {
     return false
+  }
+}
+
+const readDirSafe = async (targetPath: string) => {
+  try {
+    return await readdir(targetPath, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+const getDirectoryMtimeMs = async (targetPath: string) => {
+  try {
+    const stats = await lstat(targetPath)
+    return stats.isDirectory() && !stats.isSymbolicLink() ? stats.mtimeMs : undefined
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined
+    }
+    throw error
   }
 }
 
@@ -1623,11 +1646,95 @@ const runCodexLogin = async (params: {
   }
 }
 
-const syncSharedCodexSessionHomeFiles = async (
-  ctx: Pick<AdapterCtx, 'cwd' | 'env'>,
+const copyDirectoryContentsWithoutOverwrite = async (params: {
+  sourceDir: string
+  targetDir: string
+}) => {
+  const sourceDir = resolve(params.sourceDir)
+  const targetDir = resolve(params.targetDir)
+  if (sourceDir === targetDir) return
+
+  const stats = await getDirectoryMtimeMs(sourceDir)
+  if (stats == null) return
+
+  await mkdir(targetDir, { recursive: true })
+  const entries = await readDirSafe(sourceDir)
+  await Promise.all(entries.map(entry =>
+    cp(join(sourceDir, entry.name), join(targetDir, entry.name), {
+      errorOnExist: false,
+      force: false,
+      recursive: true
+    })
+  ))
+}
+
+const resolveLegacyCodexSessionStorageDirs = async (
+  ctx: Pick<AdapterCtx, 'cwd' | 'env' | 'ctxId'>,
+  sessionId: string
+) => {
+  const cacheRoot = resolveProjectAiPath(ctx.cwd, ctx.env, 'caches')
+  const entries = await readDirSafe(cacheRoot)
+  const candidates: Array<{ mtimeMs: number; sourceDir: string }> = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === ctx.ctxId) continue
+
+    const sourceDir = resolveProjectAiPath(
+      ctx.cwd,
+      ctx.env,
+      'caches',
+      entry.name,
+      sessionId,
+      'adapter-codex-home',
+      '.codex',
+      'sessions'
+    )
+    const mtimeMs = await getDirectoryMtimeMs(sourceDir)
+    if (mtimeMs != null) {
+      candidates.push({ mtimeMs, sourceDir })
+    }
+  }
+
+  return candidates
+    .sort((left, right) => right.mtimeMs - left.mtimeMs || left.sourceDir.localeCompare(right.sourceDir))
+    .map(candidate => candidate.sourceDir)
+}
+
+const migrateCodexSessionStorageToMockHome = async (params: {
+  ctx: Pick<AdapterCtx, 'cwd' | 'env' | 'ctxId'>
   homeDir: string
+  sessionId: string
+  targetDir: string
+}) => {
+  await copyDirectoryContentsWithoutOverwrite({
+    sourceDir: join(params.homeDir, '.codex', 'sessions'),
+    targetDir: params.targetDir
+  })
+
+  const legacyDirs = await resolveLegacyCodexSessionStorageDirs(params.ctx, params.sessionId)
+  for (const sourceDir of legacyDirs) {
+    await copyDirectoryContentsWithoutOverwrite({
+      sourceDir,
+      targetDir: params.targetDir
+    })
+  }
+}
+
+const syncSharedCodexSessionHomeFiles = async (
+  ctx: Pick<AdapterCtx, 'cwd' | 'env' | 'ctxId'>,
+  homeDir: string,
+  sessionId: string
 ) => {
   const mockHome = resolveMockHome(ctx.cwd, ctx.env)
+  const sharedSessionsDir = join(mockHome, '.codex', 'sessions')
+  await mkdir(sharedSessionsDir, { recursive: true })
+  await migrateCodexSessionStorageToMockHome({
+    ctx,
+    homeDir,
+    sessionId,
+    targetDir: sharedSessionsDir
+  })
+
   const sharedMappings: Array<{ sourcePath: string; targetPath: string; type: 'dir' | 'file' }> = [
     {
       sourcePath: join(mockHome, '.agents', 'skills'),
@@ -1637,6 +1744,11 @@ const syncSharedCodexSessionHomeFiles = async (
     {
       sourcePath: join(mockHome, '.codex', 'skills'),
       targetPath: join(homeDir, '.codex', 'skills'),
+      type: 'dir'
+    },
+    {
+      sourcePath: sharedSessionsDir,
+      targetPath: join(homeDir, '.codex', 'sessions'),
       type: 'dir'
     },
     {
@@ -1684,7 +1796,7 @@ export const prepareCodexSessionHome = async (params: {
     realHome: ctx.env.__VF_PROJECT_REAL_HOME__ ?? undefined,
     mockHome: homeDir
   })
-  await syncSharedCodexSessionHomeFiles(ctx, homeDir)
+  await syncSharedCodexSessionHomeFiles(ctx, homeDir, sessionId)
   await syncSymlinkTarget({
     sourcePath: selectedAccount?.authFilePath ?? join(homeDir, MISSING_AUTH_SENTINEL_FILE),
     targetPath: join(homeDir, '.codex', 'auth.json'),

--- a/packages/adapters/kimi/__tests__/runtime-config.spec.ts
+++ b/packages/adapters/kimi/__tests__/runtime-config.spec.ts
@@ -270,6 +270,7 @@ describe('kimi runtime helpers', () => {
       await chmod(fakePathBinary, 0o755)
 
       ctx.env.PATH = `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`
+      ctx.env.__VF_PROJECT_AI_ADAPTER_KIMI_AUTO_INSTALL__ = 'false'
 
       await initKimiAdapter(ctx)
 
@@ -373,6 +374,51 @@ exit 2
         model: 'gpt-5',
         max_context_size: 123456
       })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('migrates legacy Kimi share sessions only from the adapter-kimi path', async () => {
+    const { ctx, cleanup } = await createCtx()
+    try {
+      const sessionId = 'session-kimi-resume'
+      const legacySessionsDir = join(
+        ctx.cwd,
+        '.ai',
+        'caches',
+        'legacy-ctx',
+        sessionId,
+        'adapter-kimi',
+        'share',
+        'sessions'
+      )
+      const otherAdapterSessionsDir = join(
+        ctx.cwd,
+        '.ai',
+        'caches',
+        'legacy-ctx',
+        sessionId,
+        'adapter-gemini',
+        'share',
+        'sessions'
+      )
+      await mkdir(legacySessionsDir, { recursive: true })
+      await mkdir(otherAdapterSessionsDir, { recursive: true })
+      await writeFile(join(legacySessionsDir, 'kimi-session.json'), '{"id":"kimi-native"}\n', 'utf8')
+      await writeFile(join(otherAdapterSessionsDir, 'gemini-session.json'), '{"id":"gemini-native"}\n', 'utf8')
+
+      const base = await resolveKimiSessionBase(ctx, {
+        type: 'resume',
+        runtime: 'server',
+        sessionId,
+        onEvent: () => {}
+      })
+
+      await expect(readFile(join(base.shareDir, 'sessions', 'kimi-session.json'), 'utf8')).resolves.toContain(
+        'kimi-native'
+      )
+      await expect(readFile(join(base.shareDir, 'sessions', 'gemini-session.json'), 'utf8')).rejects.toThrow()
     } finally {
       await cleanup()
     }

--- a/packages/adapters/kimi/src/runtime/config.ts
+++ b/packages/adapters/kimi/src/runtime/config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 
 import { accessSync, constants } from 'node:fs'
-import { copyFile, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
@@ -58,6 +58,25 @@ const pathExists = (targetPath: string) => {
     return true
   } catch {
     return false
+  }
+}
+
+const readDirSafe = async (targetPath: string) => {
+  try {
+    return await readdir(targetPath, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+const getOwnedDirectoryMtimeMs = async (targetPath: string) => {
+  try {
+    const stats = await lstat(targetPath)
+    return stats.isDirectory() && !stats.isSymbolicLink() ? stats.mtimeMs : undefined
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
   }
 }
 
@@ -386,6 +405,47 @@ const stageSkillOverlays = async (sessionRoot: string, options: AdapterQueryOpti
   return skillsDir
 }
 
+const restoreLegacyKimiSessionState = async (params: {
+  ctx: AdapterCtx
+  sessionId: string
+  shareDir: string
+}) => {
+  const currentSessionsDir = resolve(params.shareDir, 'sessions')
+  if (pathExists(currentSessionsDir)) return
+
+  const cacheRoot = resolve(params.ctx.cwd, '.ai', 'caches')
+  const entries = await readDirSafe(cacheRoot)
+  const candidates: Array<{ mtimeMs: number; sourceDir: string }> = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === params.ctx.ctxId) continue
+
+    const sourceDir = resolve(
+      cacheRoot,
+      entry.name,
+      params.sessionId,
+      'adapter-kimi',
+      'share',
+      'sessions'
+    )
+    const mtimeMs = await getOwnedDirectoryMtimeMs(sourceDir)
+    if (mtimeMs != null) {
+      candidates.push({ mtimeMs, sourceDir })
+    }
+  }
+
+  const sourceDir = candidates.sort((left, right) =>
+    right.mtimeMs - left.mtimeMs || left.sourceDir.localeCompare(right.sourceDir)
+  )[0]?.sourceDir
+  if (sourceDir == null) return
+
+  await cp(sourceDir, currentSessionsDir, {
+    errorOnExist: false,
+    force: false,
+    recursive: true
+  })
+}
+
 export const hasStoredKimiSessionState = (shareDir: string) => pathExists(resolve(shareDir, 'sessions'))
 
 export const resolveKimiSessionBase = async (
@@ -399,6 +459,7 @@ export const resolveKimiSessionBase = async (
 
   await mkdir(shareDir, { recursive: true })
   await ensureCredentialsLink(shareDir, realShareDir)
+  await restoreLegacyKimiSessionState({ ctx, sessionId: options.sessionId, shareDir })
 
   const copiedConfigPath = await resolveCopiedConfigPath(shareDir, realShareDir)
   const nativeHookState = resolveKimiNativeHookState(ctx)

--- a/packages/mcp/__tests__/task-manager.spec.ts
+++ b/packages/mcp/__tests__/task-manager.spec.ts
@@ -197,6 +197,40 @@ describe('taskManager fatal error scenarios', () => {
     }))
   })
 
+  it('uses the task id as the adapter cache context instead of an inherited parent context', async () => {
+    process.env.__VF_PROJECT_AI_CTX_ID__ = 'parent-ctx'
+    const { TaskManager } = await import('#~/tools/task/manager.js')
+
+    mocks.run.mockResolvedValueOnce({
+      session: {
+        emit: vi.fn(),
+        kill: vi.fn()
+      }
+    })
+
+    try {
+      const managedTaskManager = new TaskManager()
+      await managedTaskManager.startTask({
+        taskId: 'task-stable-context',
+        description: 'trigger',
+        adapter: 'codex'
+      })
+    } finally {
+      delete process.env.__VF_PROJECT_AI_CTX_ID__
+    }
+
+    expect(mocks.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          __VF_PROJECT_AI_CTX_ID__: 'task-stable-context'
+        })
+      }),
+      expect.objectContaining({
+        sessionId: 'task-stable-context'
+      })
+    )
+  })
+
   it('responds to pending interactions and syncs the response', async () => {
     const { TaskManager } = await import('#~/tools/task/manager.js')
     const respondInteraction = vi.fn()

--- a/packages/mcp/src/tools/task/manager.ts
+++ b/packages/mcp/src/tools/task/manager.ts
@@ -342,7 +342,7 @@ export class TaskManager {
       task.workspaceCwd = resolvedConfig.workspace?.cwd
       const env = {
         ...process.env,
-        __VF_PROJECT_AI_CTX_ID__: process.env.__VF_PROJECT_AI_CTX_ID__ ?? task.taskId,
+        __VF_PROJECT_AI_CTX_ID__: task.taskId,
         __VF_PROJECT_WORKSPACE_FOLDER__: taskCwd,
         __VF_PROJECT_PRIMARY_WORKSPACE_FOLDER__: rootCwd
       }
@@ -355,7 +355,7 @@ export class TaskManager {
       }, env)
 
       const injectDefaultSystemPrompt = await loadInjectDefaultSystemPromptValue(taskCwd)
-      const ctxId = process.env.__VF_PROJECT_AI_CTX_ID__ ?? task.taskId
+      const ctxId = task.taskId
       const { session, resolvedAdapter } = await run({
         adapter: task.adapter,
         cwd: taskCwd,

--- a/packages/task/__tests__/prepare.spec.ts
+++ b/packages/task/__tests__/prepare.spec.ts
@@ -119,6 +119,25 @@ describe('prepare', () => {
     expect(ctx.env.__VF_PROJECT_AI_ENABLE_BUILTIN_PERMISSION_HOOKS__).toBe('1')
   })
 
+  it('reads adapter resume cache through same-key legacy fallback only', async () => {
+    const { prepare } = await import('#~/prepare.js')
+
+    const [ctx] = await prepare({
+      cwd: '/tmp/project',
+      ctxId: 'session-1',
+      env: {}
+    }, {
+      type: 'resume',
+      runtime: 'server',
+      sessionId: 'session-1',
+      onEvent: vi.fn()
+    } as any)
+
+    await ctx.cache.set('adapter.gemini.session', { geminiSessionId: 'gemini-native' })
+
+    await expect(ctx.cache.get('adapter.codex.threads')).resolves.toBeUndefined()
+  })
+
   it('syncs declared marketplace plugins before resolving workspace assets on create', async () => {
     const { prepare } = await import('#~/prepare.js')
     const marketplaces = {

--- a/packages/task/src/prepare.ts
+++ b/packages/task/src/prepare.ts
@@ -8,7 +8,7 @@ import {
 } from '@vibe-forge/config'
 import { syncConfiguredMarketplacePlugins } from '@vibe-forge/managed-plugins'
 import type { AdapterCtx, AdapterQueryOptions } from '@vibe-forge/types'
-import { getCache, setCache } from '@vibe-forge/utils/cache'
+import { getCacheWithLegacyFallback, setCache } from '@vibe-forge/utils/cache'
 import { createLogger } from '@vibe-forge/utils/create-logger'
 import { resolveServerLogLevel } from '@vibe-forge/utils/log-level'
 import { uuid } from '@vibe-forge/utils/uuid'
@@ -103,7 +103,7 @@ export const prepare = async (
       env,
       cache: {
         set: (key, value) => setCache(cwd, ctxId, sessionId, key, value),
-        get: (key) => getCache(cwd, ctxId, sessionId, key)
+        get: (key) => getCacheWithLegacyFallback(cwd, ctxId, sessionId, key)
       },
       logger,
       configs: [config, userConfig],

--- a/packages/utils/__tests__/cache.spec.ts
+++ b/packages/utils/__tests__/cache.spec.ts
@@ -4,8 +4,45 @@ import { dirname, join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import '../../adapters/claude-code/src/adapter-config.js'
 import '../../adapters/codex/src/adapter-config.js'
-import { getCache, getCachePath, setCache } from '#~/cache.js'
+import '../../adapters/copilot/src/adapter-config.js'
+import '../../adapters/gemini/src/adapter-config.js'
+import '../../adapters/opencode/src/adapter-config.js'
+import { getCache, getCachePath, getCacheWithLegacyFallback, setCache } from '#~/cache.js'
+
+const adapterResumeFixtures = [
+  {
+    key: 'adapter.codex.threads',
+    value: { 'context:codex': 'thr_legacy' },
+    otherKey: 'adapter.gemini.session',
+    otherValue: { geminiSessionId: 'gemini-native' }
+  },
+  {
+    key: 'adapter.claude-code.resume-state',
+    value: { canResume: true },
+    otherKey: 'adapter.codex.threads',
+    otherValue: { 'context:codex': 'thr_other_adapter' }
+  },
+  {
+    key: 'adapter.copilot.session',
+    value: { copilotSessionId: 'copilot-native' },
+    otherKey: 'adapter.claude-code.resume-state',
+    otherValue: { canResume: true }
+  },
+  {
+    key: 'adapter.gemini.session',
+    value: { geminiSessionId: 'gemini-native' },
+    otherKey: 'adapter.copilot.session',
+    otherValue: { copilotSessionId: 'copilot-native' }
+  },
+  {
+    key: 'adapter.opencode.session',
+    value: { opencodeSessionId: 'opencode-native', title: 'Vibe Forge:session-1' },
+    otherKey: 'adapter.gemini.session',
+    otherValue: { geminiSessionId: 'gemini-other' }
+  }
+] as const
 
 describe('cache utils', () => {
   const tempDirs: string[] = []
@@ -73,4 +110,35 @@ describe('cache utils', () => {
       })
     )
   })
+
+  it.each(adapterResumeFixtures)(
+    'restores $key from a legacy context for the same session and key',
+    async ({ key, value }) => {
+      const cwd = await mkdtemp(join(tmpdir(), 'vf-cache-'))
+      tempDirs.push(cwd)
+
+      await setCache(cwd, 'legacy-ctx', 'session-1', key, value)
+
+      const result = await getCacheWithLegacyFallback(cwd, 'session-1', 'session-1', key)
+
+      expect(result).toEqual(value)
+      await expect(getCache(cwd, 'session-1', 'session-1', key)).resolves.toEqual(value)
+    }
+  )
+
+  it.each(adapterResumeFixtures)(
+    'does not restore $key from another adapter key or another session',
+    async ({ key, otherKey, otherValue }) => {
+      const cwd = await mkdtemp(join(tmpdir(), 'vf-cache-'))
+      tempDirs.push(cwd)
+
+      await setCache(cwd, 'legacy-ctx', 'session-1', otherKey, otherValue)
+      await setCache(cwd, 'legacy-ctx', 'session-2', key, otherValue as never)
+
+      const result = await getCacheWithLegacyFallback(cwd, 'session-1', 'session-1', key)
+
+      expect(result).toBeUndefined()
+      await expect(getCache(cwd, 'session-1', 'session-1', key)).resolves.toBeUndefined()
+    }
+  )
 })

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -7,6 +7,14 @@ import type { Cache } from '@vibe-forge/types'
 
 import { resolveProjectAiPath } from './ai-path'
 
+const ADAPTER_RESUME_CACHE_KEYS = new Set<string>([
+  'adapter.codex.threads',
+  'adapter.claude-code.resume-state',
+  'adapter.copilot.session',
+  'adapter.gemini.session',
+  'adapter.opencode.session'
+])
+
 export const getCachePath = (
   cwd: string,
   taskId: string,
@@ -69,4 +77,61 @@ export const getCache = async <K extends keyof Cache>(
     }
     throw error
   }
+}
+
+const readDirSafe = async (targetPath: string) => {
+  try {
+    return await fs.readdir(targetPath, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+export const getCacheWithLegacyFallback = async <K extends keyof Cache>(
+  cwd: string,
+  taskId: string,
+  sessionId: string | undefined,
+  key: K
+): Promise<Cache[K] | undefined> => {
+  const current = await getCache(cwd, taskId, sessionId, key)
+  if (current !== undefined || sessionId == null || !ADAPTER_RESUME_CACHE_KEYS.has(String(key))) {
+    return current
+  }
+
+  const cacheRoot = resolveProjectAiPath(cwd, process.env, 'caches')
+  const ctxEntries = await readDirSafe(cacheRoot)
+  const candidates: Array<{ ctxId: string; mtimeMs: number; value: Cache[K] }> = []
+
+  for (const ctxEntry of ctxEntries) {
+    if (!ctxEntry.isDirectory() || ctxEntry.name === taskId) continue
+
+    const legacyPath = getCachePath(cwd, ctxEntry.name, sessionId, key)
+    let mtimeMs = 0
+    try {
+      mtimeMs = (await fs.stat(legacyPath)).mtimeMs
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue
+      }
+      throw error
+    }
+
+    const value = await getCache(cwd, ctxEntry.name, sessionId, key)
+    if (value !== undefined) {
+      candidates.push({ ctxId: ctxEntry.name, mtimeMs, value })
+    }
+  }
+
+  const legacy = candidates.sort((left, right) =>
+    right.mtimeMs - left.mtimeMs || left.ctxId.localeCompare(right.ctxId)
+  )[0]?.value
+  if (legacy === undefined) {
+    return undefined
+  }
+
+  await setCache(cwd, taskId, sessionId, key, legacy)
+  return legacy
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,9 +440,6 @@ importers:
       '@vibe-forge/hooks':
         specifier: workspace:*
         version: link:../../hooks
-      '@vibe-forge/register':
-        specifier: workspace:*
-        version: link:../../register
       '@vibe-forge/types':
         specifier: workspace:*
         version: link:../../types
@@ -464,6 +461,9 @@ importers:
       '@vibe-forge/hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@vibe-forge/register':
+        specifier: workspace:*
+        version: link:../../register
       '@vibe-forge/types':
         specifier: workspace:*
         version: link:../../types


### PR DESCRIPTION
## Summary
- Scope adapter resume cache fallback to the same VF session id and the same adapter-owned cache key.
- Stabilize server/MCP adapter cache contexts on VF session/task ids instead of inheriting an outer native runtime ctx id.
- Preserve VF-owned Codex and Kimi native session state by migrating only their adapter-specific legacy paths.

## Verification
- `pnpm exec vitest run packages/adapters/codex/__tests__/session-rpc.spec.ts packages/adapters/claude-code/__tests__/prepare.spec.ts packages/adapters/copilot/__tests__/session-runtime-stream.spec.ts packages/adapters/gemini/__tests__/session.spec.ts packages/adapters/opencode/__tests__/session-runtime-stream.spec.ts packages/adapters/kimi/__tests__/runtime-config.spec.ts`
- `pnpm exec vitest run apps/server/__tests__/services/session-start.spec.ts packages/mcp/__tests__/task-tool.spec.ts`
- `pnpm exec vitest run packages/utils/__tests__/cache.spec.ts packages/task/__tests__/prepare.spec.ts packages/adapters/codex/__tests__/accounts.spec.ts packages/adapters/kimi/__tests__/runtime-config.spec.ts apps/server/__tests__/services/session-start.spec.ts packages/mcp/__tests__/task-manager.spec.ts packages/mcp/__tests__/task-tool.spec.ts`
- `pnpm exec vitest run apps/cli/__tests__/run.spec.ts apps/cli/__tests__/workspace.spec.ts apps/cli/__tests__/session-cache.spec.ts`
- `pnpm exec eslint`
- `pnpm exec dprint check <modified files>`

Note: full `pnpm exec dprint check` still reports unrelated pre-existing formatting diffs in `apps/bootstrap/package-version-refresh-worker.cjs` and `apps/bootstrap/src/npm-package-cache.ts`.