### PR TITLE
fix(release): add shebangs to bin entrypoints

### DIFF
--- a/apps/bootstrap/cli.js
+++ b/apps/bootstrap/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname
 })

--- a/apps/bootstrap/package.json
+++ b/apps/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/bootstrap",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Vibe Forge bootstrap launcher",
   "vibeForge": {
     "runtimeTranspile": true

--- a/apps/cli/cli.js
+++ b/apps/cli/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname
 })

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vibe Forge CLI",
   "imports": {
     "#~/*.js": {

--- a/apps/server/cli.js
+++ b/apps/server/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname
 })

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/server",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vibe Forge server",
   "imports": {
     "#~/*.js": {

--- a/apps/web/cli.js
+++ b/apps/web/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname
 })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vibe Forge integrated web app",
   "vibeForge": {
     "runtimeTranspile": true

--- a/changelog/3.0.2/bootstrap.md
+++ b/changelog/3.0.2/bootstrap.md
@@ -1,0 +1,5 @@
+# @vibe-forge/bootstrap 3.0.2
+
+## Changes
+
+- Add a Node shebang to the published bootstrap bin entrypoint so package-manager bin shims can execute it directly.

--- a/changelog/3.1.1/readme.md
+++ b/changelog/3.1.1/readme.md
@@ -1,0 +1,5 @@
+# VibeForge 3.1.1
+
+## Changes
+
+- Add Node shebangs to published bin entrypoints for CLI, server, web, MCP, channel-lark MCP, and hooks so `npx` and package-manager bin shims execute them with Node instead of `sh`.

--- a/packages/channels/lark/mcp.js
+++ b/packages/channels/lark/mcp.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname,
   sourceEntry: './src/mcp/cli',

--- a/packages/channels/lark/package.json
+++ b/packages/channels/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/channel-lark",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "imports": {
     "#~/*.js": {
       "__vibe-forge__": {

--- a/packages/hooks/call-hook.js
+++ b/packages/hooks/call-hook.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { spawn } = require('node:child_process')
 const { existsSync } = require('node:fs')
 const Module = require('node:module')

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/hooks",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vibe Forge hooks runtime and bridge helpers",
   "imports": {
     "#~/*.js": {

--- a/packages/mcp/cli.js
+++ b/packages/mcp/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('@vibe-forge/cli-helper/entry').runCliPackageEntrypoint({
   packageDir: __dirname
 })

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-forge/mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vibe Forge MCP server",
   "imports": {
     "#~/*.js": {


### PR DESCRIPTION
## Summary\n- add Node shebangs to published bin entrypoints used by CLI, server, web, MCP, channel-lark, hooks, and bootstrap\n- bump affected packages for patch release: bootstrap 3.0.2 and runtime bins 3.1.1\n\n## Verification\n- node apps/cli/cli.js --version\n- shebang check for all changed bin files\n- pnpm exec dprint check changed bin/package/changelog files\n- npm pack --dry-run --json for affected packages\n\nContext: published @vibe-forge/cli@3.1.0 failed under npx because the bin target had no shebang.