### PR TITLE
chore(release): prepare vibe forge 3.1.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Vibe Forge server",
   "imports": {
     "#~/*.js": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/web",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Vibe Forge integrated web app",
   "vibeForge": {
     "runtimeTranspile": true

--- a/changelog/3.1.0/readme.md
+++ b/changelog/3.1.0/readme.md
@@ -1,0 +1,13 @@
+# VibeForge 3.1.0
+
+## Changes
+
+- Add config support for disabling automatic skill dependency downloads, covering config parsing, workspace asset resolution, and task preparation.
+- Scope adapter resume caches by task/session context to avoid cross-task resume state reuse in CLI, MCP, and server runtime paths.
+- Deduplicate Codex managed root config keys before writing generated runtime config.
+- Update Kimi adapter metadata to use the official cropped icon.
+
+## Release Scope
+
+- Publish runtime/config packages that changed directly: `@vibe-forge/types`, `@vibe-forge/utils`, `@vibe-forge/core`, `@vibe-forge/config`, `@vibe-forge/workspace-assets`, `@vibe-forge/task`, `@vibe-forge/mcp`, `@vibe-forge/server`, `@vibe-forge/adapter-codex`, and `@vibe-forge/adapter-kimi`.
+- Publish runtime entrypoints and adapter/plugin dependency closure on the same `3.1.0` line so installed CLI, server, web, adapter, and plugin packages resolve a coherent internal runtime set.

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-claude-code",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Claude Code Adapter for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-codex",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Codex App Server Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-copilot",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "GitHub Copilot CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/gemini/package.json
+++ b/packages/adapters/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-gemini",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Gemini CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/kimi/package.json
+++ b/packages/adapters/kimi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-kimi",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Kimi CLI Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/adapter-opencode",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "OpenCode Adapter for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/app-runtime",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "App-facing runtime facade for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/benchmark",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Benchmark discovery and execution for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/channels/lark/package.json
+++ b/packages/channels/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/channel-lark",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared config IO for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/core",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/definition-core/package.json
+++ b/packages/definition-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-core",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared definition-domain helpers for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/definition-loader/package.json
+++ b/packages/definition-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/definition-loader",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared definition loading utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/managed-plugins/package.json
+++ b/packages/managed-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/managed-plugins",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Managed native plugin installation and sync for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Vibe Forge MCP server",
   "imports": {
     "#~/*.js": {

--- a/packages/plugins/chrome-devtools/package.json
+++ b/packages/plugins/chrome-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-chrome-devtools",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/plugins/logger/package.json
+++ b/packages/plugins/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/plugin-logger",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/task",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Task runtime for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/types",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared types for Vibe Forge",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/utils",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared runtime utilities for Vibe Forge",
   "imports": {
     "#~/*.js": {

--- a/packages/workspace-assets/package.json
+++ b/packages/workspace-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/workspace-assets",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Workspace asset resolution and adapter asset planning for Vibe Forge",
   "imports": {
     "#~/*.js": {


### PR DESCRIPTION
## Summary\n- release VibeForge runtime/config/adapters/plugins/entrypoints as 3.1.0\n- document skill dependency download config, scoped adapter resume caches, Codex config dedupe, and Kimi icon update\n\n## Verification\n- pnpm exec vitest run packages/config/__tests__/merge.spec.ts packages/workspace-assets/__tests__/skill-dependencies-cli.spec.ts packages/task/__tests__/prepare.spec.ts packages/mcp/__tests__/task-manager.spec.ts apps/server/__tests__/services/session-start.spec.ts packages/adapters/codex/__tests__/accounts.spec.ts packages/adapters/codex/__tests__/init.spec.ts packages/adapters/kimi/__tests__/runtime-config.spec.ts packages/utils/__tests__/cache.spec.ts\n- pnpm typecheck\n- pnpm exec dprint check changelog/3.1.0/readme.md apps/cli/package.json apps/server/package.json apps/web/package.json packages/types/package.json packages/utils/package.json packages/core/package.json packages/config/package.json packages/workspace-assets/package.json packages/task/package.json packages/mcp/package.json packages/adapters/codex/package.json packages/adapters/kimi/package.json\n- npm whoami\n- npm view selected packages version\n- npm pack --dry-run --json for selected packages