### PR TITLE
fix(codex): dedupe managed root config keys

### DIFF
--- a/packages/adapters/codex/__tests__/init.spec.ts
+++ b/packages/adapters/codex/__tests__/init.spec.ts
@@ -313,6 +313,143 @@ describe('initCodexAdapter', () => {
     expect(configContent).not.toContain('/tmp/old-workspace')
   })
 
+  it('removes a stale unmanaged update-check key before writing the managed root block', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        'check_for_update_on_startup = true',
+        '',
+        '[notice]',
+        'hide_full_access_warning = true',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain('model = "gpt-5.4"')
+    expect(configContent).toContain('[notice]')
+    expect(configContent).toContain('hide_full_access_warning = true')
+    expect(configContent).toContain('check_for_update_on_startup = false')
+    expect(configContent.match(/^check_for_update_on_startup\s*=/gm)).toHaveLength(1)
+  })
+
+  it('does not remove managed-root-key-shaped text inside a root multiline string', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const rootPromptBlock = [
+      'developer_instructions = """',
+      'check_for_update_on_startup = true',
+      'keep this as prompt text',
+      '"""'
+    ].join('\n')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        rootPromptBlock,
+        '',
+        '[notice]',
+        'hide_full_access_warning = true',
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain(rootPromptBlock)
+    expect(configContent).toContain('check_for_update_on_startup = false')
+  })
+
+  it('does not remove managed root keys from TOML tables', async () => {
+    const workspace = await createWorkspace()
+    const mockHome = join(workspace, '.ai', '.mock')
+    const realHome = join(workspace, 'real-home')
+    const configPath = join(mockHome, '.codex', 'config.toml')
+    const noticeBlock = [
+      '[notice]',
+      'check_for_update_on_startup = true',
+      'hide_full_access_warning = true'
+    ].join('\n')
+
+    await mkdir(join(realHome, '.codex'), { recursive: true })
+    await mkdir(dirname(configPath), { recursive: true })
+    await writeFile(
+      configPath,
+      [
+        'model = "gpt-5.4"',
+        '',
+        noticeBlock,
+        ''
+      ].join('\n')
+    )
+
+    await initCodexAdapter({
+      cwd: workspace,
+      env: {
+        HOME: mockHome,
+        __VF_PROJECT_REAL_HOME__: realHome
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+      },
+      assets: {
+        hookPlugins: []
+      }
+    } as any)
+
+    const configContent = await readFile(configPath, 'utf8')
+    expect(configContent).toContain('check_for_update_on_startup = false')
+    expect(configContent).toContain(noticeBlock)
+  })
+
   it('removes stale unmanaged workspace trust blocks before writing the managed block', async () => {
     const workspace = await createWorkspace()
     const mockHome = join(workspace, '.ai', '.mock')

--- a/packages/adapters/codex/src/runtime/config.ts
+++ b/packages/adapters/codex/src/runtime/config.ts
@@ -318,6 +318,56 @@ const isManagedProjectMarkerLine = (line: string) => {
     trimmedLine === MANAGED_PROJECT_BLOCK_END
 }
 
+const getTomlRootAssignmentKey = (line: string) => {
+  const key = /^\s*([\w-]+(?:\s*\.\s*[\w-]+)*)\s*=/.exec(line)?.[1]
+  return key?.replaceAll(/\s*\.\s*/g, '.')
+}
+
+const getTomlRootAssignmentKeys = (content: string) => {
+  const scan = scanTomlSections(content)
+  const rootSection = scan.sections.find(section => section.header == null)
+  const keys = new Set<string>()
+  if (rootSection == null) return keys
+
+  for (let lineIndex = rootSection.startLine; lineIndex < rootSection.endLine; lineIndex += 1) {
+    const line = scan.lines[lineIndex]
+    const key = line?.stringStateBefore === 'none'
+      ? getTomlRootAssignmentKey(line.text)
+      : undefined
+    if (key != null) {
+      keys.add(key)
+    }
+  }
+
+  return keys
+}
+
+const removeUnmanagedRootConfigKeyLines = (content: string, managedRootConfigKeys: ReadonlySet<string>) => {
+  if (managedRootConfigKeys.size === 0) return content
+
+  const scan = scanTomlSections(content)
+  const rootSection = scan.sections.find(section => section.header == null)
+  if (rootSection == null) return content
+
+  const skippedLineNumbers = new Set<number>()
+  for (let lineIndex = rootSection.startLine; lineIndex < rootSection.endLine; lineIndex += 1) {
+    const line = scan.lines[lineIndex]
+    const key = line?.stringStateBefore === 'none'
+      ? getTomlRootAssignmentKey(line.text)
+      : undefined
+    if (key != null && managedRootConfigKeys.has(key)) {
+      skippedLineNumbers.add(lineIndex)
+    }
+  }
+
+  if (skippedLineNumbers.size === 0) return content
+
+  return scan.lines
+    .filter((_, lineIndex) => !skippedLineNumbers.has(lineIndex))
+    .map(line => line.text)
+    .join('\n')
+}
+
 const getSectionLineEntries = (section: TomlSection, lines: TomlLine[]) =>
   lines.slice(section.startLine, section.endLine)
 
@@ -476,13 +526,17 @@ const upsertManagedRootBlock = (params: {
   currentContent: string
   checkForUpdateOnStartup: unknown
 }) => {
-  const strippedContent = normalizeTomlContent(params.currentContent)
-    .replace(MANAGED_ROOT_BLOCK_PATTERN, '')
-    .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
-    .trim()
   const managedBlock = buildManagedCodexRootBlock({
     checkForUpdateOnStartup: params.checkForUpdateOnStartup
   })
+  const strippedManagedContent = normalizeTomlContent(params.currentContent)
+    .replace(MANAGED_ROOT_BLOCK_PATTERN, '')
+    .replace(LEGACY_MANAGED_CONFIG_BLOCK_PATTERN, '')
+    .trim()
+  const strippedContent = removeUnmanagedRootConfigKeyLines(
+    strippedManagedContent,
+    getTomlRootAssignmentKeys(managedBlock)
+  ).trim()
   const scan = scanTomlSections(strippedContent)
   const firstTableSection = scan.sections.find(section => section.header != null)
   const managedProjectPreambleLineIndex = findManagedProjectPreambleStartLine(scan.lines)


### PR DESCRIPTION
## Summary
- Dedupe stale root-level Codex config keys based on the managed root block that Vibe Forge writes
- Preserve matching text inside multiline strings and matching keys inside TOML tables
- Add regression coverage for stale `check_for_update_on_startup` duplicates

## Test Plan
- `pnpm exec vitest run packages/adapters/codex/__tests__/init.spec.ts`
- `pnpm exec eslint packages/adapters/codex/src/runtime/config.ts packages/adapters/codex/__tests__/init.spec.ts`
- `pnpm exec dprint check packages/adapters/codex/src/runtime/config.ts packages/adapters/codex/__tests__/init.spec.ts`
- `git diff --check`