### PR TITLE
fix(client): align sender account hover state

### DIFF
--- a/apps/client/src/components/chat/status-bar/ChatStatusBar.scss
+++ b/apps/client/src/components/chat/status-bar/ChatStatusBar.scss
@@ -39,6 +39,14 @@
   flex-shrink: 0;
 }
 
+html.dark .chat-status-bar__actions {
+  --nav-hover-bg: rgba(59, 130, 246, .14);
+  --nav-hover-border: rgba(96, 165, 250, .2);
+  --nav-active-bg: rgba(59, 130, 246, .2);
+  --nav-active-border: rgba(96, 165, 250, .28);
+  --nav-active-text: #3b82f6;
+}
+
 .chat-status-bar__actions .sender-select-shell,
 .chat-status-bar__actions .adapter-select-tooltip-target {
   height: var(--sender-control-height);
@@ -49,20 +57,29 @@
   color: var(--sub-text-color, #6b7280);
 }
 
-.chat-status-bar__actions .sender-select-shell:hover .account-select,
-.chat-status-bar__actions .account-select:not(.ant-select-disabled):hover,
-.chat-status-bar__actions .adapter-select:not(.ant-select-disabled):hover,
 .chat-status-bar__actions
-  .account-select:not(.ant-select-disabled).ant-select-focused,
+  .sender-select-shell:hover
+  .account-select:not(.ant-select-disabled),
 .chat-status-bar__actions
-  .adapter-select:not(.ant-select-disabled).ant-select-focused {
+  :is(.account-select, .adapter-select):not(.ant-select-disabled):is(:hover, .ant-select-focused) {
+  background-color: var(--sender-control-hover-bg);
+  color: var(--sender-control-hover-color);
   box-shadow: inset 0 0 0 1px var(--nav-hover-border, rgba(37, 99, 235, .14));
 }
 
 .chat-status-bar__actions
-  .account-select:not(.ant-select-disabled).ant-select-open,
+  .sender-select-shell:hover
+  .account-select:not(.ant-select-disabled)
+  :is(.ant-select-selection-item, .ant-select-selection-placeholder, .sender-select-arrow),
 .chat-status-bar__actions
-  .adapter-select:not(.ant-select-disabled).ant-select-open {
+  .account-select:not(.ant-select-disabled):is(:hover, .ant-select-focused)
+  :is(.ant-select-selection-item, .ant-select-selection-placeholder, .sender-select-arrow) {
+  color: inherit;
+  opacity: 1;
+}
+
+.chat-status-bar__actions
+  :is(.account-select, .adapter-select):not(.ant-select-disabled).ant-select-open {
   background-color: var(--nav-active-bg, #eff6ff);
   color: var(--nav-active-text, #2563eb);
   box-shadow: inset 0 0 0 1px var(--nav-active-border, rgba(37, 99, 235, .22));
@@ -70,16 +87,10 @@
 
 .chat-status-bar__actions
   .account-select:not(.ant-select-disabled).ant-select-open
-  .ant-select-selection-item,
-.chat-status-bar__actions
-  .account-select:not(.ant-select-disabled).ant-select-open
-  .sender-select-arrow,
+  :is(.ant-select-selection-item, .sender-select-arrow),
 .chat-status-bar__actions
   .adapter-select:not(.ant-select-disabled).ant-select-open
-  .adapter-option__icon,
-.chat-status-bar__actions
-  .adapter-select:not(.ant-select-disabled).ant-select-open
-  .adapter-option__icon--fallback {
+  :is(.adapter-option__icon, .adapter-option__icon--fallback) {
   color: inherit;
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- align sender account selector hover/focus styling with other status bar dropdowns
- keep dark-mode hover/active variables consistent across account and adapter controls

## Verification
- pnpm exec dprint check apps/client/src/components/chat/status-bar/ChatStatusBar.scss
- pnpm -C apps/client exec vite build